### PR TITLE
[xen]: sched_poll.nr_ports should be number of elements in the array, not

### DIFF
--- a/lib/os/runtime_xen/kernel/main.c
+++ b/lib/os/runtime_xen/kernel/main.c
@@ -39,7 +39,7 @@ caml_block_domain(value v_timeout)
   s_time_t secs = (s_time_t)(Double_val(v_timeout) * 1000000000);
   s_time_t until = NOW() + secs;
   set_xen_guest_handle(sched_poll.ports, ports);
-  sched_poll.nr_ports = sizeof(ports);
+  sched_poll.nr_ports = sizeof(ports) / sizeof(evtchn_port_t);
   sched_poll.timeout = until;
   HYPERVISOR_sched_op(SCHEDOP_poll, &sched_poll);
   CAMLreturn(Val_unit);


### PR DESCRIPTION
[xen]: sched_poll.nr_ports should be number of elements in the array, not the size of the array in bytes.

For example the XCP linux-2.6.32 usage:

```
/* Poll waiting for an irq to become pending.  In the usual case, the
   irq will be disabled so it won't deliver an interrupt. */
void xen_poll_irq(int irq)
{
        evtchn_port_t evtchn = evtchn_from_irq(irq);

        if (VALID_EVTCHN(evtchn)) {
                struct sched_poll poll;

                poll.nr_ports = 1;
                poll.timeout = 0;
                set_xen_guest_handle(poll.ports, &evtchn);

                if (HYPERVISOR_sched_op(SCHEDOP_poll, &poll) != 0)
                        BUG();
        }
}
```
