### PR TITLE
[Tracking] Better errors

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -217,8 +217,11 @@ class block_conf file =
          else (1 lsl 28)  lor (b.number lsl 8)) |> string_of_int
 
     method connect i s _ =
-      Printf.sprintf "%s.connect %S" s
-        (self#connect_name (get_target i) @@ Info.root i)
+      Format.sprintf "@[<v 2>%s.connect %S >|= function@ \
+                      | `Error e -> die \"@@[<v 2>Error connecting block device %%S:@@ %%a@@]\" %S Block.pp_error e@ \
+                      | `Ok _ as ok -> ok@]" s
+      (self#connect_name (get_target i) @@ Info.root i)
+      file
 
   end
 
@@ -1525,6 +1528,9 @@ module Project = struct
   let version = Mirage_version.current
   let prelude =
     "open Lwt\n\
+     let die fmt =\n\
+       Format.kfprintf (fun _ -> exit 1) Format.err_formatter\n\
+         (\"*** Setup failure ***@\\n@\\n\" ^^ fmt ^^ \"@.\")\n\
      let run = OS.Main.run"
   let driver_error = driver_error
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -102,6 +102,14 @@ let or_fail_str label connect =
     | `Error msg -> die \"%%s: %%s\" %S msg"
   connect label
 
+(** Handle errors from devices that provide a [pp_error] formatter. *)
+let or_fail_pp label modname connect =
+  Printf.sprintf
+    "%s >|= function\n\
+    | `Ok x -> x\n\
+    | `Error err -> die \"%%s: %%a\" %S %s.pp_error err"
+  connect label modname
+
 let default_random = impl random_conf
 
 type console = CONSOLE
@@ -411,8 +419,8 @@ let ethernet_conf = object
   method packages = Key.pure ["tcpip"]
   method libraries = Key.pure ["tcpip.ethif"]
   method connect _ modname = function
-    | [ eth ] -> Printf.sprintf "%s.connect %s" modname eth
-                 |> or_fail_opaque "ethernet"
+    | [ eth ] ->
+        Printf.sprintf "%s.connect %s" modname eth
     | _ -> failwith "The ethernet connect should receive exactly one argument."
 end
 
@@ -433,7 +441,6 @@ let arpv4_conf = object
   method connect _ modname = function
     | [ eth ; _clock ; _time ] ->
         Printf.sprintf "%s.connect %s" modname eth
-        |> or_fail_opaque "arpv4"
     | _ -> failwith "The arpv4 connect should receive exactly three arguments."
 
 end
@@ -492,7 +499,6 @@ let ipv4_conf ?address ?netmask ?gateways () = impl @@ object
           (opt_key "netmask") netmask
           (opt_key "gateways") gateways
           etif arp
-        |> or_fail_opaque "ipv4"
       | _ -> failwith "The ipv4 connect should receive exactly two arguments."
   end
 
@@ -535,7 +541,6 @@ let ipv6_conf ?address ?netmask ?gateways () = impl @@ object
           (opt_key "netmask") netmask
           (opt_key "gateways") gateways
           etif
-        |> or_fail_opaque "ipv6"
       | _ -> failwith "The ipv6 connect should receive exactly three arguments."
   end
 
@@ -589,7 +594,6 @@ let udp_direct_conf () = object
   method connect _ modname = function
     | [ ip ] ->
         Printf.sprintf "%s.connect %s" modname ip
-        |> or_fail_opaque "udp_direct"
     | _  -> failwith "The udpv6 connect should receive exactly one argument."
 end
 
@@ -611,7 +615,6 @@ let udpv4_socket_conf ipv4_key = object
     | `Xen -> failwith "No socket implementation available for Xen"
   method connect _ modname _ =
     Format.asprintf "%s.connect %a" modname pp_key ipv4_key
-    |> or_fail_opaque "udpv4_socket"
 end
 
 let socket_udpv4 ?group ip = impl (udpv4_socket_conf @@ Key.V4.socket ?group ip)
@@ -636,7 +639,6 @@ let tcp_direct_conf () = object
   method connect _ modname = function
     | [ip; _time; _clock; _random] ->
         Printf.sprintf "%s.connect %s" modname ip
-        |> or_fail_opaque "tcp_direct"
     | _ -> failwith "The tcp connect should receive exactly four arguments."
 end
 
@@ -661,7 +663,6 @@ let tcpv4_socket_conf ipv4_key = object
     | `Xen  -> failwith "No socket implementation available for Xen"
   method connect _ modname _ =
     Format.asprintf "%s.connect %a" modname  pp_key ipv4_key
-    |> or_fail_opaque "tcpv4_socket"
 end
 
 let socket_tcpv4 ?group ip = impl (tcpv4_socket_conf @@ Key.V4.socket ?group ip)
@@ -709,11 +710,10 @@ let stackv4_direct_conf ?(group="") config = impl @@ object
           "@[<2>let config = {V1_LWT.@ \
            name = %S;@ \
            interface = %s;@ mode = %a }@]@ in@ \
-           %s.connect config@ %s %s %s %s %s"
+           %s.connect config@ %s %s %s %s %s %s"
           name
           interface pp_stackv4_config config
-          modname ethif arp ip udp tcp
-        |> or_fail_opaque "stackv4"
+          modname ethif arp ip icmp udp tcp
       | _ -> failwith "Wrong arguments to connect to tcpip direct stack."
 
   end
@@ -780,7 +780,6 @@ let stackv4_socket_conf ?(group="") interfaces = impl @@ object
           name
           pp_key interfaces
           modname udpv4 tcpv4
-        |> or_fail_opaque "stackv4_socket"
       | _ -> failwith "Wrong arguments to connect to tcpip socket stack."
 
   end

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -84,6 +84,24 @@ let random_conf = object
   method module_name = "Random"
 end
 
+(* Handle the case of a connect function that returns an error that cannot
+   be displayed. Do not use this in new code. Use something that prints a
+   useful error message instead. *)
+let or_fail_opaque label connect =
+  Printf.sprintf
+    "%s >|= function\n\
+    | `Ok x -> x\n\
+    | `Error _ -> die \"%%s: failed (can't show error message)\" %S"
+  connect label
+
+(** Handle errors from devices that return [`Error of string] *)
+let or_fail_str label connect =
+  Printf.sprintf
+    "%s >|= function\n\
+    | `Ok x -> x\n\
+    | `Error msg -> die \"%%s: %%s\" %S msg"
+  connect label
+
 let default_random = impl random_conf
 
 type console = CONSOLE
