### PR TITLE
travis: install mirage-types from here, check everything still builds

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -28,6 +28,7 @@ opam install mirage-console-unix mirage-console-xen \
     mirage-block-unix mirage-block-xen \
     fat-filesystem crunch mirage-http
 
+make # build ./main.native
 cd lib_test
 make MODE=unix
 make clean


### PR DESCRIPTION
Previously we were installing the 1.1.0 release version of mirage-types
and building other repos against that. It's probably better to install
this version of mirage-types to detect pull requests which make incompat
changes.

Signed-off-by: David Scott dave.scott@citrix.com
