### PR TITLE
Deprecate functions which require functoria base_context

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -2,7 +2,7 @@ bash -ex .travis-opam.sh
 
 eval `opam config env`
 opam install mirage -y
-git clone -b remove-console https://github.com/yomimono/mirage-skeleton.git
+git clone -b mirage-dev https://github.com/mirage/mirage-skeleton.git
 cd mirage-skeleton
 MODE=unix make
 MODE=xen  make

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - UPDATE_GCC_BINUTILS=1
   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
   matrix:
-  - PACKAGE=mirage OCAML_VERSION=4.03 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"
-  - PACKAGE=mirage-types OCAML_VERSION=4.03 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"
-  - PACKAGE=mirage OCAML_VERSION=4.02 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"
-  - PACKAGE=mirage-types OCAML_VERSION=4.02 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"
+  - PACKAGE=mirage OCAML_VERSION=4.03 PINS="dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"
+  - PACKAGE=mirage-types OCAML_VERSION=4.03 PINS="dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"
+  - PACKAGE=mirage OCAML_VERSION=4.02 PINS="dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"
+  - PACKAGE=mirage-types OCAML_VERSION=4.02 PINS="dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - UPDATE_GCC_BINUTILS=1
   - EXTRA_REMOTES="https://github.com/yomimono/mirage-dev.git#remove-console"
   matrix:
-  - PACKAGE=mirage OCAML_VERSION=4.03 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"
-  - PACKAGE=mirage-types OCAML_VERSION=4.03 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"
-  - PACKAGE=mirage OCAML_VERSION=4.02 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"
-  - PACKAGE=mirage-types OCAML_VERSION=4.02 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields"
+  - PACKAGE=mirage OCAML_VERSION=4.03 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"
+  - PACKAGE=mirage-types OCAML_VERSION=4.03 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"
+  - PACKAGE=mirage OCAML_VERSION=4.02 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"
+  - PACKAGE=mirage-types OCAML_VERSION=4.02 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: bash -ex .travis-ci.sh
 env:
   global:
   - UPDATE_GCC_BINUTILS=1
-  - EXTRA_REMOTES="https://github.com/yomimono/mirage-dev.git#remove-console"
+  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
   matrix:
   - PACKAGE=mirage OCAML_VERSION=4.03 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"
   - PACKAGE=mirage-types OCAML_VERSION=4.03 PINS="charrua-core:git://github.com/yomimono/charrua-core.git#use_new_marshallers dns:git://github.com/yomimono/ocaml-dns.git#standardize_record_fields functoria:git://github.com/yomimono/functoria.git#no-base-context mirage:git://github.com/yomimono/mirage.git#no-base-context"

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ the appropriate boilerplate for your chosen platform.
 To configure for the Unix-direct target (using tap interfaces), do:
 
 ```
-mirage configure --unix
+mirage configure -t unix
 ```
 
 To build for the Xen target, do:
 
 ```
-mirage configure --xen
+mirage configure -t xen
 ```
 
 ### Building Mirage Applications
@@ -121,7 +121,7 @@ directory).
 ### Compiling to Xen and deploying to the cloud
 
 In order to deploy a Mirage unikernel to Amazon EC2, you need to install the AWS
-tools on your machine, build a unikernel with the `--xen` option and then use
+tools on your machine, build a unikernel with the `-t xen` option and then use
 the `ec2.sh` script (in directory `script`) in order to register your kernel
 with AWS. Then you can start your kernel with the web interface to AWS or any
 other means AWS provides to start EC2 instances.

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1561,18 +1561,6 @@ end
 
 include Functoria_app.Make (Project)
 
-(** {Deprecated functions} *)
-
-let get_mode () = Key.(get (get_base_context ()) target)
-
-let libraries_ref = ref []
-let add_to_ocamlfind_libraries l =
-  libraries_ref := !libraries_ref @ l
-
-let packages_ref = ref []
-let add_to_opam_packages l =
-  packages_ref := !packages_ref @ l
-
 (** {Custom registration} *)
 
 let (++) acc x = match acc, x with
