### PR TITLE
Do not run crunched filesystem modules through `camlp4`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,8 @@
 * Only activate MacOS X compilation by default on 10.10 (Yosemite) or higher.
   Older revisions of MacOS X will use the generic Unix mode by default, since
   the `vmnet` framework requires Yosemite or higher.
+* Do not run crunched filesystem modules through `camlp4`, which significantly
+  speeds up compilation on ARM platforms (from minutes to seconds!) (#299).
 
 2.1.0 (2014-12-07):
 * Add specific support for `MacOSX` as a platform, which enables network bridging

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -2131,13 +2131,16 @@ let configure_makefile t =
   begin match !mode with
     | `Xen  ->
       append oc "SYNTAX = -tags \"syntax(camlp4o),annot,bin_annot,strict_sequence,principal\"\n";
+      append oc "SYNTAX += -tag-line \"<static*.*>: -syntax(camlp4o)\"\n";
       append oc "FLAGS  = -cflag -g -lflags -g,-linkpkg,-dontlink,unix\n";
       append oc "XENLIB = $(shell ocamlfind query mirage-xen)\n"
     | `Unix ->
       append oc "SYNTAX = -tags \"syntax(camlp4o),annot,bin_annot,strict_sequence,principal\"\n";
+      append oc "SYNTAX += -tag-line \"<static*.*>: -syntax(camlp4o)\"\n";
       append oc "FLAGS  = -cflag -g -lflags -g,-linkpkg\n"
     | `MacOSX ->
       append oc "SYNTAX = -tags \"syntax(camlp4o),annot,bin_annot,strict_sequence,principal,thread\"\n";
+      append oc "SYNTAX += -tag-line \"<static*.*>: -syntax(camlp4o)\"\n";
       append oc "FLAGS  = -cflag -g -lflags -g,-linkpkg\n"
   end;
   append oc "BUILD  = ocamlbuild -classic-display -use-ocamlfind $(LIBS) $(SYNTAX) $(FLAGS)\n\


### PR DESCRIPTION
This speeds up compilation on ARM platforms (from minutes to seconds!)

Closes #299
