### PR TITLE
Emit an ocamlfind predicate that matches the target

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1454,9 +1454,12 @@ let configure_makefile ~target ~root ~name ~warn_error info =
       append fmt "SYNTAX = -tags \"thread,%s\"\n" default_tags;
       append fmt "FLAGS  = -r -cflag -g -lflags -g,-linkpkg\n"
   end;
+  append fmt "TAGS = \"predicate(%s)\""
+    (match target with
+      `Unix | `MacOSX -> "unix" | `Xen -> "xen" | `Virtio | `Ukvm -> "solo5" );
   append fmt "SYNTAX += -tag-line \"<static*.*>: warn(-32-34)\"\n";
   append fmt "LD?=ld";
-  append fmt "BUILD  = ocamlbuild -use-ocamlfind $(LIBS) $(SYNTAX) $(FLAGS)\n\
+  append fmt "BUILD  = ocamlbuild -use-ocamlfind -tags $(TAGS) $(LIBS) $(SYNTAX) $(FLAGS)\n\
               OPAM   = opam\n\n\
               export PKG_CONFIG_PATH=$(shell opam config var prefix)\
               /lib/pkgconfig\n\n\


### PR DESCRIPTION
This relatively innocuous change adds arguments like `-tags 'predicate(xen)'` to the `ocamlbuild` invocation in the `Makefile`. The set of tags is currently `[unix, xen, solo5]`, but this is open for discussion.

The motivation is my long standing frustration: one can do a variety of simple interactions with the system from the code written directly in a unikernel, but it's almost impossible to extract that code to a library.

One example is in the [simplest Mirage demo](https://github.com/mirage/mirage-skeleton/blob/079e37e1b46831e9816c84f19a491356856994e9/console/unikernel.ml#L10). This call is not available from code compiled separately. Of course, I can use a [different one](https://github.com/mirage/mirage/blob/9a52cca64e25feef35099ca2bfd8e4ad52b881ed/types/V1.mli#L76) for that particular purpose, at the cost of functorizing my library, and any bit of code that ever wants to interact with it. But I cannot [peek into the args](https://github.com/mirage/mirage-platform/blob/master/unix/lib/env.mli#L19), [hook into the life-cycle](https://github.com/mirage/mirage-platform/blob/master/unix/lib/lifecycle.mli#L15), or [interact with the event loop](https://github.com/mirage/mirage-platform/blob/master/unix/lib/main.mli).

Actually I _can_ write a bit of OCaml code that does exactly that; the problem is that I need to compile it against at least three implementations of the same interface, and package the three resulting libraries. This is not where the pain stops, it's where it begins: since I now have three separate libraries, either in opam or just in ocamlfind sense, in order to make it seamless for others to use my code, I need to create a pull request to this very repo. In this PR I bake the knowledge of my new libraries into `mirage`, and have it decide which one to use depending on the backend. To add to the fun, I also need to invent semantics of triggering this backend-directed resolution of dependencies. Do I expect the user to depend on the canonical version, intercept it, and inject the specialized version instead? Or maybe just parse the unikernel source, try to detect references to `Twigglet`, and make that trigger my logic.

By exposing the mirage target to ocamlfind, library authors can do surprisingly flexible things just from the `META` files, without touching the `mirage` tool itself. They can also hide this parametricity of their libraries from the users. My motivating example is a completely  trivial [shim](https://github.com/pqwy/mirage-os-shim/blob/master/unix/mirage_OS.ml) over the common intersection of the `OS` API. It needs a bit of work, and having the actual API signature it presents blessed in the official code would help. But it's already solving headaches over library duplication I have elsewhere.

This should of course in no sense be considered a critique of the main design tenet behind Mirage, that interfaces should be functorized over. That technique seems to work very well in most places. It's just that functorizing a library and its six dependants to invoke `sleep` doesn't seem to be one of them.