### PR TITLE
Update to use libminios-xen >= 0.2

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1715,7 +1715,7 @@ let configure_makefile t =
   begin match !mode with
     | `Xen ->
       append oc "build: main.native.o";
-      let pkg_config_deps = "openlibm libminios" in
+      let pkg_config_deps = "openlibm 'libminios-xen >= 0.2'" in
       let path = read_command "ocamlfind printconf path" in
       let lib = strip path ^ "/mirage-xen" in
       append oc "\tpkg-config --print-errors --exists %s" pkg_config_deps;


### PR DESCRIPTION
This adds hardware floating point and stack overflow detection on ARM. It also fixes the .got-clearing problem that prevents the TCP checksum code from working.

Note: the mirage-xen-libs patch should be merged first, otherwise people won't be able to install the dependency this change requires: https://github.com/mirage/mirage-xen-libs/pull/1
