### PR TITLE
[RFC] Add `disconnect` to `FLOW`

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -898,6 +898,10 @@ module type CHANNEL = sig
   (** [close t] calls {!flush} and then close the underlying
       flow. *)
 
+  val disconnect: t -> unit io
+  (** [disconnect t] calls {!disconnect} on the underlying flow without
+      flushing first. *)
+
 end
 
 (** {1 Filesystem} *)

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -190,6 +190,22 @@ module type FLOW = sig
       before returning. At this point no data can flow in either direction
       and resources associated with the flow can be freed.
       *)
+
+  val disconnect: flow -> unit io
+  (** [disconnect flow] disconnects from the flow without flushing and
+      frees local resources.
+
+      Warning: [disconnect flow] may drop in-flight data: to ensure data is
+      transmitted use [close flow] first.
+
+      [disconnect flow] waits for the local resources to be freed. The time
+      taken depends on the underlying implementation; for example an implementation
+      over a Unix pipe can be freed quickly, while a connection to a
+      remote machine over TCP may require the connection to remain in a
+      "TIME-WAIT" state for several minutes, see
+      {{:http://www.isi.edu/touch/pubs/infocomm99/infocomm99-web/}The TIME-WAIT
+      state in TCP and Its Effect on Busy Servers}.
+  *)
 end
 
 (** {1 Console input/output} *)


### PR DESCRIPTION
`FLOW` already includes `close` which performs a graceful shutdown
of one half of a bidirectional connection (also known as a half-close
and written in Unix as `Unix.(shutdown fd Unix.SHUTDOWN_SEND)`).
For example in the Mirage tcpip stack, [close](https://github.com/mirage/mirage-tcpip/blob/29a5e068f6175207bb42965edd228d334157f56f/lib/tcp/flow.ml#L74) will send a FIN
and wait for the FIN ACK and then continue accepting data in the
other direction. This is important for protocols like HTTP where a
common pattern is to `connect`, `write` a request and then `close`
(a.k.a. `Unix.(shutdown fd SHUTDOWN_SEND)`), and then `read` the
response.

This patch requires a `disconnect` function which performs an
ungraceful shutdown of both halves of a bidirectional connection.
`disconnect` waits until all local resources have been cleaned up
(within limits imposed by the platform). Users who are happy to
let resources be freed in the background are welcome to call
`disconnect` asychronously.

Notes regarding implementations:
- in the Mirage tcpip stack, connection state is freed in the
  background as connections close and are timed-out. This extra
  function allows us to (i) request the state be cleaned up sooner;
  and (ii) optionally wait for the cleanup to be complete.
- in a Unix shim, `disconnect` should call `Unix.close` (or its
  equivalent) which will drop any buffered data rather than try to
  resend it, perform a FIN/ACK handshake and return. Unfortunately
  the Unix socket API is limited and it's not possible for us to
  wait while the kernel manages the connection in the "TIME-WAIT"
  state. This means it's possible even for careful applications
  to run out of kernel resources.

Currently it's not possible to write a TCP proxy with FLOWs
because of the confusion between half-close and full-close.

Although the terminology is different to Unix, I quite like the use of
`disconnect` here since it mirrors what we already do with `DEVICE`s
and is the opposite of `connect`.

An alternative would be:
- redefine `FLOW.close` to mean the same as `Unix.close` i.e.
  full close, drop incoming date (so one would `disconnect` a `BLOCK`
  but `close` a `FLOW`?)
- add a `FLOW.shutdown` to mean the same as `Unix.shutdown`
  to half-close the connection
- change `mirage-tcpip` to use both of these.