@@ -99,6 +117,7 @@ let console_unix str = impl @@ object
     method libraries = Key.pure ["mirage-console.unix"]
     method connect _ modname _args =
       Printf.sprintf "%s.connect %S" modname str
+      |> or_fail_opaque "console_unix"
   end
 
 let console_xen str = impl @@ object
@@ -112,6 +131,7 @@ let console_xen str = impl @@ object
     method libraries = Key.pure ["mirage-console.xen"]
     method connect _ modname _args =
       Printf.sprintf "%s.connect %S" modname str
+      |> or_fail_opaque "console_xen"
   end
 
 let custom_console str =
@@ -133,7 +153,9 @@ let crunch dirname = impl @@ object
     method packages = Key.pure [ "mirage-types"; "lwt"; "cstruct"; "crunch" ]
     method libraries = Key.pure [ "mirage-types"; "lwt"; "cstruct" ]
     method deps = [ abstract default_io_page ]
-    method connect _ modname _ = Fmt.strf "%s.connect ()" modname
+    method connect _ modname _ =
+      Fmt.strf "%s.connect ()" modname
+      |> or_fail_opaque "crunch"
 
     method configure i =
       if not (Cmd.exists "ocaml-crunch") then
@@ -165,6 +187,7 @@ let direct_kv_ro_conf dirname = impl @@ object
     method libraries = Key.pure ["mirage-fs-unix"]
     method connect i _modname _names =
       Fmt.strf "Kvro_fs_unix.connect %S" (Info.root i / dirname)
+      |> or_fail_opaque "direct_kv_ro"
   end
 
 let direct_kv_ro dirname =
