### PR TITLE
[Tracking] Remove DEVICE.connect

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -27,18 +27,11 @@ module type DEVICE = sig
   (** The type representing the internal state of the device *)
 
   type error
-  (** An error signalled by the device, normally returned after a
-      connection attempt *)
+  (** An error signalled by the device *)
 
   type id
-  (** Type defining an identifier for this device that uniquely
-      identifies it among a device tree. *)
-
-  val id : t -> id
-  (** Return the identifier that was used to construct this device *)
-
-  val connect: id -> [ `Error of error | `Ok of t ] io
-  (** Connect to the device identified by [id] *)
+  (** This type is no longer used and will be removed once other
+   * modules stop using it in their type signatures. *)
 
   val disconnect : t -> unit io
   (** Disconnect from the device.  While this might take some


### PR DESCRIPTION
When a module is functorised over a DEVICE it should only have the
ability to *use* devices it is given, not to connect to new ones.

This change also lets us get rid of the 'id' function from DEVICE.

The 'id' and 'error' types are still present to avoid breaking
existing code that uses 'with id = ...', but can be removed later.

This depends on some other patches being applied first:

- [x] https://github.com/mirage/ocaml-mbr/pull/7
- [x] https://github.com/mirage/mirage-console/pull/34
- [x] https://github.com/mirage/mirage-net-unix/pull/10
- [x] https://github.com/mirage/mirage-net-xen/pull/19
- [x] https://github.com/mirage/mirage-block-xen/pull/35
- [x] https://github.com/mirage/mirage-block-unix/pull/20
- [x] https://github.com/djs55/ocaml-vhd/pull/27
- [x] https://github.com/mirage/xen-disk/pull/18
- [x] https://github.com/mirage/mirage-tcpip/pull/100
- [x] https://github.com/mirage/mirage/pull/351
- [x] https://github.com/mirage/mirage-net-macosx/pull/1
- [x] https://github.com/mirage/mirage-entropy/pull/13
- [x] https://github.com/mirage/ocaml-crunch/pull/13
- [x] https://github.com/mirage/ocaml-fat/pull/39
- [x] https://github.com/mirage/mirage-fs-unix/pull/8

And probably some other things...