### PR TITLE
Add the possibility to ignore the command line.

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -925,7 +925,18 @@ let argv_xen = impl @@ object
     method connect _ _ _ = "Bootvar.argv ()"
   end
 
-let argv_dynamic = if_impl Key.is_xen argv_xen argv_unix
+let argv_empty = impl @@ object
+    inherit base_configurable
+    method ty = Functoria_app.argv
+    method name = "argv_empty"
+    method module_name = "Mirage_runtime"
+    method connect _ _ _ = "Lwt.return (`Ok [|\"\"|])"
+  end
+
+let argv_dynamic =
+  if_impl Key.(value argv_empty)
+    argv_empty
+    (if_impl Key.is_xen argv_xen argv_unix)
 
 (** Tracing *)
 

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -183,6 +183,13 @@ let tracing_size default =
   let key = Arg.opt ~stage:`Configure Arg.int default doc in
   Key.create "tracing_size" key
 
+(** {3 Argv} *)
+let argv_empty =
+  let doc = "Ignore the command line and set argv to [|\"\"|]" in
+  let doc = Arg.info ~docs:mirage_section ~doc ["no-argv"] in
+  let key = Arg.flag ~stage:`Configure doc in
+  Key.create "argv_empty" key
+
 (** {2 General mirage keys} *)
 
 let create_simple ?(group="") ?(stage=`Both) ~doc ~default conv name =

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -47,6 +47,9 @@ val xen: bool key
 val tracing_size: int -> int key
 (** [--tracing-size]: Key setting the tracing ring buffer size. *)
 
+val argv_empty: bool key
+(** [--no-argv]: Disable command line parsing and set argv to [|""|]. *)
+
 (** {2 Generic keys}
 
     Some keys have a [group] optional argument. This group argument allows to


### PR DESCRIPTION
Very rough fix for https://github.com/mirage/mirage/issues/493 for @talex5 and @sgrove 

It doesn't prevent the dependency on cmdliner, which is slightly annoying. It does prevent the dependency on bootvar. Is it worth trying to avoid the cmdliner dependency ?

However, if it turns out that most usage of mirage unikernels (EC2, Qubes ..) don't have precise control over their command line, we should find a more general solution than just disabling it.