### PR TITLE
'clean' should have type t -> unit

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1124,7 +1124,7 @@ let clean t =
       clean_makefile t;
       clean_main t;
       command "rm -rf %s/_build" t.root;
-      command "rm -rf %s/main.native.o %s/main.native %s/mir-main %s/*~" t.root t.root;
+      command "rm -rf %s/main.native.o %s/main.native %s/mir-main %s/*~" t.root t.root t.root t.root;
     )
 
 (*


### PR DESCRIPTION
There were some missing format string arguments.
