### PR TITLE
Support early configuration of logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-ci.sh
 env:
   global:
-          - PINS="mirage-skeleton.dev:https://github.com/yomimono/mirage-skeleton.git#charrua-0.3 tcpip:https://github.com/mirage/mirage-tcpip.git mirage-types:https://github.com/mirage/mirage.git mirage:https://github.com/mirage/mirage.git"
+          - PINS="functoria mirage-skeleton.dev:https://github.com/yomimono/mirage-skeleton.git#charrua-0.3 tcpip:https://github.com/mirage/mirage-tcpip.git mirage-types:https://github.com/mirage/mirage.git mirage:https://github.com/mirage/mirage.git"
   matrix:
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PACKAGE=mirage
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PACKAGE=mirage-types

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -42,6 +42,7 @@ val mprof_trace : size:int -> unit -> tracing
 
 val register :
   ?tracing:tracing ->
+  ?log:(job impl -> job impl) ->
   ?keys:Key.t list ->
   ?libraries:string list ->
   ?packages:string list -> string -> job impl list -> unit
@@ -51,7 +52,8 @@ val register :
     @param packages The opam packages needed by this module.
     @param keys The keys related to this module.
 
-    @param tracing Enable tracing and give a default depth.
+    @param tracing Enable tracing.
+    @param log Replace the default logger ({!mirage_logs}). To disable logging, pass the identity function.
 *)
 
 
@@ -79,6 +81,28 @@ val clock: clock typ
 val default_clock: clock impl
 (** The default mirage-clock implementation. *)
 
+
+(** {2 Logging} *)
+
+type logger
+(** Abstract type for loggers. *)
+
+val logger: logger typ
+
+val mirage_logs: ?clock:clock impl -> unit -> logger impl
+(** [mirage_logs ?clock ()] is a log reporter that prints log messages to the console,
+    timestampted with [clock] (default: [default_clock]). *)
+
+val with_logger:
+  ?level:[`Error | `Warning | `Info | `Debug] ->
+  logger impl ->
+  job impl ->
+  job impl
+(** [with_logger ?level logger job] is a job that behaves like [job], but wrapped by
+    [logger].
+    It initialises the log level to [level] (default: [`Info]), connects
+    [logger] and then connects [job] in a context provided by [logger].
+    It avoids forcing [job]'s dependencies until logging is set up. *)
 
 
 (** {2 Random} *)


### PR DESCRIPTION
To get logging, wrap your job with `mirage_logs`, like this:

    open Mirage

    let handler = foreign
      "Unikernel.Main" (stackv4 @-> job)

    let stack = generic_stackv4 tap0

    let () =
      register "stackv4" [mirage_logs (handler $ stack)]

This requires a patch to functoria: https://github.com/talex5/functoria/tree/logging

It's currently a bit hacky, but I'm sure someone who understands functoria can make it nicer. The key idea is that a `configurable` now gets given its lazy inputs directly, rather than having functoria force them automatically. This allows us to set up logging before forcing the dependencies.

(However, if a dependency is also a dependency of logging then it will be forced first. For example, if you configure a network time source as the log time-stamper then networking will be initialised before logging. I think this is the desired behaviour.)

Note: This patch is on top of the `better-errors` branch and is not as large as it looks. Just look at the last commit.

/cc @Drup 