### PR TITLE
Change mirage tool to apply Entropy_unix functor

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -436,11 +436,7 @@ module Entropy = struct
   let name _ =
     "entropy"
 
-  let module_name () =
-    match !mode with
-    | `Unix -> "Entropy_unix_instance"
-    | `Xen  -> "Entropy_xen_instance"
-
+  let module_name () = "Entropy"
 
   let construction () =
     match !mode with


### PR DESCRIPTION
Since the evented Entropy_unix requires a `TIME` and exports a functor, CLI tool needs to know how to assemble it. Fixing.
