### PR TITLE
Fix up the xen stuff so it compiles again

### DIFF
--- a/lib/os/xen/netif.ml
+++ b/lib/os/xen/netif.ml
@@ -216,8 +216,7 @@ let tx_poll nf =
 
 
 (* Transmit a packet from buffer, with offset and length *)  
-let rec output nf bsv =
-  let page = Io_page.get () in
+let rec output nf page =
   (* XXX below for debugging to avoid potential event deadlock. tell avsm if printf shows up *)
   if Gnttab.num_free_grants () < 100 then begin
     Printf.printf "low grants %d\n%!" (Gnttab.num_free_grants ());
@@ -227,10 +226,7 @@ let rec output nf bsv =
   Gnttab.grant_access ~domid:nf.backend_id ~perm:Gnttab.RO gnt page;
   let gref = Gnttab.to_int32 gnt in
   let id = Int32.to_int gref in
-  let size = List.fold_left (fun offset fragment ->
-    let fraglen = Io_page.length fragment in
-    Io_page.blit fragment (Io_page.sub page offset (Io_page.length fragment));
-    offset + fraglen) 0 bsv in
+  let size = Io_page.length page in
   let flags = 0 in
   let offset = 0 in
   lwt () = Ring.Front.push_request_async nf.tx_fring

--- a/lib/os/xen/netif.mli
+++ b/lib/os/xen/netif.mli
@@ -37,8 +37,8 @@ val plug: id -> t Lwt.t
     the unplugging is not guaranteed *)
 val unplug: id -> unit
 
-(** Output a Bitstring vector to an interface *)
-val output : t -> Io_page.t list -> unit Lwt.t
+(** Output an Io_page to an interface *)
+val output : t -> Io_page.t -> unit Lwt.t
 
 (** Listen endlesses on a Netfront, and invoke the callback function as frames are
     received. *)


### PR DESCRIPTION
The only change of significance is the new signature to the "output" function: was an Io_page.t list, but now is only an Io_page.t.
