### PR TITLE
kv_ro_of_fs bugfix

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -609,7 +609,7 @@ let fat block =
     impl fs block (module Fat)
 
 (* This would deserve to be in its own lib. *)
-let kv_ro_of_fs =
+let kv_ro_of_fs () =
   let dummy_fat = fat (block_of_file "xx") in
   let libraries = Impl.libraries dummy_fat in
   let packages = Impl.packages dummy_fat in

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -128,7 +128,7 @@ val fat_of_files: ?dir:string -> ?regexp:string -> unit -> fs impl
     image. By default, [dir] is the current working directory and
     [regexp] is {i *} *)
 
-val kv_ro_of_fs: fs impl -> kv_ro impl
+val kv_ro_of_fs: unit -> fs impl -> kv_ro impl
 (** Consider a filesystem implementation as a read-only key/value
     store. *)
 


### PR DESCRIPTION
evaluates too early, means that trying to use in a xen `config.ml` leads to `mirage-block-unix` being installed, and confusion ensues.

check the `kv_ro_of_fs-fix` branch to see a demonstration of the problem.
