### PR TITLE
Introduce a module type for ICMP and ICMPV4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-ci.sh
 env:
   global:
-          - PINS="mirage-skeleton.dev:https://github.com/mirage/mirage-skeleton.git tcpip:https://github.com/yomimono/mirage-tcpip.git#icmp_refactor"
+          - PINS="mirage-skeleton.dev:https://github.com/yomimono/mirage-skeleton.git#charrua-0.3 tcpip:https://github.com/yomimono/mirage-tcpip.git#icmp_refactor mirage-types:https://github.com/yomimono/mirage.git#icmp_type mirage:https://github.com/yomimono/mirage.git#icmp_type charrua-core:https://github.com/haesbaert/charrua-core.git"
   matrix:
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PACKAGE=mirage
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PACKAGE=mirage-types

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-ci.sh
 env:
   global:
-  - PINS="mirage-skeleton.dev:https://github.com/mirage/mirage-skeleton.git"
+  - PINS="mirage-skeleton.dev:https://github.com/mirage/mirage-skeleton.git tcpip:https://github.com/yomimono/tcpip.git#icmp_refactor"
   matrix:
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PACKAGE=mirage
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PACKAGE=mirage-types

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-ci.sh
 env:
   global:
-  - PINS="mirage-skeleton.dev:https://github.com/mirage/mirage-skeleton.git tcpip:https://github.com/yomimono/tcpip.git#icmp_refactor"
+          - PINS="mirage-skeleton.dev:https://github.com/mirage/mirage-skeleton.git tcpip:https://github.com/yomimono/mirage-tcpip.git#icmp_refactor"
   matrix:
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PACKAGE=mirage
   - UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PACKAGE=mirage-types

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -522,6 +522,27 @@ module type IPV6 = sig
   include IP
 end
 
+(** {1 ICMP module} *)
+module type ICMP = sig
+  include DEVICE
+
+  type ipaddr
+  type buffer
+
+  val pp_of_error : Format.formatter -> error -> unit
+  (** pretty-print an error. *)
+
+  val input : t -> src:ipaddr -> dst:ipaddr -> buffer -> unit io
+(** [input t src dst buffer] reacts to the ICMP message in [buffer]. *)
+
+  val write : t -> dst:ipaddr -> buffer -> unit io
+(** [write t dst buffer] sends the ICMP message in [buffer] to [dst] over IP. *)
+end
+
+module type ICMPV4 = sig
+  include ICMP
+end
+
 (** {1 UDP stack}
 
     A UDP stack that can send and receive datagrams. *)

--- a/types/V1_LWT.mli
+++ b/types/V1_LWT.mli
@@ -67,6 +67,17 @@ module type IPV6 = IPV6
    and type prefix = Ipaddr.V6.Prefix.t
    and type uipaddr = Ipaddr.t
 
+(** ICMP module *)
+module type ICMP = ICMP
+  with type 'a io = 'a Lwt.t
+   and type buffer = Cstruct.t
+
+(** ICMPV4 module *)
+module type ICMPV4 = ICMPV4
+  with type 'a io = 'a Lwt.t
+   and type buffer = Cstruct.t
+   and type ipaddr = Ipaddr.V4.t
+
 (** UDP stack *)
 module type UDP = UDP
   with type 'a io = 'a Lwt.t


### PR DESCRIPTION
Currently, ICMP functionality is implicitly provided by the modules implementing IPV4 and IPV6 module types.  Define a module type for ICMP to facilitate pulling this functionality out of IPV4/6 in order to make it more explicit and extensible.