### PR TITLE
Remove warn_error from default tags

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1294,7 +1294,7 @@ let configure_makefile ~target ~root ~name info =
   append fmt "LIBS   = %s" libraries;
   append fmt "PKGS   = %s" packages;
   let default_tags =
-    "warn_error(+1..49),warn(A-4-41-44),debug,bin_annot,\
+    "warn(A-4-41-44),debug,bin_annot,\
      strict_sequence,principal,safe_string"
   in
   begin match target with


### PR DESCRIPTION
Adding warn_error to the default tags for warnings that have been
enabled in the same step is a regression, since there has been no
inermediate period where this warnings could have been fixed.  This
change removes the warn_error tag from the default tags.

Fixes: #520