### PR TITLE
Make Lwt.tracing instructions work for Fish shell too

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1829,7 +1829,7 @@ module Tracing = struct
     if Sys.command "ocamlfind query lwt.tracing 2>/dev/null" <> 0 then (
       flush stdout;
       error "lwt.tracing module not found. Hint:\n\
-             opam pin add lwt https://github.com/mirage/lwt.git#tracing"
+             opam pin add lwt 'https://github.com/mirage/lwt.git#tracing'"
     );
 
     append_main "let () = ";


### PR DESCRIPTION
Fish interprets # as the start of a comment, even in the middle of a word.