@@ -219,7 +242,7 @@ class block_conf file =
     method connect i s _ =
       Format.sprintf "@[<v 2>%s.connect %S >|= function@ \
                       | `Error e -> die \"@@[<v 2>Error connecting block device %%S:@@ %%a@@]\" %S Block.pp_error e@ \
-                      | `Ok _ as ok -> ok@]" s
+                      | `Ok x -> x@]" s
       (self#connect_name (get_target i) @@ Info.root i)
       file
 
@@ -247,6 +270,7 @@ let archive_conf = impl @@ object
     method connect _ modname = function
       | [ block ] ->
         Fmt.strf "%s.connect %s" modname block
+        |> or_fail_opaque "archive"
       | _ -> failwith "The archive connect should receive exactly one argument."
 
   end
@@ -267,6 +291,7 @@ let fat_conf = impl @@ object
     method connect _ modname l = match l with
       | [ block_name ; _io_page_name ] ->
         Printf.sprintf "%s.connect %s" modname block_name
+        |> or_fail_opaque "fat"
       | _ -> assert false
   end
 
@@ -363,7 +388,7 @@ let network_conf (intf : string Key.key) =
     method connect _ modname _ =
       Fmt.strf "@[<v 2>%s.connect %a >|= function@ \
                 | `Error e -> die \"@@[<v 2>Error connecting network device %%S:@@ %%a@@]\" %a Netif.pp_error e@ \
-                | `Ok _ as ok -> ok@]"
+                | `Ok x -> x@]"
       modname Key.serialize_call key Key.serialize_call key
 
     method configure i =
@@ -387,6 +412,7 @@ let ethernet_conf = object
   method libraries = Key.pure ["tcpip.ethif"]
   method connect _ modname = function
     | [ eth ] -> Printf.sprintf "%s.connect %s" modname eth
+                 |> or_fail_opaque "ethernet"
     | _ -> failwith "The ethernet connect should receive exactly one argument."
 end
 
@@ -405,7 +431,9 @@ let arpv4_conf = object
   method libraries = Key.pure ["tcpip.arpv4"]
 
   method connect _ modname = function
-    | [ eth ; _clock ; _time ] -> Printf.sprintf "%s.connect %s" modname eth
+    | [ eth ; _clock ; _time ] ->
+        Printf.sprintf "%s.connect %s" modname eth
+        |> or_fail_opaque "arpv4"
     | _ -> failwith "The arpv4 connect should receive exactly three arguments."
 
 end
@@ -464,6 +492,7 @@ let ipv4_conf ?address ?netmask ?gateways () = impl @@ object
           (opt_key "netmask") netmask
           (opt_key "gateways") gateways
           etif arp
+        |> or_fail_opaque "ipv4"
       | _ -> failwith "The ipv4 connect should receive exactly two arguments."
   end
 
@@ -506,6 +535,7 @@ let ipv6_conf ?address ?netmask ?gateways () = impl @@ object
           (opt_key "netmask") netmask
           (opt_key "gateways") gateways
           etif
+        |> or_fail_opaque "ipv6"
       | _ -> failwith "The ipv6 connect should receive exactly three arguments."
   end
 
@@ -557,7 +587,9 @@ let udp_direct_conf () = object
   method packages = Key.pure [ "tcpip" ]
   method libraries = Key.pure [ "tcpip.udp" ]
   method connect _ modname = function
-    | [ ip ] -> Printf.sprintf "%s.connect %s" modname ip
+    | [ ip ] ->
+        Printf.sprintf "%s.connect %s" modname ip
+        |> or_fail_opaque "udp_direct"
     | _  -> failwith "The udpv6 connect should receive exactly one argument."
 end
 
@@ -578,7 +610,8 @@ let udpv4_socket_conf ipv4_key = object
     | `Unix | `MacOSX -> [ "tcpip.udpv4-socket" ]
     | `Xen -> failwith "No socket implementation available for Xen"
   method connect _ modname _ =
