### PR TITLE
[xen]: tidy log messages from low-level code by putting a __FILE__: prefix

### DIFF
--- a/lib/os/runtime_xen/include/log.h
+++ b/lib/os/runtime_xen/include/log.h
@@ -1,0 +1,20 @@
+/* Copyright (C) 2011 Citrix Systems Inc
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#define printk(_f, _a...) do {\
+  const char *filename = strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__; \
+  printk("%s: " _f, filename, ## _a); \
+} while (0) 
+

--- a/lib/os/runtime_xen/kernel/gnttab_stubs.c
+++ b/lib/os/runtime_xen/kernel/gnttab_stubs.c
@@ -23,6 +23,8 @@
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 
+#include <log.h>
+
 static grant_entry_t *gnttab_table;
 
 /* Return the size of the grant table */

--- a/lib/os/runtime_xen/kernel/kernel.c
+++ b/lib/os/runtime_xen/kernel/kernel.c
@@ -40,6 +40,7 @@
 #include <fcntl.h>
 #include <xen/features.h>
 #include <xen/version.h>
+#include <log.h>
 
 int app_main(start_info_t *);
 void do_exit(void);

--- a/lib/os/runtime_xen/kernel/mm.c
+++ b/lib/os/runtime_xen/kernel/mm.c
@@ -42,6 +42,7 @@
 #include <mini-os/lib.h>
 #include <mini-os/xmalloc.h>
 #include <errno.h>
+#include <log.h>
 
 #ifdef MM_DEBUG
 #define DEBUG(_f, _a...) \

--- a/lib/os/runtime_xen/kernel/x86_mm.c
+++ b/lib/os/runtime_xen/kernel/x86_mm.c
@@ -41,6 +41,7 @@
 #include <mini-os/lib.h>
 #include <mini-os/xmalloc.h>
 #include <xen/memory.h>
+#include <log.h>
 
 #ifdef MM_DEBUG
 #define DEBUG(_f, _a...) \

--- a/lib/os/runtime_xen/kernel/x86_setup.c
+++ b/lib/os/runtime_xen/kernel/x86_setup.c
@@ -28,6 +28,7 @@
 
 #include <mini-os/x86/os.h>
 #include <mini-os/lib.h> /* for printk, memcpy */
+#include <log.h>
 
 /*
  * Shared page for communicating with the hypervisor.


### PR DESCRIPTION
[xen]: tidy log messages from low-level code by putting a **FILE**: prefix

Is this the kind of tidy-up you were thinking of?