@@ -1584,8 +1572,6 @@ let register
     ?(argv=default_argv) ?tracing ?(reporter=default_reporter ())
     ?keys ?(libraries=[]) ?(packages=[])
     name jobs =
-  let libraries = !libraries_ref @ libraries in
-  let packages = !packages_ref @ packages in
   let argv = Some (Functoria_app.keys argv) in
   let reporter = if reporter == no_reporter then None else Some reporter in
   let init = None ++ argv ++ reporter ++ tracing in

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1537,8 +1537,6 @@ module Project = struct
       method module_name = "Mirage_runtime"
       method keys = [
         Key.(abstract target);
-        Key.(abstract unix);
-        Key.(abstract xen);
         Key.(abstract no_ocaml_check);
         Key.(abstract warn_error);
       ]

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -428,24 +428,6 @@ val app_info: info impl
 (** [app_info] exports all the information available at configure time
     into a runtime {!Mirage.Info.t} value. *)
 
-(** {2 Deprecated functions} *)
-
-val get_mode: unit -> [ `Unix | `Xen | `MacOSX ]
-(** Current configuration mode.
-    @deprecated Use {!Key.target} and {!Key.is_xen}.
-*)
-
-val add_to_opam_packages : string list -> unit
-(** Register opam packages.
-    @deprecated Use the [~package] argument from {!register}.
-*)
-
-val add_to_ocamlfind_libraries : string list -> unit
-(** Register ocamlfind libraries.
-    @deprecated Use the [~libraries] argument from {!register}.
-*)
-
-
 (** {2 Application registering} *)
 
 val register :

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -120,26 +120,6 @@ let is_xen =
   | `Xen -> true
   | `Unix | `MacOSX -> false
 
-let unix =
-  let doc =
-    "Set $(b,target) to $(i,unix). For OSX (Yosemite or higher) \
-     $(i,unix) is equivalent to `--target=macosx`. Otherwise it is \
-     `--target=unix`."
-  in
-  let doc = Arg.info ~docs:mirage_section ~docv:"BOOL" ~doc ["unix"] in
-  let setter b = if b then Some (Lazy.force default_unix) else None in
-  let alias = Alias.flag doc in
-  let alias = Alias.add target setter alias in
-  Key.alias "unix" alias
-
-let xen =
-  let doc = "Set $(b,target) to $(i,xen)." in
-  let doc = Arg.info ~docs:mirage_section ~docv:"BOOL" ~doc ["xen"] in
-  let setter b = if b then Some `Xen else None in
-  let alias = Alias.flag doc in
-  let alias = Alias.add target setter alias in
-  Key.alias "xen" alias
-
 let no_ocaml_check =
   let doc = "Bypass the OCaml compiler version checks." in
   let doc =

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -38,12 +38,6 @@ val pp_target: [ `Unix | `Xen | `MacOSX ] Fmt.t
 val is_xen: bool value
 (** Is true iff the {!target} keys takes the value [`Xen]. *)
 
-val unix: bool key
-(** [--unix]. Set {!target} to [`Unix]. *)
-
-val xen: bool key
-(** [--xen]. Set {!target} to [`Xen]. *)
-
 val no_ocaml_check: bool key
 (** [--no-ocaml-check]. Do not check the version of the compiler. *)
 


### PR DESCRIPTION
See #461 for motivation, and https://github.com/mirage/functoria/pull/65 for the related upstream change.

This patch removes the following deprecated functions:

* invoking mirage configure --unix and mirage configure --xen to build for UNIX/Xen targets.  Instead, use mirage configure -t unix or -t xen.

* using add_to_opam_packages to install extra required packages not detected by the mirage front-end tool.  Instead, pass the same list to `register` in the ~packages named argument.

* similarly, using add_to_ocamlfind_libraries to link against extra libraries.  Instead, pass the same list to `register` in the ~libraries named argument.