### PR TITLE
[RFC] simplify random

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -113,6 +113,17 @@ end
 
 let stdlib_random = impl stdlib_random_conf
 
+let nocrypto_random_conf = object
+  inherit base_configurable
+  method ty = random
+  method name = "random"
+  method module_name = "Nocrypto.Rng"
+  method packages = Key.pure ["nocrypto"]
+  method libraries = Key.pure ["nocrypto"]
+end
+
+let nocrypto_random = impl nocrypto_random_conf
+
 type console = CONSOLE
 let console = Type CONSOLE
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -100,14 +100,18 @@ let default_monotonic_clock = impl monotonic_clock_conf
 type random = RANDOM
 let random = Type RANDOM
 
-let random_conf = object
+let stdlib_random_conf = object
   inherit base_configurable
   method ty = random
   method name = "random"
-  method module_name = "Random"
+  method module_name = "Stdlibrandom"
+  method packages = Key.pure ["mirage-stdlib-random"]
+  method libraries = Key.pure ["mirage-stdlib-random"]
+  method connect _ modname _args =
+    Printf.sprintf "Lwt.return (`Ok (%s.initialize ()))" modname
 end
 
-let default_random = impl random_conf
+let stdlib_random = impl stdlib_random_conf
 
 type console = CONSOLE
 let console = Type CONSOLE
@@ -655,7 +659,7 @@ end
 let tcp_direct_func () = impl (tcp_direct_conf ())
 
 let direct_tcp
-    ?(clock=default_monotonic_clock) ?(random=default_random) ?(time=default_time) ip =
+    ?(clock=default_monotonic_clock) ?(random=stdlib_random) ?(time=default_time) ip =
   tcp_direct_func () $ ip $ time $ clock $ random
 
 let tcpv4_socket_conf ipv4_key = object
@@ -729,7 +733,7 @@ let stackv4_direct_conf ?(group="") config = impl @@ object
 
 let direct_stackv4_with_config
     ?(clock=default_monotonic_clock)
-    ?(random=default_random)
+    ?(random=stdlib_random)
     ?(time=default_time)
     ?group
     network config =

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -109,7 +109,7 @@ type random
 val random: random typ
 (** Implementations of the [V1.RANDOM] signature. *)
 
-val default_random: random impl
+val stdlib_random: random impl
 (** Passthrough to the OCaml Random generator. *)
 
 

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -112,6 +112,9 @@ val random: random typ
 val stdlib_random: random impl
 (** Passthrough to the OCaml Random generator. *)
 
+val nocrypto_random: random impl
+(** Passthrough to the Fortuna PRNG implemented in nocrypto. *)
+
 
 (** {2 Consoles} *)
 

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -80,23 +80,14 @@ end
 
 (** {1 Random}
 
-    Operations to generate randomness. This is currently a passthrough
-    to the OCaml Random generator, and will be deprecated and
-    turned into a proper DEVICE with blocking modes. *)
+    Operations to generate random numbers. *)
 module type RANDOM = sig
 
-  val self_init: unit -> unit
-  (** Initialize the generator with a random seed chosen in a
-      system-dependent way. *)
+  type buffer
+  (** The type for memory buffer. *)
 
-  val int: int -> int
-  (** [int bound] returns a random integer between 0 (inclusive) and
-      [bound] (exclusive). [bound] must be greater than 0 and less
-      than 2{^30}. *)
-
-  val int32: int32 -> int32
-  (** [int32 bound] returns a random integer between 0 (inclusive) and
-      [bound] (exclusive). [bound] must be greater than 0. *)
+  val generate: int -> buffer
+  (** [generate n] is a buffer of length [n] filled with random. *)
 end
 
 (** {1 POSIX clock}

--- a/types/V1_LWT.mli
+++ b/types/V1_LWT.mli
@@ -21,6 +21,9 @@ open V1
 module type TIME = TIME
   with type 'a io = 'a Lwt.t
 
+module type RANDOM = RANDOM
+  with type buffer = Cstruct.t
+
 module type FLOW = FLOW
   with type 'a io = 'a Lwt.t
    and type buffer = Cstruct.t


### PR DESCRIPTION
this is only the interface change -- after discussion I'll adapt the mirage tool to do the magic.

- in contrast to common believe, there is no need for random to have blocking behaviour
- helper functions which generate *your favourite number representation here* between bounds will be done in a helper library (no need to convolute the interface with it)
- my current plan is to have two implementations: OCaml's `Random` and nocrypto's fortuna.  if anywhere in your dependency chain you have `nocrypto` already, that one is used as `default_random` (the [logic for this is already in the mirage tool](https://github.com/mirage/mirage/blob/074cb5fe080b23779bddeb24ddb59f24766fd5c0/lib/mirage.ml#L763-L781)).  you can always explicitly pass the [lagged-Fiobnacci PRNG](https://github.com/ocaml/ocaml/blob/4515477da8034cf21001ed3a6ae49b1a00a61121/stdlib/random.ml) ([seeded with](https://github.com/ocaml/ocaml/blob/4515477da8034cf21001ed3a6ae49b1a00a61121/byterun/sys.c#L412-L452) `/dev/urandom` or `gettimeofday` etc. -- fine for MirageOS on Unix, brittle on Xen (esp. on [ARM](https://github.com/talex5/mini-os/blob/444542b05e0f8a6220129b90f4697563d4bd0e1b/arch/arm/time.c#L75-L85) where there is no [wall clock](https://github.com/talex5/mini-os/blob/444542b05e0f8a6220129b90f4697563d4bd0e1b/arch/arm/time.c#L54-L56))) to your modules instead of the `default_random`.  Initialisation of any PRNG is done via its `connect` function (as atm for nocrypto, but not for `Random`).