### PR TITLE
Express io-page dependency of crunch in libraries and packages.

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -169,8 +169,8 @@ let crunch dirname = impl @@ object
     val name = Name.create ("static" ^ dirname) ~prefix:"static"
     method name = name
     method module_name = String.Ascii.capitalize name
-    method packages = Key.pure [ "mirage-types"; "lwt"; "cstruct"; "crunch" ]
-    method libraries = Key.pure [ "mirage-types"; "lwt"; "cstruct" ]
+    method packages = Key.pure [ "mirage-types"; "lwt"; "cstruct"; "crunch"; "io-page" ]
+    method libraries = Key.pure [ "mirage-types"; "lwt"; "cstruct"; "io-page" ]
     method deps = [ abstract default_io_page ]
     method connect _ modname _ = Fmt.strf "%s.connect ()" modname
 


### PR DESCRIPTION
This change is needed to get `io-page` included in the set of packages against which a unikernel that includes a `crunch` filesystem builds.  The autogenerated `staticN.ml` requires `io-page`, but installing and running `crunch` itself doesn't, which is why the dependency isn't expressed in the `opam` file for the `crunch` package.

`get_extra_ld_flags` in `mirage.ml` will find `io-page` in the list when compiling for `-t xen` already, because `io-page` is a dependency of the `mirage-xen` package, so we always get it "for free" in that backend -- otherwise, the existing code wouldn't have ever worked.