### PR TITLE
[xen] Xs.monitor_paths calls callbacks with a (path, token) not a (path, 

### DIFF
--- a/lib/os/xen/blkif.ml
+++ b/lib/os/xen/blkif.ml
@@ -177,9 +177,11 @@ let plug (id:id) =
     wrfn "state" Xb.State.(to_string Connected) 
   )) >>
   lwt monitor_t = Xs.(monitor_paths Xs.t
-    [sprintf "%s/state" backend, (Xb_state.(to_string Connected))] 20. 
-    (fun (k,v) -> Xb_state.(of_string v = Connected))
-  ) in
+    [sprintf "%s/state" backend, "XXX"] 20. 
+    (fun (k,_) ->
+        lwt state = try_lwt Xs.t.Xs.read k with _ -> return "" in
+	    return Xb_state.(of_string state = Connected)
+	)) in
   (* XXX bug: the xenstore watches seem to come in before the
      actual update. A short sleep here for the race, but not ideal *)
   Time.sleep 0.1 >>

--- a/lib/os/xen/xs.mli
+++ b/lib/os/xen/xs.mli
@@ -64,7 +64,7 @@ val read_watchevent : xsh -> (string * string) Lwt.t
 val monitor_paths : xsh
                  -> (string * string) list
                  -> float
-                 -> (string * string -> bool)
+                 -> (string * string -> bool Lwt.t)
                  -> unit Lwt.t
 
 val t : xsh


### PR DESCRIPTION
[xen] Xs.monitor_paths calls callbacks with a (path, token) not a (path, current value): callbacks are expected to check xenstore for themselves

Watch callback tokens should only be used for sharing callbacks between multiple callers.

To wait for a particular condition to become true one should
1. watch a particular tree
2. in the callback, evaluate whether the condition is now true or not

(2) requires the ability to read xenstore and therefore to block.

This probably explains the 'XXX bug' in blkif, although since it still doesn't
completely work I can't be sure.
