### PR TITLE
Fix link order in generated Makefile

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 trunk (unreleased):
 * Add `register ~tracing` to enable tracing with mirage-profile at start-up.
+* [xen]: fixed link order in generated Makefile.
 
 2.0.0 (2014-11-05):
 * [types]: backwards incompatible change: CONSOLE is now a FLOW;


### PR DESCRIPTION
libm has to come last because other libraries might depend on maths
functions, not just main.o. Moved libocaml and libxencaml to the end
for the same reason (they certainly won't depend on any of the
project-specific C libraries).

This uncovered some "multiple definition" errors because mirage-xen
overrides the functions in bigarray and shared_memory_ring_stubs, but
was also listing them as libraries. These libraries are now removed
from the linker command.

With this change, mirage requires libminios-xen >= 0.4.2 (https://github.com/mirage/mirage-xen-minios/pull/8).
