### PR TITLE
Minor API docs updates: use the present tense and active voice

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -19,7 +19,29 @@
 (** MirageOS Signatures.
 
     This module defines the basic signatures that functor parameters
-    should implement in MirageOS to be portable. *)
+    should implement in MirageOS to be portable.
+
+    {1 General conventions}
+
+    {ul
+    {- errors which application programmers are expected to handle
+       (e.g. connection refused or end of file) are encoded as result types
+       where [`Ok x] means the operation was succesful and returns [x] and
+       where [`Error e] means the operation has failed with error [e]. }
+    {- errors which represent programming errors such as assertion failures
+       or illegal arguments are encoded as exceptions. The application may
+       attempt to catch exceptions and recover or simply let the exception
+       propagate and crash the application. If the application crashes then
+       the runtime system should output diagnostics and abort. }
+    {- operations which perform I/O return values of [type +'a io] which
+       allow the application to either wait for the I/O to be completed or
+       leave it running asynchronously. If the I/O completes with an error
+       then the operation may have completely failed, partially succeeded
+       or even completely succeeded (e.g. it may only be a confirmation
+       message in a network protocol which was missed): see individual API
+       descriptions for details. }
+    }
+ *)
 
 (** {1 Abstract devices}
 

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -156,10 +156,9 @@ module type FLOW = sig
       has not called [close] is similar to that of a half-closed TCP
       connection or a Unix socket after [shutdown(SHUTDOWN_WRITE)].
 
-      The result [unit io] determines when the remote endpoint
-      finishes calling [write] and calls [close]. At this point no data
-      can flow in either direction and resources associated with the flow
-      can be freed.
+      [close flow] waits until the remote endpoint has also called [close]
+      before returning. At this point no data can flow in either direction
+      and resources associated with the flow can be freed.
       *)
 end
 

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -125,26 +125,24 @@ module type FLOW = sig
       logging. *)
 
   val read: flow -> [`Ok of buffer | `Eof | `Error of error ] io
-  (** [read flow] will block until it either successfully reads a
-      segment of data from the current flow, receives an [Eof]
-      signifying that the connection is now closed, or an [Error]. *)
+  (** [read flow] reads some data from the flow and returns a
+      fresh buffer (of arbitrary size), an [`Eof] if the other side has
+      called [close] or an [`Error]. *)
 
   val write: flow -> buffer -> [`Ok of unit | `Eof | `Error of error ] io
-  (** [write flow buffer] will block until [buffer] has been added to
-      the send queue. There is no indication when the buffer has
-      actually been read and, therefore, it must not be reused.  The
-      contents may be transmitted in separate packets, depending on
-      the underlying transport. The result [`Ok ()] indicates success,
-      [`Eof] indicates that the connection is now closed and [`Error]
-      indicates some other error. *)
+  (** [write flow buffer] writes a buffer to the flow. There is no
+      indication when the buffer has actually been read and, therefore,
+      it must not be reused.  The contents may be transmitted in
+      separate packets, depending on the underlying transport. The
+      result [`Ok ()] indicates success, [`Eof] indicates that the
+      connection is now closed and [`Error] indicates some other error. *)
 
   val writev: flow -> buffer list -> [`Ok of unit | `Eof | `Error of error ] io
-  (** [writev flow buffers] will block until the buffers have all been
-      added to the send queue. There is no indication when the buffers
-      have actually been read and, therefore, they must not be reused.
-      The result [`Ok ()] indicates success, [`Eof] indicates that the
-      connection is now closed and [`Error] indicates some other
-      error. *)
+  (** [writev flow buffers] writes a sequence of buffers to the flow.
+      There is no indication when the buffers have actually been read and,
+      therefore, they must not be reused. The result [`Ok ()] indicates
+      success, [`Eof] indicates that the connection is now closed and
+      [`Error] indicates some other error. *)
 
   val close: flow -> unit io
   (** [close flow] flushes all pending writes and signals the remote

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -147,10 +147,10 @@ module type FLOW = sig
       error. *)
 
   val close: flow -> unit io
-  (** [close flow] will flush all pending writes and signal the remote
+  (** [close flow] flushes all pending writes and signals the remote
       endpoint that there will be no future writes. Once the remote endpoint
       has read all pending data, it is expected that calls to [read] on
-      the remote will return [`Eof].
+      the remote return [`Eof].
 
       Note it is still possible for the remote endpoint to [write] to
       the flow and for the local endpoint to call [read]. This state where
@@ -158,7 +158,7 @@ module type FLOW = sig
       has not called [close] is similar to that of a half-closed TCP
       connection or a Unix socket after [shutdown(SHUTDOWN_WRITE)].
 
-      The result [unit io] will become determined when the remote endpoint
+      The result [unit io] determines when the remote endpoint
       finishes calling [write] and calls [close]. At this point no data
       can flow in either direction and resources associated with the flow
       can be freed.

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -147,9 +147,17 @@ module type FLOW = sig
       logging. *)
 
   val read: flow -> [`Ok of buffer | `Eof | `Error of error ] io
-  (** [read flow] reads some data from the flow and returns a
-      fresh buffer (of arbitrary size), an [`Eof] if the other side has
-      called [close] or an [`Error]. *)
+  (** [read flow] blocks until some data is available and returns a
+      fresh buffer containing it.
+
+      The returned buffer will be of a size convenient to the flow
+      implementation, but will always have at least 1 byte.
+
+      If the remote endpoint calls [close] then calls to [read] will
+      keep returning data until all the in-flight data has been read.
+      [read flow] will return [`Eof] when the remote endpoint has
+      called [close] and when there is no more in-flight data.
+   *)
 
   val write: flow -> buffer -> [`Ok of unit | `Eof | `Error of error ] io
   (** [write flow buffer] writes a buffer to the flow. There is no


### PR DESCRIPTION
This standardises on the present tense and active voice (rather than e.g. the future tense). Most of the API was already like this, but it was inconsistent.

There's no implied semantic change in this PR (at least I hope not!)

This PR also starts a new section at the top called "General conventions" which calls out

1. errors which the application is supposed to handle (e.g. connection refused) are represented as error values
2. errors which the application is not supposed to handle (e.g. assertion failures) are represented as exceptions which are expected to abort the program with diagnostic data
3. operations which perform I/O return a `type +'a io` which allows the application to either wait for completion or let them run asynchronously.
