### PR TITLE
don't supply console to stackv4

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -2,7 +2,7 @@ bash -ex .travis-opam.sh
 
 eval `opam config env`
 opam install mirage -y
-git clone -b mirage-dev https://github.com/mirage/mirage-skeleton.git
+git clone -b remove-console https://github.com/yomimono/mirage-skeleton.git
 cd mirage-skeleton
 MODE=unix make
 MODE=xen  make

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-ci.sh
 env:
   global:
-  - UPDATE_GCC_BINUTILS=1 
+  - UPDATE_GCC_BINUTILS=1
+  - EXTRA_REMOTES="https://github.com/yomimono/mirage-dev.git#remove-console"
   matrix:
-  - PACKAGE=mirage OCAML_VERSION=4.03 PINS="tcpip mirage-types mirage-types-lwt mirage charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"
-  - PACKAGE=mirage-types OCAML_VERSION=4.03 PINS="tcpip mirage-types mirage-types-lwt mirage charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"
-  - PACKAGE=mirage OCAML_VERSION=4.02 PINS="tcpip mirage-types mirage-types-lwt mirage charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"
-  - PACKAGE=mirage-types OCAML_VERSION=4.02 PINS="tcpip mirage-types mirage-types-lwt mirage charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"
+  - PACKAGE=mirage OCAML_VERSION=4.03 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"
+  - PACKAGE=mirage-types OCAML_VERSION=4.03 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"
+  - PACKAGE=mirage OCAML_VERSION=4.02 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"
+  - PACKAGE=mirage-types OCAML_VERSION=4.02 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -717,7 +717,7 @@ let stackv4_socket_conf ?(group="") interfaces = impl @@ object
     method ty = stackv4
     val name = add_suffix "stackv4_socket" ~suffix:group
     method name = name
-    method module_name = "Tcpip_stack_socket.Make"
+    method module_name = "Tcpip_stack_socket"
     method keys = [ Key.abstract interfaces ]
     method packages = Key.pure [ "tcpip" ]
     method libraries = Key.pure [ "tcpip.stack-socket" ]

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -637,7 +637,7 @@ let stackv4_direct_conf ?(group="") config = impl @@ object
     inherit base_configurable
 
     method ty =
-      console @-> time @-> random @-> network @->
+      time @-> random @-> network @->
       ethernet @-> arpv4 @-> ipv4 @-> icmpv4 @-> udpv4 @-> tcpv4 @->
       stackv4
 
@@ -662,14 +662,13 @@ let stackv4_direct_conf ?(group="") config = impl @@ object
     method libraries = Key.pure [ "tcpip.stack-direct" ; "mirage.runtime" ]
 
     method connect _i modname = function
-      | [ console; _t; _r; interface; ethif; arp; ip; icmp; udp; tcp ] ->
+      | [ _t; _r; interface; ethif; arp; ip; icmp; udp; tcp ] ->
         Fmt.strf
           "@[<2>let config = {V1_LWT.@ \
-           name = %S;@ console = %s;@ \
+           name = %S;@ \
            interface = %s;@ mode = %a }@]@ in@ \
            %s.connect config@ %s %s %s %s %s %s"
-          name console
-          interface  pp_stackv4_config config
+          name interface pp_stackv4_config config
           modname ethif arp ip icmp udp tcp
       | _ -> failwith "Wrong arguments to connect to tcpip direct stack."
 
@@ -681,41 +680,41 @@ let direct_stackv4_with_config
     ?(random=default_random)
     ?(time=default_time)
     ?group
-    console network config =
+    network config =
   let eth = etif_func $ network in
   let arp = arp ~clock ~time eth in
   let ip = ipv4_conf () $ eth $ arp in
   stackv4_direct_conf ?group config
-  $ console $ time $ random $ network
+  $ time $ random $ network
   $ eth $ arp $ ip
   $ direct_icmpv4 ip
   $ direct_udp ip
   $ direct_tcp ~clock ~random ~time ip
 
 let direct_stackv4_with_dhcp
-    ?clock ?random ?time ?group console network =
+    ?clock ?random ?time ?group network =
   direct_stackv4_with_config
-    ?clock ?random ?time ?group console network `DHCP
+    ?clock ?random ?time ?group network `DHCP
 
 let direct_stackv4_with_static_ipv4
-    ?clock ?random ?time ?group console network
+    ?clock ?random ?time ?group network
     {address; netmask; gateways} =
   let address = Key.V4.ip ?group address in
   let netmask = Key.V4.netmask ?group netmask in
   let gateways = Key.V4.gateways ?group gateways in
   direct_stackv4_with_config
-    ?clock ?random ?time ?group console network
+    ?clock ?random ?time ?group network
     (`IPV4 (address, netmask, gateways))
 
 let direct_stackv4_with_default_ipv4
-    ?clock ?random ?time ?group console network =
+    ?clock ?random ?time ?group network =
   direct_stackv4_with_static_ipv4
-    ?clock ?random ?time ?group console network
+    ?clock ?random ?time ?group network
     default_ipv4_conf
 
 let stackv4_socket_conf ?(group="") interfaces = impl @@ object
     inherit base_configurable
-    method ty = console @-> stackv4
+    method ty = stackv4
     val name = add_suffix "stackv4_socket" ~suffix:group
     method name = name
     method module_name = "Tcpip_stack_socket.Make"
@@ -728,21 +727,21 @@ let stackv4_socket_conf ?(group="") interfaces = impl @@ object
     ]
 
     method connect _i modname = function
-      | [ console ; udpv4 ; tcpv4 ] ->
+      | [ udpv4 ; tcpv4 ] ->
         Fmt.strf
           "let config =@[@ \
-           { V1_LWT.name = %S;@ console = %s ;@ \
+           { V1_LWT.name = %S;@ \
            interface = %a ;@ mode = () }@] in@ \
            %s.connect config %s %s"
           name
-          console  pp_key interfaces
+          pp_key interfaces
           modname udpv4 tcpv4
       | _ -> failwith "Wrong arguments to connect to tcpip socket stack."
 
   end
 
-let socket_stackv4 ?group console ipv4s =
-  stackv4_socket_conf ?group (Key.V4.interfaces ?group ipv4s) $ console
+let socket_stackv4 ?group ipv4s =
+  stackv4_socket_conf ?group (Key.V4.interfaces ?group ipv4s)
 
 (** Generic stack *)
 
@@ -750,14 +749,14 @@ let generic_stackv4
     ?group
     ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
     ?(net_key = Key.value @@ Key.net ?group ())
-    console tap =
+    (tap : network impl) : stackv4 impl=
   if_impl
     Key.(pure ((=) `Socket) $ net_key)
