### PR TITLE
Remove the `mirage run` command

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,8 @@
 2.4.0:
+* Add the ability to specify `Makefile.user` to extend the generated
+  `Makefile`. Also `all`, `build` and `clean` are now extensible make
+  targets.
+* Remove the `mirage run` command (#379)
 * Call `opam depext` when configuring (#373)
 * Add opam files for `mirage` and `mirage-types` packages
 * Fix `mirage --version` (#374)

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -123,18 +123,6 @@ let build =
     `Ok (Mirage.build t) in
   Term.(ret (pure build $ file)), term_info "build" ~doc ~man
 
-(* RUN *)
-let run_doc = "Run a Mirage application."
-let run =
-  let doc = run_doc in
-  let man = [
-    `S "DESCRIPTION";
-    `P "Run a Mirage application on the selected backend."] in
-  let run file =
-    let t = Mirage.load file in
-    `Ok (Mirage.run t) in
-  Term.(ret (pure run $ file)), term_info "run" ~doc ~man
-
 (* CLEAN *)
 let clean_doc = "Clean the files produced by Mirage for a given application."
 let clean =
@@ -192,11 +180,10 @@ let default =
       The most commonly used mirage commands are:\n\
       \    configure   %s\n\
       \    build       %s\n\
-      \    run         %s\n\
       \    clean       %s\n\
       \n\
       See 'mirage help <command>' for more information on a specific command.\n%!"
-      configure_doc build_doc run_doc clean_doc in
+      configure_doc build_doc clean_doc in
   Term.(pure usage $ pure ()),
   Term.info "mirage"
     ~version:Mirage_version.current
@@ -207,7 +194,6 @@ let default =
 let commands = [
   configure;
   build;
-  run;
   clean;
 ]
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -2293,9 +2293,9 @@ let configure_makefile t =
              export OPAMYES=1";
   newline oc;
   append oc ".PHONY: all depend clean build main.native\n\
-             all: build\n\
+             all:: build\n\
              \n\
-             depend:\n\
+             depend::\n\
              \t$(OPAM) install $(PKGS) --verbose\n\
              \n\
              main.native:\n\
@@ -2329,7 +2329,7 @@ let configure_makefile t =
         get_extra_ld_flags ~filter pkgs
         |> String.concat " \\\n\t  " in
 
-      append oc "build: main.native.o";
+      append oc "build:: main.native.o";
       let pkg_config_deps = "mirage-xen" in
       append oc "\tpkg-config --print-errors --exists %s" pkg_config_deps;
       append oc "\tld -d -static -nostdlib \\\n\
@@ -2352,7 +2352,7 @@ let configure_makefile t =
     | `Unix | `MacOSX ->
       append oc "\t$(SUDO) ./mir-%s\n" t.name
   end;
-  append oc "clean:\n\
+  append oc "clean::\n\
              \tocamlbuild -clean";
   close_out oc
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -2344,14 +2344,6 @@ let configure_makefile t =
       append oc "\tln -nfs _build/main.native mir-%s" t.name;
   end;
   newline oc;
-  append oc "run: build";
-  begin match !mode with
-    | `Xen ->
-      append oc "\t@echo %s.xl has been created. Edit it to add VIFs or VBDs" t.name;
-      append oc "\t@echo Then do something similar to: xl create -c %s.xl\n" t.name
-    | `Unix | `MacOSX ->
-      append oc "\t$(SUDO) ./mir-%s\n" t.name
-  end;
   append oc "clean::\n\
              \tocamlbuild -clean";
   close_out oc
@@ -2466,12 +2458,6 @@ let build t =
   info "Build: %s" (blue_s (get_config_file ()));
   in_dir t.root (fun () ->
       command "%s build" (make ())
-    )
-
-let run t =
-  info "Run: %s" (blue_s (get_config_file ()));
-  in_dir t.root (fun () ->
-      command "%s run" (make ())
     )
 
 let clean t =

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -2346,6 +2346,8 @@ let configure_makefile t =
   newline oc;
   append oc "clean::\n\
              \tocamlbuild -clean";
+  newline oc;
+  append oc "-include Makefile.user";
   close_out oc
 
 let clean_makefile t =

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -482,9 +482,6 @@ val clean: t -> unit
 val build: t -> unit
 (** Call [make build] in the right directory. *)
 
-val run: t -> unit
-(** call [make run] in the right directory. *)
-
 (** {2 Extensions} *)
 
 module type CONFIGURABLE = sig


### PR DESCRIPTION
This needs a companion PR in `mirage-www` and `mirage-skeletons` to remove any occurrences of `mirage run` in the docs and Makefiles.