### PR TITLE
generate doc for each backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,13 @@ all:
 doc:
 	@cd docs && $(MAKE) all
 	@cd lib && $(MAKE) doc
-	@./docs/_build/parse.native lib/_build/unix-direct > docs/_build/info.json
+
+doc-json:
+	@./docs/_build/parse.native lib/_build/unix-socket > docs/_build/unix-socket.json
+	@./docs/_build/parse.native lib/_build/unix-direct > docs/_build/unix-direct.json
+	@./docs/_build/parse.native lib/_build/node > docs/_build/node.json
+#	@./docs/_build/parse.native lib/_build/xen > docs/_build/xen.json
+
 
 install:
 	@rm -rf _build


### PR DESCRIPTION
I wasn't able to generate the docs for the Xen backend. If you can, would be nice to then copy the generated JSON into mirage-tutorial/docs/xen/data/info.json