-    (socket_stackv4 console ?group [Ipaddr.V4.any])
+    (socket_stackv4 ?group [Ipaddr.V4.any])
     (if_impl
        dhcp_key
-       (direct_stackv4_with_dhcp ?group console tap)
-       (direct_stackv4_with_default_ipv4 ?group console tap)
+       (direct_stackv4_with_dhcp ?group tap)
+       (direct_stackv4_with_default_ipv4 ?group tap)
     )
 
 (* This is to check that entropy is a dependency if "tls" is in

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -340,7 +340,7 @@ val direct_stackv4_with_default_ipv4:
   ?random:random impl ->
   ?time:time impl ->
   ?group:string ->
-  console impl -> network impl -> stackv4 impl
+  network impl -> stackv4 impl
 
 (** Direct network stack with ip.
     Exposes the keys {!Key.V4.ip}, {!Key.V4.netmask} and {!Key.V4.gateways}. *)
@@ -349,7 +349,7 @@ val direct_stackv4_with_static_ipv4:
   ?random:random impl ->
   ?time:time impl ->
   ?group:string ->
-  console impl -> network impl -> ipv4_config -> stackv4 impl
+  network impl -> ipv4_config -> stackv4 impl
 
 (** Direct network stack using dhcp. *)
 val direct_stackv4_with_dhcp:
@@ -357,11 +357,11 @@ val direct_stackv4_with_dhcp:
   ?random:random impl ->
   ?time:time impl ->
   ?group:string ->
-  console impl -> network impl -> stackv4 impl
+  network impl -> stackv4 impl
 
 (** Network stack with sockets. Exposes the key {Key.interfaces}. *)
 val socket_stackv4:
-  ?group:string -> console impl -> Ipaddr.V4.t list -> stackv4 impl
+  ?group:string -> Ipaddr.V4.t list -> stackv4 impl
 
 (** Generic stack using a [dhcp] and a [net] keys: {!Key.net} and {!Key.dhcp}.
     - If [net] = [socket] then {!socket_stackv4} is used.
@@ -375,7 +375,7 @@ val generic_stackv4 :
   ?group:string ->
   ?dhcp_key:bool value ->
   ?net_key:[ `Direct | `Socket ] value ->
-  console impl -> network impl -> stackv4 impl
+  network impl -> stackv4 impl
 
 (** {2 Resolver configuration} *)
 

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -707,9 +707,6 @@ end
     receive and transmit network traffic. *)
 module type STACKV4 = sig
 
-  type console
-  (** The type for console logger. *)
-
   type netif
   (** The type for network interface that is used to transmit and
       receive traffic associated with this stack. *)
@@ -719,7 +716,7 @@ module type STACKV4 = sig
       These can consist of the IPv4 address binding, or a DHCP
       interface. *)
 
-  type ('console, 'netif, 'mode) config
+  type ('netif, 'mode) config
   (** The type for the collection of user configuration specified to
       construct a stack. *)
 
@@ -745,7 +742,7 @@ module type STACKV4 = sig
 
   include DEVICE with
     type error := error
-    and type id = (console, netif, mode) config
+    and type id = (netif, mode) config
 
   module UDPV4: UDP
     with type +'a io = 'a io

--- a/types/V1_LWT.mli
+++ b/types/V1_LWT.mli
@@ -138,9 +138,8 @@ type direct_stack_config = [
   | `IPv4 of Ipaddr.V4.t * Ipaddr.V4.t * Ipaddr.V4.t list
 ]
 
-type ('console, 'netif, 'mode) stackv4_config = {
+type ('netif, 'mode) stackv4_config = {
   name: string;
-  console: 'console;
   interface: 'netif;
   mode: 'mode;
 }
@@ -148,6 +147,6 @@ type ('console, 'netif, 'mode) stackv4_config = {
 (** Single network stack *)
 module type STACKV4 = STACKV4
   with type 'a io = 'a Lwt.t
-   and type ('a,'b,'c) config = ('a,'b,'c) stackv4_config
+   and type ('a,'b) config = ('a,'b) stackv4_config
    and type ipv4addr = Ipaddr.V4.t
    and type buffer = Cstruct.t


### PR DESCRIPTION
Attendant changes in mirage-tcpip are required (see https://github.com/mirage/mirage-tcpip/pull/200 and the forthcoming PR building on it) along with changes in any `config.ml` which invoked an affected configuring function:

* `direct_stackv4_with_default_ipv4`
* `direct_stackv4_with_static_ipv4`
* `direct_stackv4_with_dhcp`
* `socket_stackv4`
* `generic_stackv4`

PRs for `mirage-skeleton` and `dns`, two prolific packages affected by these changes, will be submitted shortly.