### PR TITLE
Added error_message function to FLOW

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -148,6 +148,9 @@ module type FLOW = sig
 
   type error
 
+  val error_message : error -> string
+  (** Convert an error to a human-readable message, suitable for logging. *)
+
   val read : flow -> [`Ok of buffer | `Eof | `Error of error ] io
   (** [read flow] will block until it either successfully reads a segment
       of data from the current flow, receives an [Eof] signifying that


### PR DESCRIPTION
This allows for generic handling of errors without losing detail. For example, a user of a FLOW can use this to log errors. Before, the user would need to know the specific implementation of FLOW
being used.

This is required for TLS support in Conduit. It requires patches to console, vchan and tcpip to be applied first to add the extra method.

Longer term, we may want to add this function to `DEVICE` too.