### PR TITLE
[RFC] Add TLS support in Conduit

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+* Conduit now takes an optional TLS argument, allowing servers to support encryption.
+
 2.3.0 (2015-03-10):
 * Remove the `IO_PAGE` module type from `V1`. This has now moved into the
   `io-page` pacakge (#356)

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -354,11 +354,15 @@ val vchan_localhost : ?uuid:string -> unit -> vchan impl
 val vchan_xen : ?uuid:string -> unit -> vchan impl
 val vchan_default : ?uuid:string -> unit -> vchan impl
 
+(** {TLS configuration} *)
+type conduit_tls
+val tls_over_conduit : entropy impl -> conduit_tls impl
+
 (** {Conduit configuration} *)
 
 type conduit
 val conduit: conduit typ
-val conduit_direct : ?vchan:vchan impl -> stackv4 impl -> conduit impl
+val conduit_direct : ?vchan:vchan impl -> ?tls:conduit_tls impl -> stackv4 impl -> conduit impl
 
 type conduit_client = [
   | `TCP of Ipaddr.t * int


### PR DESCRIPTION
Notes:
* Entropy is now initialised automatically, since we don't want to expose the application to this. Is this the correct way to do it?
* Conduit now *requires* a TLS implementation. Should this be optional?
* You can't configure an https web server directly because there's no way to pass in the configuration. Instead, your unikernel needs to take a conduit argument, load the certificate itself, and create the web-server from that.
* This depends on https://github.com/mirage/ocaml-conduit/pull/37