### PR TITLE
Build with ocamlbuild -r

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ env:
   global:
   matrix:
   - PACKAGE=mirage UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PINS="functoria mirage-logs"
-  -  PACKAGE=mirage-types UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02
+  - PACKAGE=mirage-types UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PINS="functoria"

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1381,14 +1381,14 @@ let configure_makefile ~target ~root ~name ~warn_error info =
   begin match target with
     | `Xen  ->
       append fmt "SYNTAX = -tags \"%s\"\n" default_tags;
-      append fmt "FLAGS  = -cflag -g -lflags -g,-linkpkg,-dontlink,unix\n";
+      append fmt "FLAGS  = -r -cflag -g -lflags -g,-linkpkg,-dontlink,unix\n";
       append fmt "XENLIB = $(shell ocamlfind query mirage-xen)\n"
     | `Unix ->
       append fmt "SYNTAX = -tags \"%s\"\n" default_tags;
-      append fmt "FLAGS  = -cflag -g -lflags -g,-linkpkg\n"
+      append fmt "FLAGS  = -r -cflag -g -lflags -g,-linkpkg\n"
     | `MacOSX ->
       append fmt "SYNTAX = -tags \"thread,%s\"\n" default_tags;
-      append fmt "FLAGS  = -cflag -g -lflags -g,-linkpkg\n"
+      append fmt "FLAGS  = -r -cflag -g -lflags -g,-linkpkg\n"
   end;
   append fmt "SYNTAX += -tag-line \"<static*.*>: warn(-32-34)\"\n";
   append fmt "BUILD  = ocamlbuild -use-ocamlfind $(LIBS) $(SYNTAX) $(FLAGS)\n\


### PR DESCRIPTION
This is the default behaviour if you have a _tags or myocamlbuild.ml,
but not otherwise in case you're running from your home directory. In
our case, we know the current directory is a valid project and can
always have this on.

Avoids a long and misleading error that is otherwise printed after every
compilation failure telling the user to enable this.

Fixes #536.