### PR TITLE
Clarify the meaning of `FLOW.close`

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -147,11 +147,22 @@ module type FLOW = sig
       error. *)
 
   val close: flow -> unit io
-  (** [close flow] will flush all pending writes and signal the end of
-      the flow to the remote endpoint.  When the result [unit io]
-      becomes determined, all further calls to [read flow] will result
-      in a [`Eof]. *)
+  (** [close flow] will flush all pending writes and signal the remote
+      endpoint that there will be no future writes. Once the remote endpoint
+      has read all pending data, it is expected that calls to [read] on
+      the remote will return [`Eof].
 
+      Note it is still possible for the remote endpoint to [write] to
+      the flow and for the local endpoint to call [read]. This state where
+      the local endpoint has called [close] but the remote endpoint
+      has not called [close] is similar to that of a half-closed TCP
+      connection or a Unix socket after [shutdown(SHUTDOWN_WRITE)].
+
+      The result [unit io] will become determined when the remote endpoint
+      finishes calling [write] and calls [close]. At this point no data
+      can flow in either direction and resources associated with the flow
+      can be freed.
+      *)
 end
 
 (** {1 Console input/output} *)


### PR DESCRIPTION
This patch extends the description of `FLOW.close` to include discussion
of the flow state when one side has called `FLOW.close` and the other
has not.

Hopefully this is not actually a change in intended meaning, as the
mirage tcp/ip stack already behavies this way: `FLOW.close` is
implemented by sending a `FIN` to the peer which terminates only one
side of the full-duplex connection. When the peer finishes transmitting
all of its data -- at some arbitrary later date -- it will also send a `FIN`
to close the remainder of the connection.

`FLOW.close` means I will not call `write` again, so the peer can
receive `Eof` once it has read all pending/buffered data. This patch
clarifies that, after calling `close`, I can still call `read` to
read data being written by the other side, until the other side also
calls `close`.

`FLOW.close` is a handshake with the peer: when the peer also calls
`FLOW.close`, both threads unblock and resources associated with the
connection can be freed.

Signed-off-by: David Scott <dave.scott@docker.com>