### PR TITLE
Provide noop configuration for default_time

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -357,7 +357,9 @@ module Time = struct
 
   let libraries () = []
 
-  let configure () = ()
+  let configure () =
+    append_main "let time () = return (`Ok ())";
+    newline_main ()
 
   let clean () = ()
 


### PR DESCRIPTION
Without this patch, unikernels that attempt to take a module of type `V1_LWT.TIME` and a `time impl` will fail at time of `make`, because mirage generates a `main.ml` with invalid syntax.