### PR TITLE
ICMP: change pp_of_error to pp_error

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -529,7 +529,7 @@ module type ICMP = sig
   type ipaddr
   type buffer
 
-  val pp_of_error : Format.formatter -> error -> unit
+  val pp_error : Format.formatter -> error -> unit
   (** pretty-print an error. *)
 
   val input : t -> src:ipaddr -> dst:ipaddr -> buffer -> unit io


### PR DESCRIPTION
Per @talex5's suggestion, call it pp_error instead of pp_of_error .  Should be merged alongside https://github.com/mirage/mirage-tcpip/pull/197 .