### PR TITLE
Support attaching files via a read-only tar-formatted BLOCK

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -585,13 +585,17 @@ let direct_kv_ro dirname =
 
 module Block = struct
 
-  type t = string
+  type t = {
+    filename: string;
+  }
 
   let name t =
-    Name.of_key ("block" ^ t) ~base:"block"
+    Name.of_key ("block" ^ t.filename) ~base:"block"
 
   let module_name _ =
     "Block"
+
+  let connect_name t = t.filename
 
   let packages _ = [
     match !mode with
@@ -607,15 +611,15 @@ module Block = struct
 
   let configure t =
     append_main "let %s () =" (name t);
-    append_main "  %s.connect %S" (module_name t) t;
+    append_main "  %s.connect %S" (module_name t) (connect_name t);
     newline_main ()
 
   let clean t =
     ()
 
   let update_path t root =
-    if Sys.file_exists (root / t) then
-      root / t
+    if Sys.file_exists (root / t.filename) then
+      { filename = root / t.filename }
     else
       t
 
@@ -626,7 +630,7 @@ type block = BLOCK
 let block = Type BLOCK
 
 let block_of_file filename =
-  impl block filename (module Block)
+  impl block { Block.filename } (module Block)
 
 module Archive = struct
 

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -154,6 +154,10 @@ val kv_ro: kv_ro typ
 val crunch: string -> kv_ro impl
 (** Crunch a directory. *)
 
+val archive: block impl -> kv_ro impl
+
+val archive_of_files: ?dir:string -> unit -> kv_ro impl
+
 val direct_kv_ro: string -> kv_ro impl
 (** Direct access to the underlying filesystem as a key/value
     store. For Xen backends, this is equivalent to [crunch]. *)


### PR DESCRIPTION
The unikernel `config.ml` can use something like `archive_of_files ~dir:"./htdocs" ()` and then:

- `mirage configure` will generate a tar archive
- the .xl config file will have a completed `disk` section
- the .xe script will have a disk upload section

All the device numbering stuff is hidden from the user.

Example changes: [mirage/mirage-skeleton#99]

Requires tar-format.0.4.0: [ocaml/opam-repository#4503] (now merged)

Minimal wiki changes + support for "FS=archive": [mirage/mirage-www#372]