### PR TITLE
Add "Build succeeded" message in Xen Makefile

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1393,6 +1393,7 @@ let configure_makefile ~target ~root ~name info =
                   \t  $(shell gcc -print-libgcc-file-name) \\\n\
                   %s"
         extra_c_archives pkg_config_deps generate_image ;
+      append fmt "\t@@echo Build succeeded";
       R.ok ()
     | `Unix | `MacOSX ->
       append fmt "build: main.native";


### PR DESCRIPTION
Adds a "Build succeeded" message after the `ld` call in the Xen Makefile to avoid showing an error message as the last line for successful builds. See also issues https://github.com/mirage/mirage-skeleton/issues/106 and https://github.com/mirage/mirage/issues/258