### PR TITLE
Enthalpy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ lib_test/**/make-fat1-image.sh
 lib_test/**/myocamlbuild.ml
 lib_test/**/static1.ml
 lib_test/**/static1.mli
+lib/mirage_version.ml

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -440,59 +440,6 @@ let random = Type RANDOM
 let default_random: random impl =
   impl random () (module Random)
 
-module Entropy = struct
-
-  type t = unit
-
-  let name _ =
-    "entropy"
-
-  let module_name () = "Entropy"
-
-  let construction () =
-    match !mode with
-    | `Unix | `MacOSX -> "Entropy_unix"
-    | `Xen  -> "Entropy_xen.Make(OS.Time)"
-
-  let id t =
-    match !mode with
-    (* default on Unix is the system entropy source *)
-    | (`Unix | `MacOSX) -> "()"
-    | `Xen -> "`From_host"
-
-  let packages () =
-    [ "nocrypto" ] @
-    match !mode with
-    | `Unix | `MacOSX -> [ "mirage-entropy-unix" ]
-    | `Xen  -> [ "mirage-entropy-xen" ]
-
-  let libraries = packages
-
-  let configure t =
-    append_main "module %s = %s" (module_name t) (construction t) ;
-    newline_main () ;
-    append_main "let %s () =" (name t);
-    append_main "  %s.connect %s >>= function" (module_name t) (id t);
-    append_main "  | `Error e -> %s" (driver_initialisation_error "entropy");
-    append_main "  | `Ok entropy ->";
-    append_main "  %s.handler entropy Nocrypto.Rng.Accumulator.add_rr >>= fun () ->" (module_name t);
-    append_main "  return (`Ok entropy)";
-    newline_main ()
-
-  let clean () = ()
-
-  let update_path t _ = t
-
-end
-
-type entropy = ENTROPY
-
-let entropy = Type ENTROPY
-
-(* The default is to get real entropy from the host *)
-let default_entropy: entropy impl =
-  impl entropy () (module Entropy)
-
 module Console = struct
 
   type t = string

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1630,40 +1630,6 @@ let vchan_default ?uuid () =
   | `Xen -> vchan_xen ?uuid ()
   | `Unix | `MacOSX -> vchan_localhost ?uuid ()
 
-module TLS_over_conduit = struct
-  type t = entropy impl
-
-  let name t =
-    let key = "tls_with_" ^ Impl.name t in
-    Name.of_key key ~base:"tls"
-
-  let module_name t =
-    String.capitalize (name t)
-
-  let packages t =
-    [ "tls" ] @ Impl.packages t
-
-  let libraries t =
-    [ "tls.mirage" ] @ Impl.libraries t
-
-  let configure t =
-    Impl.configure t;
-    append_main "module %s = Tls_mirage.Make(Conduit_mirage.Dynamic_flow)(%s)" (module_name t) (Impl.module_name t);
-    newline_main ();
-    append_main "let %s =" (name t);
-    append_main "  %s () >>= function" (Impl.name t);
-    append_main "  | `Error _    -> %s" (driver_initialisation_error (Impl.name t));
-    append_main "  | `Ok _entropy ->";
-    append_main "  return (`Ok ())";
-    newline_main ()
-
-  let clean t =
-    Impl.clean t
-
-  let update_path t root =
-    Impl.update_path t root
-end
-
 module TLS_none = struct
   type t = unit
 
@@ -1687,7 +1653,6 @@ end
 type conduit_tls = Conduit_TLS
 let conduit_tls = Type Conduit_TLS
 
-let tls_over_conduit entropy = impl conduit_tls entropy (module TLS_over_conduit)
 let tls_none = impl conduit_tls () (module TLS_none)
 
 module Conduit = struct

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -347,7 +347,6 @@ val vchan_default : ?uuid:string -> unit -> vchan impl
 
 (** {TLS configuration} *)
 type conduit_tls
-val tls_over_conduit : entropy impl -> conduit_tls impl
 
 (** {Conduit configuration} *)
 

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -95,17 +95,6 @@ val default_random: random impl
 (** Passthrough to the OCaml Random generator. *)
 
 
-(** {2 Entropy} *)
-
-type entropy
-(** Abstract type for entropy sources. *)
-
-val entropy: entropy typ
-(** The [V1.ENTROPY] module signature. *)
-
-val default_entropy: entropy impl
-(** Pick the strongest entropy source available. *)
-
 (** {2 Consoles} *)
 
 (** Implementations of the [V1.CONSOLE] signature. *)

--- a/lib/mirage_misc.ml
+++ b/lib/mirage_misc.ml
@@ -351,4 +351,7 @@ module OCamlfind = struct
     let out = read_command "ocamlfind query %s %s %s %s" fmt pred r pkgs in
     split out '\n'
 
+  let installed lib =
+    Sys.command ("ocamlfind query " ^ lib ^ " 2>&1 1>/dev/null") = 0
+
 end

