### PR TITLE
[block] the 'id' type is abstract; the xen blkif create function should take an 'id' rather than an 'int'

### DIFF
--- a/lib/os/xen/blkif.mli
+++ b/lib/os/xen/blkif.mli
@@ -51,7 +51,7 @@ type t
 type id
 exception Read_error of string
 val poll : t -> 'a Lwt.t
-val create : int -> (t * 'a Lwt.t) Lwt.t
+val create : id -> (t * 'a Lwt.t) Lwt.t
 val enumerate : unit -> id list Lwt.t
 val read_page : t -> int64 -> Bitstring.t Lwt.t
 val read_512 : t -> int64 -> int64 -> Bitstring.bitstring array Lwt.t


### PR DESCRIPTION
[block] the 'id' type is abstract; the xen blkif create function should take an 'id' rather than an 'int'

With this change the simple block test compiles for xen again.
