### PR TITLE
Require "pseudoheaders" function for IP module types.

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -2,7 +2,7 @@ bash -ex .travis-opam.sh
 
 eval `opam config env`
 opam install mirage -y
-git clone https://github.com/mirage/mirage-skeleton.git
+git clone -b update-skeleton https://github.com/yomimono/mirage-skeleton.git
 cd mirage-skeleton
 MODE=unix make
 MODE=xen  make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ script: bash -ex .travis-ci.sh
 env:
   global:
   matrix:
-  - PACKAGE=mirage UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PINS="mirage-logs mirage-types mirage-types-lwt"
-  - PACKAGE=mirage-types UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PINS="tcpip mirage mirage-types-lwt"
+  - PACKAGE=mirage UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PINS="tcpip mirage-types:git://github.com/yomimono/mirage.git#pseudoheaders mirage-types-lwt:git://github.com/yomimono/mirage.git#pseudoheaders charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers"
+  - PACKAGE=mirage-types UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PINS="tcpip charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers mirage:git://github.com/yomimono/mirage.git#pseudoheaders mirage-types-lwt:git://github.com/yomimono/mirage.git#pseudoheaders"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ script: bash -ex .travis-ci.sh
 env:
   global:
   matrix:
-  - PACKAGE=mirage UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PINS="functoria mirage-logs"
-  - PACKAGE=mirage-types UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PINS="functoria"
+  - PACKAGE=mirage UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PINS="mirage-logs mirage-types mirage-types-lwt"
+  - PACKAGE=mirage-types UPDATE_GCC_BINUTILS=1 OCAML_VERSION=4.02 PINS="tcpip mirage mirage-types-lwt"

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -429,7 +429,7 @@ module type IP = sig
 
   val pseudoheader : t -> dst:ipaddr -> proto:[< `TCP | `UDP ] -> int -> Cstruct.t
   (** [pseudoheader t dst proto len] gives a pseudoheader suitable for use in
-      TCP checksum calculation based on [t]. *)
+      TCP or UDP checksum calculation based on [t]. *)
 
   val get_source: t -> dst:ipaddr -> ipaddr
   (** [get_source ip ~dst] is the source address to be used to send a

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -427,6 +427,10 @@ module type IP = sig
       assumes that frame is of the form returned by [allocate_frame],
       i.e., that it contains the link-layer part. *)
 
+  val pseudoheader : t -> dst:ipaddr -> proto:[< `TCP | `UDP ] -> int -> Cstruct.t
+  (** [pseudoheader t dst proto len] gives a pseudoheader suitable for use in
+      TCP checksum calculation based on [t]. *)
+
   val get_source: t -> dst:ipaddr -> ipaddr
   (** [get_source ip ~dst] is the source address to be used to send a
       packet to [dst]. *)

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -427,7 +427,7 @@ module type IP = sig
       assumes that frame is of the form returned by [allocate_frame],
       i.e., that it contains the link-layer part. *)
 
-  val pseudoheader : t -> dst:ipaddr -> proto:[< `TCP | `UDP ] -> int -> Cstruct.t
+  val pseudoheader : t -> dst:ipaddr -> proto:[< `TCP | `UDP ] -> int -> buffer
   (** [pseudoheader t dst proto len] gives a pseudoheader suitable for use in
       TCP or UDP checksum calculation based on [t]. *)
 


### PR DESCRIPTION
Some transport layer protocols want to calculate a checksum over fields from the underlying network layer (the "pseudoheader").  Require modules to provide a `pseudoheader` function which assembles the correct pseudoheader given the parameters this should express.

Implementations of `pseudoheader` for IPv4 and IPv6 are included in a PR to `mirage-tcpip`.