### PR TITLE
look for extra flags for ld when the target is unix too

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1517,6 +1517,8 @@ let configure_makefile ~target ~root ~name ~warn_error info =
       pre_ld_flags "solo5-kernel-ukvm" ;
       R.ok ()
     | `Unix | `MacOSX ->
+      get_extra_ld_flags "unix" libs >>= fun archives ->
+      extra_ld_flags archives;
       R.ok ()
   end >>= fun () ->
   newline fmt;


### PR DESCRIPTION
This PR gives us a way to hint that we need `-lrt` on some platforms when the target is `unix` - see https://github.com/mirage/mirage-clock/issues/10 .