--- a/lib/mirage_misc.ml
+++ b/lib/mirage_misc.ml
@@ -337,3 +337,18 @@ module StringSet = Set.Make(struct
 
 let dedup l =
   StringSet.(elements (List.fold_left (fun s e -> add e s) empty l))
+
+module OCamlfind = struct
+
+  let query ?predicates ?(format="%p") ?(recursive=false) xs =
+    let pred = match predicates with
+      | None    -> ""
+      | Some ps -> "-predicates '" ^ String.concat "," ps ^ "'"
+    and fmt  = "-format '" ^ format ^ "'"
+    and r    = if recursive then "-recursive" else ""
+    and pkgs = String.concat " " xs
+    in
+    let out = read_command "ocamlfind query %s %s %s %s" fmt pred r pkgs in
+    split out '\n'
+
+end

--- a/lib/mirage_misc.mli
+++ b/lib/mirage_misc.mli
@@ -69,6 +69,10 @@ val uname_s: unit -> string option
 val uname_m: unit -> string option
 val uname_r: unit -> string option
 
+module OCamlfind : sig
+  val query : ?predicates:string list -> ?format:string -> ?recursive:bool -> string list -> string list
+end
+
 (** {2 Display} *)
 
 val set_section: string -> unit

--- a/lib/mirage_misc.mli
+++ b/lib/mirage_misc.mli
@@ -71,6 +71,7 @@ val uname_r: unit -> string option
 
 module OCamlfind : sig
   val query : ?predicates:string list -> ?format:string -> ?recursive:bool -> string list -> string list
+  val installed : string -> bool
 end
 
 (** {2 Display} *)

--- a/lib/mirage_version.ml
+++ b/lib/mirage_version.ml
@@ -1,0 +1,1 @@
+let current = "2.4.0"

--- a/lib/mirage_version.ml
+++ b/lib/mirage_version.ml
@@ -1,1 +1,0 @@
-let current = "2.4.0"

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -76,39 +76,6 @@ module type RANDOM = sig
       [bound] (exclusive). [bound] must be greater than 0. *)
 end
 
-(** {1 Native entropy provider} **)
-module type ENTROPY = sig
-
-  type error = [
-    | `No_entropy_device of string
-  ]
-  (** The type for errors when attaching the entropy provider. *)
-
-  include DEVICE with
-    type error := error
-
-  type buffer
-  (** The type for memory buffers. *)
-
-  type handler = source:int -> buffer -> unit
-  (** A [handler] is called whenever the system has extra entropy to
-      announce.  No guarantees are made about the entropy itself,
-      other than it being environmentally derived. In particular, the
-      amount of entropy in the buffer can be far lower than the size
-      of the [buffer].
-
-      [source] is a small integer, describing the provider but with no
-      other meaning.
-
-      [handler] is expected to return quickly.  *)
-
-  val handler: t -> handler -> unit io
-  (** [handler h] registers the single global [handler] that will
-      receive entropy. There might be additional, provider-specific
-      blocking semantics.  *)
-
-end
-
 (** {1 Clock operations}
 
     Currently read-only to retrieve the time in various formats. *)

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -57,7 +57,7 @@ end
 
 (** {1 Random}
 
-    Operations to generate entropy. This is currently a passthrough
+    Operations to generate randomness. This is currently a passthrough
     to the OCaml Random generator, and will be deprecated in V2 and
     turned into a proper DEVICE with blocking modes. *)
 module type RANDOM = sig

--- a/types/V1_LWT.mli
+++ b/types/V1_LWT.mli
@@ -102,11 +102,6 @@ module type CONSOLE = CONSOLE
   with type 'a io = 'a Lwt.t
    and type buffer = Cstruct.t
 
-(** Entropy *)
-module type ENTROPY = ENTROPY
-  with type 'a io = 'a Lwt.t
-   and type buffer = Cstruct.t
-
 (** Block devices *)
 module type BLOCK = BLOCK
   with type 'a io = 'a Lwt.t


### PR DESCRIPTION
* Removes mentions of the `ENTROPY` interface.
* Removes `TLS_over_conduit` that depended on it.
* If `nocrypto` is found in the set of transitive dependencies, they are extended with its appropriate seeding module and the seeding process is triggered just before the application-side of the unikernel runs.

I apologise for simply deleting tls+conduit, wasn't sure what to do with it. In general, anything that depends on `tls` should just work now, so it should be a breeze to re-add.

The detection code is horribly wonky. Since there is no clearly defined point when the variables `ps` and `ls` are consumed, and to avoid running `ocamlfind` several times, it uses a side-effect and a fragile assumption about the ordering of calls to `packages` and `libraries`. I could not figure out a non-intrusive way to extend the tool and make this clean at the same time.

Another problem is in the detection logic: it scans for `nocrypto` only in the set of (opam-level) *packages* depended on, not in the set of (ocamlfind-level) *libraries*. The detection will fail if someone has, say, `tls` installed and wants to use it, but forgets to `add_to_opam_packages` it. I wasn't sure what exactly to do here -- feedback appreciated.

(Needed for [this](https://github.com/mirleft/ocaml-nocrypto/issues/55).)