### PR TITLE
Set on_crash = 'preserve' in default Xen config

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+Trunk:
+* Set on_crash = 'preserve' in default Xen config.
+
 1.2.0 (2014-07-05):
 
 The Mirage frontend tool now generates a Makefile with a `make depend`

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1642,6 +1642,7 @@ let configure_main_xl t =
   append oc "kernel = '%s/mir-%s.xen'" t.root t.name;
   append oc "builder = 'linux'";
   append oc "memory = 256";
+  append oc "on_crash = 'preserve'";
   newline oc;
   append oc "# You must define the network and block interfaces manually.";
   newline oc;


### PR DESCRIPTION
Without this, if a domain crashes quickly at startup Xen may not be
able to attach to the console fast enough to display the error.
