### PR TITLE
[For discussion] Extract a FLOW signature from TCPv4

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -99,6 +99,37 @@ module type CLOCK = sig
       known as GMT. *)
 end
 
+module type FLOW = sig
+  (** A connection between endpoints. *)
+
+  type +'a io
+  (** A potentially blocking I/O operation *)
+
+  type buffer
+  (** Abstract type for a memory buffer that may not be page aligned. *)
+
+  type flow
+  (** A flow represents the state of a single stream that is connected
+      to an endpoint. *)
+
+  type error
+
+  val read : flow -> [`Ok of buffer | `Eof | `Error of error ] io
+  (** [read flow] will block until it either successfully reads a segment
+      of data from the current flow, receives an [Eof] signifying that
+      the connection is now closed, or an [Error]. *)
+
+  val write : flow -> buffer -> unit io
+  (** [write flow buffer] will block until the contents of [buffer] are
+      transmitted to the remote endpoint.  The contents may be transmitted
+      in separate packets, depending on the underlying transport. *)
+
+  val writev : flow -> buffer list -> unit io
+  (** [writev flow buffers] will block until the contents of [buffer list]
+      are all successfully transmitted to the remote endpoint. *)
+
+end
+
 module type CONSOLE = sig
   (** Text console input/output operations. *)
 
@@ -430,9 +461,6 @@ end
 module type TCPV4 = sig
   (** A TCPv4 stack that can send and receive reliable streams using the TCP protocol. *)
 
-  type buffer
-  (** Abstract type for a memory buffer that may not be page aligned. *)
-
   type ipv4
   (** Abstract type for an IPv4 stack for this stack to connect to. *)
 
@@ -443,10 +471,6 @@ module type TCPV4 = sig
   (** An input function continuation to pass onto the underlying {!ipv4}
       stack.  This will normally be a NOOP for a conventional kernel, but
       a direct implementation will parse the buffer. *)
-
-  type flow
-  (** A flow represents the state of a single TCPv4 stream that is connected
-      to an endpoint. *)
 
   type error = [
     | `Unknown of string (** an undiagnosed error. *)
@@ -459,26 +483,16 @@ module type TCPV4 = sig
       type error := error
   and type id := ipv4
 
+  include FLOW with
+      type error := error
+  and type 'a io := 'a io
+
   type callback = flow -> unit io
   (** Application callback that receives a [flow] that it can read/write to. *)
 
   val get_dest : flow -> ipv4addr * int
   (** Get the destination IPv4 address and destination port that a flow is
       currently connected to. *)
-
-  val read : flow -> [`Ok of buffer | `Eof | `Error of error ] io
-  (** [read flow] will block until it either successfully reads a segment
-      of data from the current flow, receives an [Eof] signifying that
-      the connection is now closed, or an [Error]. *)
-
-  val write : flow -> buffer -> unit io
-  (** [write flow buffer] will block until the contents of [buffer] are
-      transmitted to the remote endpoint.  The contents may be transmitted
-      in separate packets, depending on the underlying transport. *)
-
-  val writev : flow -> buffer list -> unit io
-  (** [writev flow buffers] will block until the contents of [buffer list]
-      are all successfully transmitted to the remote endpoint. *)
 
   val write_nodelay : flow -> buffer -> unit io
   (** [write_nodelay flow] will block until the contents of [buffer list]


### PR DESCRIPTION
Ideally as many things as possible should implement this. I have in
mind:
- CONSOLEs
- VCHANs
- TCP connections
- TLS connections

Unfortunately the lower levels of the network stack don't quite fit this
pattern because they typically have:
- write (good)
- writev (good)
- listen ~one_cb ~two_cb ... ~n_cb (bad)

Signed-off-by: David Scott dave.scott@citrix.com

NB this is a backwards compatible change (unless adding 'FLOW' causes a namespace problem somewhere)