-    Format.asprintf "%s.connect %a" modname  pp_key ipv4_key
+    Format.asprintf "%s.connect %a" modname pp_key ipv4_key
+    |> or_fail_opaque "udpv4_socket"
 end
 
 let socket_udpv4 ?group ip = impl (udpv4_socket_conf @@ Key.V4.socket ?group ip)
@@ -601,7 +634,9 @@ let tcp_direct_conf () = object
   method packages = Key.pure [ "tcpip" ]
   method libraries = Key.pure [ "tcpip.tcp" ]
   method connect _ modname = function
-    | [ip; _time; _clock; _random] -> Printf.sprintf "%s.connect %s" modname ip
+    | [ip; _time; _clock; _random] ->
+        Printf.sprintf "%s.connect %s" modname ip
+        |> or_fail_opaque "tcp_direct"
     | _ -> failwith "The tcp connect should receive exactly four arguments."
 end
 
@@ -626,6 +661,7 @@ let tcpv4_socket_conf ipv4_key = object
     | `Xen  -> failwith "No socket implementation available for Xen"
   method connect _ modname _ =
     Format.asprintf "%s.connect %a" modname  pp_key ipv4_key
+    |> or_fail_opaque "tcpv4_socket"
 end
 
 let socket_tcpv4 ?group ip = impl (tcpv4_socket_conf @@ Key.V4.socket ?group ip)
@@ -673,9 +709,11 @@ let stackv4_direct_conf ?(group="") config = impl @@ object
           "@[<2>let config = {V1_LWT.@ \
            name = %S;@ \
            interface = %s;@ mode = %a }@]@ in@ \
-           %s.connect config@ %s %s %s %s %s %s"
-          name interface pp_stackv4_config config
-          modname ethif arp ip icmp udp tcp
+           %s.connect config@ %s %s %s %s %s"
+          name
+          interface pp_stackv4_config config
+          modname ethif arp ip udp tcp
+        |> or_fail_opaque "stackv4"
       | _ -> failwith "Wrong arguments to connect to tcpip direct stack."
 
   end
@@ -742,6 +780,7 @@ let stackv4_socket_conf ?(group="") interfaces = impl @@ object
           name
           pp_key interfaces
           modname udpv4 tcpv4
+        |> or_fail_opaque "stackv4_socket"
       | _ -> failwith "Wrong arguments to connect to tcpip socket stack."
 
   end
@@ -807,7 +846,7 @@ let nocrypto = impl @@ object
         then "Nocrypto_entropy_xen.initialize ()"
         else "Nocrypto_entropy_lwt.initialize ()"
       in
-      Fmt.strf "%s >|= fun x -> `Ok x" s
+      Fmt.strf "%s" s
 
   end
 
@@ -823,7 +862,7 @@ let tcp_conduit_connector = impl @@ object
     method libraries = Key.pure [ "conduit.mirage" ]
     method connect _ modname = function
       | [ stack ] ->
-        Fmt.strf "let f = %s.connect %s in@ return (`Ok f)@;" modname stack
+        Fmt.strf "return (%s.connect %s)@;" modname stack
       | _ -> failwith "Wrong arguments to connect to tcp conduit connector."
   end
 
@@ -835,7 +874,7 @@ let tls_conduit_connector = impl @@ object
     method packages = Key.pure [ "mirage-conduit" ; "tls" ]
     method libraries = Key.pure [ "conduit.mirage" ; "tls.mirage" ]
     method deps = [ abstract nocrypto ]
-    method connect _ _ _ = "return (`Ok Conduit_mirage.with_tls)"
+    method connect _ _ _ = "return Conduit_mirage.with_tls"
   end
 
 type conduit = Conduit
@@ -859,7 +898,7 @@ let conduit_with_connectors connectors = impl @@ object
         Fmt.strf
           "Lwt.return Conduit_mirage.empty >>=@ \
            %a\
-           fun t -> Lwt.return (`Ok t)"
+           Lwt.return"
           pp_connectors connectors
   end
 
