### PR TITLE
[xen]: ensure each xenstore TRANSACTION_START actually gets a unique requ

### DIFF
--- a/lib/os/xen/queueop.ml
+++ b/lib/os/xen/queueop.ml
@@ -61,7 +61,7 @@ let unwatch path data =
 	let data = data_concat [ path; data; ] in
 	Xb.Packet.create 0 (next_rid ()) Xb.Op.Unwatch data
 
-let transaction_start =
+let transaction_start () =
 	Xb.Packet.create 0 (next_rid ()) Xb.Op.Transaction_start (data_concat [])
 
 let transaction_end tid commit =

--- a/lib/os/xen/queueop.mli
+++ b/lib/os/xen/queueop.mli
@@ -35,7 +35,7 @@ val getperms : int -> string -> Xs_packet.t
 val debug : string list -> Xs_packet.t
 val watch : string -> token -> Xs_packet.t
 val unwatch : string -> token -> Xs_packet.t
-val transaction_start : Xs_packet.t
+val transaction_start : unit -> Xs_packet.t
 val transaction_end : int -> bool -> Xs_packet.t
 val introduce : int -> nativeint -> int -> Xs_packet.t
 val release : int -> Xs_packet.t

--- a/lib/os/xen/xsraw.ml
+++ b/lib/os/xen/xsraw.ml
@@ -244,7 +244,7 @@ let unwatch path token con =
     return ()
 
 let transaction_start con =
-	lwt _, data = rpc (Queueop.transaction_start) con in
+	lwt _, data = rpc (Queueop.transaction_start ()) con in
 	try_lwt
 		return (int_of_string data)
 	with


### PR DESCRIPTION
[xen]: ensure each xenstore TRANSACTION_START actually gets a unique request id
