### PR TITLE
Pass the original name, not the prefixed name, to 'connect'.

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -98,7 +98,7 @@ let console_unix str = impl @@ object
     method packages = Key.pure ["mirage-console"; "mirage-unix"]
     method libraries = Key.pure ["mirage-console.unix"]
     method connect _ modname _args =
-      Printf.sprintf "%s.connect %S" modname name
+      Printf.sprintf "%s.connect %S" modname str
   end
 
 let console_xen str = impl @@ object
@@ -111,7 +111,7 @@ let console_xen str = impl @@ object
         ["mirage-console"; "xenstore"; "mirage-xen"; "xen-gnt"; "xen-evtchn"]
     method libraries = Key.pure ["mirage-console.xen"]
     method connect _ modname _args =
-      Printf.sprintf "%s.connect %S" modname name
+      Printf.sprintf "%s.connect %S" modname str
   end
 
 let custom_console str =


### PR DESCRIPTION
Fixes https://github.com/mirage/mirage/issues/467.  @drup, could you confirm that this is the right fix?