### PR TITLE
Treat Clock and Random modules as 'devices'

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -385,7 +385,9 @@ module Clock = struct
 
   let libraries () = packages ()
 
-  let configure () = ()
+  let configure () =
+    append_main "let clock () = return (`Ok ())";
+    newline_main ()
 
   let clean () = ()
 
@@ -414,7 +416,9 @@ module Random = struct
 
   let libraries () = []
 
-  let configure () = ()
+  let configure () =
+    append_main "let random () = return (`Ok ())";
+    newline_main ()
 
   let clean () = ()
 


### PR DESCRIPTION
We want the user to specify Clock and Random 'devices' in their
configuration so that the appropriate packages are linked in. However
these 'devices' don't have a 'connect' method, so replace with a
'return (`Ok ())'

Fixes #289

Signed-off-by: David Scott dave.scott@citrix.com
