### PR TITLE
Support the 2 Xen entropy sources

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -451,7 +451,7 @@ module Entropy = struct
 
   let construction _ =
     match !mode with
-    | `Unix | `MacOSX -> "Entropy_unix.Make (OS.Time)"
+    | `Unix | `MacOSX -> "Entropy_unix"
     | `Xen  -> "Entropy_xen.Make(OS.Time)"
 
   let id t =

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -106,6 +106,9 @@ val entropy: entropy typ
 val default_entropy: entropy impl
 (** Pick the strongest entropy source available. *)
 
+val weak_entropy: entropy impl
+(** Use a known-weak entropy source for testing only. *)
+
 (** {2 Consoles} *)
 
 (** Implementations of the [V1.CONSOLE] signature. *)


### PR DESCRIPTION
In a `config.ml` one can use

- `default_entropy`: this is documented as "Pick the strongest entropy source available.". On Xen the only strong source we currently have is via `xentropyd`, although this could change with [mirage/mirage-entropy#9]
- `weak_entropy`: using this means that we will accept bad entropy, typically for dev/test/experimentation

Note that the Unix entropy source has been defunctorised while the Xen source needs to be functorised.