### PR TITLE
Annotate variable Mirage.mode with explicit type

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -50,7 +50,7 @@ type mode = [
   | `MacOSX
 ]
 
-let mode = ref `Unix
+let mode : mode ref = ref `Unix
 
 let set_mode m =
   mode := m


### PR DESCRIPTION
I was pulling onto my local branch and took me 15 minutes to figure out why it wasn't compiling.  I had a `match` in my local changes that didn't contain the ``MacOSX` term and type inference + subtyping of polymorphic variants resulted in the error appearing in a completely unrelated place with a very misleading error message.
