### PR TITLE
profiling support

### DIFF
--- a/scripts/myocamlbuild.ml
+++ b/scripts/myocamlbuild.ml
@@ -487,7 +487,8 @@ let _ = dispatch begin function
     flag ["ocaml"; "compile"] & std_flags;
     flag ["ocaml"; "pack"] & std_flags;
     flag ["ocaml"; "link"] & std_flags;
-    flag ["ocaml"; "compile"; "native" ] & S [A"-p"; A"-g"];
+    if profiling
+      flag ["ocaml"; "compile"; "native" ] & S [A"-p"; A"-g"];
 
     (* Include the correct stdlib depending on which backend is chosen *)
     List.iter (fun be ->


### PR DESCRIPTION
appears to be a bug - profiling switches are set on native compile regardless of `profiling` variable value.

protect those switches so they're only set if `profiling=true`.
