### PR TITLE
Removing misleading function Netif.get_writebuf.

### DIFF
--- a/xen/lib/netif.ml
+++ b/xen/lib/netif.ml
@@ -414,12 +414,6 @@ let create () =
 (* The Xenstore MAC address is colon separated, very helpfully *)
 let mac nf = nf.t.mac
 
-(* Get write buffer for Netif output *)
-let get_writebuf t =
-  let page = Io_page.get 1 in
-  (* TODO: record statistics for requesting thread here (in debug mode?) *)
-  return (Cstruct.of_bigarray page)
-
 let _ =
   printf "Netif: add resume hook\n%!";
   Sched.add_resume_hook resume

--- a/xen/lib/netif.mli
+++ b/xen/lib/netif.mli
@@ -51,8 +51,6 @@ val listen : t -> (Cstruct.t -> unit Lwt.t) -> unit Lwt.t
 val mac : t -> Macaddr.t
 (** [mac nf] is the MAC address of [nf]. *)
 
-val get_writebuf : t -> Cstruct.t Lwt.t
-
 val resume : unit -> unit Lwt.t
 (** [resume ()] is a thread that resumes all devices when a unikernel
     is resumed. You do not have to call this function manually as it


### PR DESCRIPTION
This function is useless, and actually misleading because it takes an argument it does not use. Removing it.