@@ -886,7 +925,7 @@ let resolver_unix_system = impl @@ object
       | `Unix | `MacOSX -> [ "mirage-conduit" ]
       | `Xen -> failwith "Resolver_unix not supported on Xen"
     method libraries = Key.pure [ "conduit.mirage"; "conduit.lwt-unix" ]
-    method connect _ _modname _ = "return (`Ok Resolver_lwt_unix.system)"
+    method connect _ _modname _ = "return Resolver_lwt_unix.system"
   end
 
 let resolver_dns_conf ~ns ~ns_port = impl @@ object
@@ -904,8 +943,7 @@ let resolver_dns_conf ~ns ~ns_port = impl @@ object
         Fmt.strf
           "let ns = %a in@;\
            let ns_port = %a in@;\
-           let res = %s.R.init ?ns ?ns_port ~stack:%s () in@;\
-           return (`Ok res)@;"
+           return (%s.R.init ?ns ?ns_port ~stack:%s ())@;"
           meta_ns ns
           meta_port ns_port
           modname stack
@@ -928,7 +966,7 @@ let http_server conduit = impl @@ object
     method libraries = Key.pure [ "mirage-http" ]
     method deps = [ abstract conduit ]
     method connect _i modname = function
-      | [ conduit ] -> Fmt.strf "%s.connect %s" modname conduit
+      | [ conduit ] -> Fmt.strf "%s.connect %s >|= fun (`Ok x) -> x" modname conduit
       | _ -> failwith "The http connect should receive exactly one argument."
   end
 
@@ -939,7 +977,7 @@ let argv_unix = impl @@ object
     method ty = Functoria_app.argv
     method name = "argv_unix"
     method module_name = "OS.Env"
-    method connect _ _ _ = "OS.Env.argv () >>= (fun x -> Lwt.return (`Ok x))"
+    method connect _ _ _ = "OS.Env.argv ()"
   end
 
 let argv_xen = impl @@ object
@@ -949,7 +987,9 @@ let argv_xen = impl @@ object
     method module_name = "Bootvar"
     method packages = Key.pure [ "mirage-bootvar-xen" ]
     method libraries = Key.pure [ "mirage-bootvar" ]
-    method connect _ _ _ = "Bootvar.argv ()"
+    method connect _ _ _ =
+      "Bootvar.argv ()"
+      |> or_fail_str "argv_xen"
   end
 
 let no_argv = impl @@ object
@@ -1042,7 +1082,7 @@ let mprof_trace ~size () =
     method connect i _ _ = match Key.(get (Info.context i) target) with
       | `Unix | `MacOSX ->
         Fmt.strf
-          "return (`Ok ()))@.\
+          "return ())@.\
            let () = (@ \
              @[<v 2>  let buffer = MProf_unix.mmap_buffer ~size:%a %S in@ \
              let trace_config = MProf.Trace.Control.make buffer MProf_unix.timestamper in@ \
@@ -1051,7 +1091,7 @@ let mprof_trace ~size () =
           unix_trace_file;
       | `Xen  ->
         Fmt.strf
-          "return (`Ok ()))@.\
+          "return ())@.\
            let () = (@ \
              @[<v 2>  let trace_pages = MProf_xen.make_shared_buffer ~size:%a in@ \
              let buffer = trace_pages |> Io_page.to_cstruct |> Cstruct.to_bigarray in@ \

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -361,7 +361,10 @@ let network_conf (intf : string Key.key) =
     method libraries = self#packages
 
     method connect _ modname _ =
-      Fmt.strf "%s.connect %a" modname Key.serialize_call key
+      Fmt.strf "@[<v 2>%s.connect %a >|= function@ \
+                | `Error e -> die \"@@[<v 2>Error connecting network device %%S:@@ %%a@@]\" %a Netif.pp_error e@ \
+                | `Ok _ as ok -> ok@]"
+      modname Key.serialize_call key Key.serialize_call key
 
     method configure i =
       all_networks := Key.get (Info.context i) intf :: !all_networks;

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -303,12 +303,13 @@ module type NETWORK = sig
   type buffer
   (** The type for memory buffers. *)
 
