### PR TITLE
Add a Dockerfile to install the mirage binary

### DIFF
--- a/.opam-config-exec
+++ b/.opam-config-exec
@@ -1,0 +1,2 @@
+#!/bin/sh
+opam config exec $*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:trusty
+MAINTAINER Anil Madhavapeddy <anil@recoil.org>
+RUN apt-get -y install sudo pkg-config git build-essential m4 software-properties-common ocaml camlp4-extra ocaml-native-compilers opam
+RUN git config --global user.email "docker@example.com"
+RUN git config --global user.name "Docker CI"
+RUN adduser --disabled-password --gecos "" mirage
+RUN passwd -l mirage
+ADD .opam-config-exec /usr/bin/opam-config-exec
+RUN chmod 755 /usr/bin/opam-config-exec
+USER mirage
+ENV HOME /home/mirage
+ENV OPAMVERBOSE 1
+ENV OPAMYES 1
+RUN opam init -a
+ENTRYPOINT opam-config-exec


### PR DESCRIPTION
This is still a bit pointless as we don't have a volume mount to
actually get the build results out!
