### PR TITLE
Generate an .xl.in as well as an .xl file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+* Xen: improve the .xl file generation. We now have
+  - `name.xl`: this has sensible defaults for everything including the
+    network bridges and should "just work" if used on the build box
+  - `name.xl.in`: this has all the settings needed to boot (e.g. presence of
+    block and network devices) but all the environmental dependencies are
+    represented by easily-substitutable variables. This file is intended for
+    production use: simply replace the variables for the paths, bridges, memory
+    sizes etc. and run `xl create` as before.
+
 ### 2.6.0 (2015-07-28)
 
 * Better ARP support. This needs `mirage-tcpip.2.6.0` (#419, by @yomimono)

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -2261,12 +2261,12 @@ module Substitutions = struct
     ] @ blocks
 end
 
-let configure_main_xl ?substitutions t =
+let configure_main_xl ?substitutions ext t =
   let open Substitutions in
   let substitutions = match substitutions with
     | Some x -> x
     | None -> defaults t in
-  let file = t.root / t.name ^ ".xl" in
+  let file = t.root / t.name ^ ext in
   let oc = open_out file in
   append oc "# %s" generated_by_mirage;
   newline oc;
@@ -2297,8 +2297,8 @@ let configure_main_xl ?substitutions t =
   append oc "# vif = [ 'mac=c0:ff:ee:c0:ff:ee,bridge=br0' ]";
   close_out oc
 
-let clean_main_xl t =
-  remove (t.root / t.name ^ ".xl")
+let clean_main_xl ext t =
+  remove (t.root / t.name ^ ext)
 
 let configure_main_xe t =
   let file = t.root / t.name ^ ".xe" in
@@ -2580,7 +2580,8 @@ let configure t =
       if !manage_opam_packages_ then configure_opam t;
       configure_myocamlbuild_ml t;
       configure_makefile t;
-      configure_main_xl t;
+      configure_main_xl ".xl" t;
+      configure_main_xl ~substitutions:[] ".xl.in" t;
       configure_main_xe t;
       configure_main_libvirt_xml t;
       configure_main t
@@ -2603,7 +2604,8 @@ let clean t =
       if !manage_opam_packages_ then clean_opam t;
       clean_myocamlbuild_ml t;
       clean_makefile t;
-      clean_main_xl t;
+      clean_main_xl ".xl" t;
+      clean_main_xl ".xl.in" t;
       clean_main_xe t;
       clean_main_libvirt_xml t;
       clean_main t;

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -2303,6 +2303,9 @@ let configure_main_xl ?substitutions ext t =
   let networks = List.map (fun n ->
     Printf.sprintf "'bridge=%s'" (lookup substitutions (Network n))
   ) !all_networks in
+  append oc "# if your system uses openvswitch then either edit /etc/xen/xl.conf and set";
+  append oc "#     vif.default.script=\"vif-openvswitch\"";
+  append oc "# or add \"script=vif-openvswitch,\" before the \"bridge=\" below:";
   append oc "vif = [ %s ]" (String.concat ", " networks);
   close_out oc
 


### PR DESCRIPTION
The .xl file is unchanged and is mostly useful as an example of a working .xl file (except the network configuration which is still missing). For example you can build `mirage-skeleton/block` and immediately run it with the generated `block_test.xl`.

The .xl.in file contains everything needed for the VM to boot (again except the network configuration) but with `@VARIABLES@` which must be substituted by the sysadmin according to their preferences. For example every required `BLOCK` device is present as a `disk`, with the correct `vdev` (matching the `Block.connect` inside the kernel) but with a variable `@BLOCK:filename@` which should be replaced with the full path to the expected block device file on the host.

Ideally deployments will base themselves on the .xl.in file, substituting the variables to suit local conditions. Then, if we change how mirage boots (e.g. PV to HVM), nothing on the deployment side needs to be changed.