### PR TITLE
An IO_PAGE module has a private bigarray type t

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -812,7 +812,7 @@ module type IO_PAGE = sig
   type buf
   (** Type of a C buffer (usually Cstruct) *)
 
-  type t = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+  type t = private (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
   (** Type of memory blocks. *)
 
   val get : int -> t


### PR DESCRIPTION
This seems to fix mirage/mirage-skeleton#73.