### PR TITLE
Add a Dockerfile that generates package documentation

### DIFF
--- a/Dockerfile.doc
+++ b/Dockerfile.doc
@@ -1,0 +1,9 @@
+FROM ocaml/opam:alpine-3.4_ocaml-4.03.0
+RUN cd /home/opam/opam-repository && git pull origin master && opam update
+RUN opam remote add mirage-dev git://github.com/mirage/mirage-dev
+RUN opam pin add -n opkg https://github.com/dbuenzli/opkg.git
+RUN opam depext -uivy -j 2 opkg 
+RUN opam depext -uivj 3 mirage tcpip tls cohttp lwt irmin ipaddr uri github
+RUN opam config exec -- opkg ocamldoc
+EXPOSE 8080
+ENTRYPOINT opam config exec -- cohttp-server-lwt /home/opam/.opam/4.03.0/var/cache/opkg/ocamldoc


### PR DESCRIPTION
… and runs a webserver

```
docker build -t mirage-doc -f Dockerfile.doc .
docker run -d --name mirage-doc -p 8080:8080
```

Still experimental, dont merge quite yet (PR for autobuild purposes)