### PR TITLE
CONSOLE is now a FLOW

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,6 @@
 2.0.0 (trunk):
+* [types]: backwards incompatible change: CONSOLE is now a FLOW;
+  'write' has a different signature and 'write_all' has been removed.
 * Set on_crash = 'preserve' in default Xen config.
 * Automatically install dependencies again, but display the live output to the
   user.

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -186,15 +186,10 @@ module type CONSOLE = sig
   include DEVICE with
     type error := error
 
-  val write : t -> string -> int -> int -> int
-  (** [write t buf off len] writes up to [len] chars of [String.sub buf
-      off len] to the console [t] and returns the number of bytes
-      written. Raises {!Invalid_argument} if [len > buf - off]. *)
-
-  val write_all : t -> string -> int -> int -> unit io
-  (** [write_all t buf off len] is a thread that writes [String.sub buf
-      off len] to the console [t] and returns when done. Raises
-      {!Invalid_argument} if [len > buf - off]. *)
+  include FLOW with
+      type error  := error
+  and type 'a io  := 'a io
+  and type flow   := t
 
   val log : t -> string -> unit
   (** [log str] writes as much characters of [str] that can be written

--- a/types/V1_LWT.mli
+++ b/types/V1_LWT.mli
@@ -71,6 +71,7 @@ module type KV_RO = KV_RO
 (** Consoles *)
 module type CONSOLE = CONSOLE
   with type 'a io = 'a Lwt.t
+   and type buffer = Cstruct.t
 
 (** Entropy *)
 module type ENTROPY = ENTROPY


### PR DESCRIPTION
NB this should not be merged until changes have been made to mirage-console (implementation) and to as many old users of 'write' that we can find.

This is a backwards-incompatible change which affects the following
CONSOLE functions:

  write
  write_all

Client applications need to be updated to use the new Cstruct.t based
blocking 'write' function:

  val write : flow -> buffer -> [`Ok of unit |`Eof | `Error of error ]
io

There is no non-blocking 'write' function. I believe lossy console
output functions are a mistake because they cause confusion when
debugging.

This is part of [mirage/mirage#203]

Signed-off-by: David Scott dave.scott@citrix.com
