### PR TITLE
TIME: use an int64 for sleep

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -2,7 +2,7 @@ bash -ex .travis-opam.sh
 
 eval `opam config env`
 opam install mirage -y
-git clone -b mirage-dev https://github.com/mirage/mirage-skeleton.git
+git clone -b sleep-nsec https://github.com/hannesm/mirage-skeleton.git
 cd mirage-skeleton
 MODE=unix make
 MODE=xen  make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: bash -ex .travis-ci.sh
 env:
   global:
   - UPDATE_GCC_BINUTILS=1
-  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
+  - EXTRA_REMOTES="git://github.com/hannesm/mirage-dev.git#sleep-nsec"
   matrix:
   - PACKAGE=mirage OCAML_VERSION=4.03
   - PACKAGE=mirage-types OCAML_VERSION=4.03

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -73,8 +73,9 @@ module type TIME = sig
   type +'a io
   (** The type for potentially blocking I/O operation *)
 
-  val sleep: float -> unit io
-  (** [sleep nsec] Block the current thread for. {b FIXME:} remove float. *)
+  val sleep_ns: int64 -> unit io
+  (** [sleep_ns n] Block the current thread for [n] nanoseconds, treating
+      the [n] unsigned.  *)
 end
 
 (** {1 Random}


### PR DESCRIPTION
I got derailed while wanting to adapt the RANDOM module type with the TIME module type.

Its documentation:
```OCaml
  val sleep: float -> unit io
  (** [sleep nsec] Block the current thread for. {b FIXME:} remove float. *)
```

I propose to have: `val sleep : Int64 -> unit io`, the amount of nanoseconds (this is what we get out of the monotonic clock on [xen](https://github.com/mirage/mirage-platform/blob/ed19a1a318e944a7020239fa01c0b674b02cf471/bindings/clock_stubs.c#L39), and likely as well from Lwt_unix.sleep.  The range will be up to 9223372036854775807L nanoseconds (106751 days).

I've PRs for (compiles + test run with 4.03 on Unix (FreeBSD)):
- [mirage-platform 188](https://github.com/mirage/mirage-platform/pull/168) (mirage-xen and mirage-unix)
- [mirage-solo5 8](https://github.com/mirage/mirage-solo5/pull/8)
- [dns 95](https://github.com/mirage/ocaml-dns/pull/95)
- [tcpip 216](https://github.com/mirage/mirage-tcpip/pull/216)
- [mirage-skeleton 171](https://github.com/mirage/mirage-skeleton/pull/171)

anyone aware of other users of (OS.)Time.sleep (our website tutorial for sure)?  Any comments on this proposed API change?