### PR TITLE
meta_ipv4 parenthesizes its output

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -431,7 +431,7 @@ let meta_triple ppx ppy ppz =
   Fmt.parens @@ pp_triple ~sep:(Fmt.unit ",@ ") ppx ppy ppz
 
 let meta_ipv4 ppf s =
-  Fmt.pf ppf "Ipaddr.V4.of_string_exn %S" (Ipaddr.V4.to_string s)
+  Fmt.pf ppf "(Ipaddr.V4.of_string_exn %S)" (Ipaddr.V4.to_string s)
 
 type ipv4_config = (Ipaddr.V4.t, Ipaddr.V4.t) ip_config
 


### PR DESCRIPTION
If meta_ipv4 is called in a context where it may be used in a
constructor (e.g. Some meta_ipv4), failing to parenthesize the call to Ipaddr.V4.of_string_exn
results in a compilation error on a currified constructor.
Parenthesizing hurts nothing, so just do it by default.