### PR TITLE
Fix block device naming on Xen when kv_ro_of_fs

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -645,8 +645,7 @@ let all_blocks = Hashtbl.create 7
 let dummy_filename = "xx"
 
 let block_of_file =
-  (* NB: reserve number 0 for the boot disk *)
-  let next_number = ref 1 in
+  let next_number = ref 0 in
   fun filename ->
     let b =
       if Hashtbl.mem all_blocks filename

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1009,7 +1009,7 @@ module Arpv4 = struct
     time: time impl;
   }
 
-  let name t = 
+  let name t =
     Name.of_key ("arpv4" ^ Impl.name t.ethernet) ~base:"arpv4"
 
   let module_name t =
@@ -1019,13 +1019,13 @@ module Arpv4 = struct
     "tcpip" :: Impl.packages t.time @ Impl.packages t.clock @ Impl.packages t.ethernet
 
   let libraries t =
-    let arp_library = 
+    let arp_library =
       match !mode with
       | `Unix | `MacOSX -> "tcpip.arpv4-unix"
       | `Xen  -> "tcpip.arpv4"
     in
-    arp_library :: 
-    Impl.libraries t.ethernet @ 
+    arp_library ::
+    Impl.libraries t.ethernet @
     Impl.libraries t.clock @
     Impl.libraries t.ethernet
 
@@ -1033,8 +1033,8 @@ module Arpv4 = struct
     let name = name t in
     let mname = module_name t in
     append_main "module %s = Arpv4.Make(%s)(%s)(%s)" mname
-      (Impl.module_name t.ethernet) 
-      (Impl.module_name t.clock)  
+      (Impl.module_name t.ethernet)
+      (Impl.module_name t.clock)
       (Impl.module_name t.time);
     newline_main ();
     append_main "let %s () =" name;
@@ -1056,8 +1056,8 @@ end
 type arpv4 = Arpv4
 let arpv4 = Type Arpv4
 
-let arp ?(clock = default_clock) ?(time = default_time) (eth : ethernet impl) = impl arpv4 
-    { Arpv4.ethernet = eth; 
+let arp ?(clock = default_clock) ?(time = default_time) (eth : ethernet impl) = impl arpv4
+    { Arpv4.ethernet = eth;
       clock;
       time
     } (module Arpv4)
@@ -1096,7 +1096,7 @@ module IPV4 = struct
     String.capitalize (name t)
 
   let packages t =
-    "tcpip" :: Impl.packages t.arpv4 
+    "tcpip" :: Impl.packages t.arpv4
 
   let libraries t  =
     (match !mode with

--- a/mirage.install
+++ b/mirage.install
@@ -1,0 +1,4 @@
+bin: [
+  "?_build/lib/main.byte"   {"mirage"}
+  "?_build/lib/main.native" {"mirage"}
+]

--- a/mirage.opam
+++ b/mirage.opam
@@ -13,10 +13,8 @@ build: [
   [make]
 ]
 install: [make "install"]
-remove: [
-  ["rm" "-f" "%{bin}%/mirage"]
-  ["ocamlfind" "remove" "mirage"]
-]
+remove: ["ocamlfind" "remove" "mirage"]
+
 depends: [
   "ipaddr"       {>= "1.0.0"}
   "mirage-types" {>= "2.6.0"}

--- a/mirage.opam
+++ b/mirage.opam
@@ -19,7 +19,7 @@ remove: [
 ]
 depends: [
   "ipaddr"       {>= "1.0.0"}
-  "mirage-types" {>= "2.5.1"}
+  "mirage-types" {>= "2.6.0"}
   "cmdliner"     {>= "0.9.2"}
   "lwt"          {>= "2.4.3"}
   "mirage-types-lwt"


### PR DESCRIPTION
This should make mirage.io live again. I'm currently testing this, if this works, I'll make a bug-fix 2.6.1 release.