### PR TITLE
[RFC] Don't put '-classic-display' in the generated Makefiles

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+* Don't put '-classic-display' in the generated Makefiles.
+
 2.2.1 (2015-01-29):
 * Fix logging errors when `mirage` output is not redirected. (#355)
 * Do not reverse the order of C libraries when linking.  This fixes Zarith

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -2259,7 +2259,7 @@ let configure_makefile t =
       append oc "SYNTAX += -tag-line \"<static*.*>: -syntax(camlp4o)\"\n";
       append oc "FLAGS  = -cflag -g -lflags -g,-linkpkg\n"
   end;
-  append oc "BUILD  = ocamlbuild -classic-display -use-ocamlfind $(LIBS) $(SYNTAX) $(FLAGS)\n\
+  append oc "BUILD  = ocamlbuild -use-ocamlfind $(LIBS) $(SYNTAX) $(FLAGS)\n\
              OPAM   = opam\n\n\
              export PKG_CONFIG_PATH=$(shell opam config var prefix)/lib/pkgconfig\n\n\
              export OPAMVERBOSE=1\n\


### PR DESCRIPTION
Classic mode makes it hard to see warnings among the verbose output. If some users want this, I think it would be better to make it a general ocamlbuild configuration setting rather than special-casing it for Mirage.