### PR TITLE
RFC: Support checksum offload

### DIFF
--- a/types/V2.mli
+++ b/types/V2.mli
@@ -292,6 +292,9 @@ module type NETWORK = sig
   (** [writev nf bufs] output a list of buffers to netfront [nf] as a
       single packet. *)
 
+  val writev2 : needs_checksum:bool -> t -> buffer list -> unit io
+  (** Extends [writev] with the ability to request TCP checksum offload. *)
+
   val listen : t -> (buffer -> unit io) -> unit io
   (** [listen nf fn] is a blocking operation that calls [fn buf] with
       every packet that is read from the interface.  It returns as soon
@@ -349,6 +352,9 @@ module type ETHIF = sig
   val writev : t -> buffer list -> unit io
   (** [writev nf bufs] output a list of buffers to netfront [nf] as a
       single packet. *)
+
+  val writev2 : ?needs_checksum:bool -> t -> buffer list -> unit io
+  (** Extends [writev] with the ability to request TCP checksum offload. *)
 
   val mac : t -> macaddr
   (** [mac nf] is the MAC address of [nf]. *)


### PR DESCRIPTION
This pull request is just to track this feature. Possible improvements include:
- Replace `needs_checksum` with a more generic `flags` argument.
- Consider modifying `writev` rather than adding a new function (makes us incompatible with V1 though).
- Provide a way to tell users whether offload is supported.