-  type error = [
-    | `Unknown of string (** an undiagnosed error *)
+  type error = private [>
     | `Unimplemented     (** operation not yet implemented in the code *)
     | `Disconnected      (** the device has been previously disconnected *)
   ]
   (** The type for IO operation errors *)
+
+  val pp_error : Format.formatter -> error -> unit
 
   type macaddr
   (** The type for unique MAC identifiers for the device. *)

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -229,17 +229,17 @@ module type BLOCK = sig
   type page_aligned_buffer
   (** The type for page-aligned memory buffers. *)
 
-  type error = [
-    | `Unknown of string (** an undiagnosed error *)
+  type error = private [>
     | `Unimplemented     (** operation not yet implemented in the code *)
     | `Is_read_only      (** you cannot write to a read/only instance *)
     | `Disconnected      (** the device has been previously disconnected *)
   ]
   (** The type for IO operation errors. *)
 
-
   include DEVICE with
     type error := error
+
+  val pp_error : Format.formatter -> error -> unit
 
   type info = {
     read_write: bool;    (** True if we can write, false if read/only *)

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -362,12 +362,13 @@ module type ETHIF = sig
   type netif
   (** The type for ethernet network interfaces. *)
 
-  type error = [
-    | `Unknown of string (** an undiagnosed error *)
+  type error = private [>
     | `Unimplemented     (** operation not yet implemented in the code *)
     | `Disconnected      (** the device has been previously disconnected *)
   ]
   (** The type for IO operation errors. *)
+
+  val pp_error : Format.formatter -> error -> unit
 
   type macaddr
   (** The type for unique MAC identifiers. *)
@@ -410,15 +411,8 @@ module type IP = sig
   type prefix
   (** The type for IP prefixes. *)
 
-  type error = [
-    | `Unknown of string (** an undiagnosed error *)
-    | `Unimplemented     (** operation not yet implemented in the code *)
-  ]
-  (** The type for IO operation errors. *)
-
   include DEVICE with
-        type error := error
-    and type id    := ethif
+    type id := ethif
 
   type callback = src:ipaddr -> dst:ipaddr -> buffer -> unit io
   (** An input continuation used by the parsing functions to pass on
@@ -597,14 +591,8 @@ module type UDP = sig
       conventional kernel, but a direct implementation will parse the
       buffer. *)
 
-  type error = [
-    | `Unknown of string (** an undiagnosed error *)
-  ]
-  (** The type for IO operation errors. *)
-
   include DEVICE with
-      type error := error
-  and type id := ip
+    type id := ip
 
   type callback = src:ipaddr -> dst:ipaddr -> src_port:int -> buffer -> unit io
   (** The type for callback functions that adds the UDP metadata for
@@ -649,12 +637,13 @@ module type TCP = sig
   (** A flow represents the state of a single TCPv4 stream that is connected
       to an endpoint. *)
 
-  type error = [
-    | `Unknown of string (** an undiagnosed error. *)
+  type error = private [>
     | `Timeout  (** connection attempt did not get a valid response. *)
     | `Refused  (** connection attempt was actively refused via an RST. *)
   ]
   (** The type for IO operation errors. *)
+
+  val pp_error : Format.formatter -> error -> unit
 
   include DEVICE with
       type error := error
@@ -736,14 +725,7 @@ module type STACKV4 = sig
   type ipv4
   (** The type for IPv4 stacks. *)
 
-  type error = [
-    | `Unknown of string
-  ]
-  (** The type for I/O operation errors. *)
-
-  include DEVICE with
-    type error := error
-    and type id = (netif, mode) config
+  include DEVICE
 
   module UDPV4: UDP
     with type +'a io = 'a io


### PR DESCRIPTION
This is the improved error handling described in http://canopy.mirage.io/Posts/Errors

It allows each device to handle errors in a way suited to that device (which could be using a `pp_error` function, but other options are available too - in particular, some devices never fail and so no error handling is needed).

I've updated it to remove the old logging support (since a different system got merged in the end). Haven't tested the update much. Might need a few tweaks to get https://github.com/mirage/mirage-dev/pull/107 passing again.

Depends on https://github.com/mirage/functoria/pull/55, which I've also updated.

(not very happy with the `die` function - should probably fail, and catch in the main project instead)