### PR TITLE
Don't reverse order of C libraries

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -2107,7 +2107,6 @@ let get_extra_ld_flags ~filter pkgs =
     | None -> acc
     | Some (dir, ldflags) -> Printf.sprintf "-L%s %s" dir ldflags :: acc
   ) []
-  |> List.rev
 
 let configure_makefile t =
   let file = t.root / "Makefile" in


### PR DESCRIPTION
Looks like they were sorted correctly in the first place. Needed to link zarith, whose C stubs depend on those from gmp.
