### PR TITLE
Fix the Mirage HTTP compilation problem by using the new split HTTP libraries

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 1.0.3 (trunk):
 * Do not remove OPAM packages when doing `mirage clean` (#143)
 * [xen] generate a simple main.xl, without block devices or network interfaces/
-* The HTTP dependency now also installs `mirage-tcp-*`.
+* The HTTP dependency now also installs `mirage-tcp-*` and `mirage-http-*`.
 * Fix generated Makefile dependency on source OCaml files to rebuild reliably.
 * Support `Fat_KV_RO` (a read-only k/v version of the FAT filesystem).
 * The `KV_RO` filesystem in Unix now passes through to the underlying filesystem instead of calling `crunch`.

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -704,17 +704,17 @@ module HTTP = struct
     "http_" ^ string_of_int t.port
 
   let packages t = function
-    | `Unix _ -> ["cohttp"; "mirage-tcpip-unix"]
-    | `Xen    -> ["cohttp"; "mirage-tcpip-xen"]
+    | `Unix _ -> ["mirage-http-unix"]
+    | `Xen    -> ["mirage-http-xen"]
 
   let libraries t = function
-    | `Unix _ -> ["cohttp.mirage-unix"]
-    | `Xen    -> ["cohttp.mirage-xen"]
+    | `Unix _ -> ["mirage-http-unix"]
+    | `Xen    -> ["mirage-http-xen"]
 
   let configure t mode d =
     let name = name t in
     if not (StringMap.mem name d.modules) then (
-      let m = "Cohttp_mirage.Server" in
+      let m = "HTTP.Server" in
       d.modules <- StringMap.add name m d.modules;
       IP.configure t.ip mode d;
       append d.oc "let %s =" name;


### PR DESCRIPTION
Not to be merged until OPAM has the new libraries

Closes mirage/mirage#161
