### PR TITLE
Only activate MacOS X compilation by default on 10.10 (Yosemite)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,9 @@
 * Do not reuse the Unix linker options when building Xen unikernels.  Instead,
   get the linker options from the ocamlfind `xen_linkopts` variables (#332).
   See tcpip.2.1.0 for a library that does this for a C binding.
+* Only activate MacOS X compilation by default on 10.10 (Yosemite) or higher.
+  Older revisions of MacOS X will use the generic Unix mode by default, since
+  the `vmnet` framework requires Yosemite or higher.
 
 2.1.0 (2014-12-07):
 * Add specific support for `MacOSX` as a platform, which enables network bridging

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -51,7 +51,21 @@ let target =
 let mode unix xen target =
   let default_unix = 
     match Mirage_misc.uname_s () with
-    | Some "Darwin" -> `MacOSX
+    | Some "Darwin" -> begin
+      (* Only use MacOS-specific functionality from Yosemite upwards *)
+      let is_yosemite_or_higher = 
+        match Mirage_misc.uname_r () with
+        | None -> false
+        | Some vs ->
+           match Mirage_misc.split vs '.' with
+           | [] -> false
+           | hd::_ -> begin
+              let v = try int_of_string hd with _ -> 0 in
+              v >= 14
+           end
+      in
+      if is_yosemite_or_higher then `MacOSX else `Unix
+    end
     | _ -> `Unix
   in
   (** Specifying --target takes priority over other flags *)

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -50,6 +50,12 @@ type mode = [
   | `MacOSX
 ]
 
+let string_of_mode =
+  function
+  | `Unix -> "Unix"
+  | `Xen -> "Xen"
+  | `MacOSX -> "MacOS X"
+ 
 let mode : mode ref = ref `Unix
 
 let set_mode m =
@@ -2355,6 +2361,7 @@ let load file =
   let file = scan_conf file in
   let root = realpath (Filename.dirname file) in
   let file = root / Filename.basename file in
+  info "%s %s" (blue_s "Compiling for target:") (string_of_mode !mode);
   set_config_file file;
   compile_and_dynlink file;
   let t = registered () in

--- a/lib/mirage_misc.ml
+++ b/lib/mirage_misc.ml
@@ -254,6 +254,7 @@ let collect_output cmd =
 
 let uname_s () = collect_output "uname -s"
 let uname_m () = collect_output "uname -m"
+let uname_r () = collect_output "uname -r"
 
 let command_exists s =
   Sys.command ("which " ^ s ^ " > /dev/null") = 0

--- a/lib/mirage_misc.mli
+++ b/lib/mirage_misc.mli
@@ -67,6 +67,7 @@ val in_dir: string -> (unit -> 'a) -> 'a
 
 val uname_s: unit -> string option
 val uname_m: unit -> string option
+val uname_r: unit -> string option
 
 (** {2 Display} *)
 


### PR DESCRIPTION
Older revisions of MacOS X will use the generic Unix mode by default, since
the `vmnet` framework requires Yosemite or higher.

Reported by: Brian Brietzke bbrietzke@gmail.com
