### PR TITLE
[xen] experimental fix for the page corruption issue

### DIFF
--- a/lib/os/xen/io_page.ml
+++ b/lib/os/xen/io_page.ml
@@ -76,9 +76,13 @@ let with_pages n f =
   List.iter put pages;
   return res
 
-let to_bitstring (x: t) =
+(*
+let detach (x: t) =
   Gc.finalise return_to_free_list x.page;
-  x.detached <- true;
+  x.detached <- true
+*)
+
+let to_bitstring (x: t) =
   x.page
 
 let of_bitstring (x: Bitstring.t) = {


### PR DESCRIPTION
I think we added the finaliser to the 'page' and then proceeded to take
a reference to a 'subbitstring' which is a separate object from the GC's
point of view.

As a quick workaround, switch to performing a full copy of the relevant
data and then immediately free the Io_page.

What do you think?
