### PR TITLE
Require a `mem` function in KV_RO; allow failures other than `Unknown_key`

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -987,6 +987,9 @@ module type KV_RO = sig
       value associated with [key]. If less data is returned than
       requested, this indicates the end of the value. *)
 
+  val mem: t -> string -> bool
+  (** [mem t key] returns [true] if a value is set for [key] in [t], and [false] if not so. *)
+
   val size: t -> string -> [`Error of error | `Ok of int64] io
   (** Get the value size. *)
 

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -975,6 +975,7 @@ module type KV_RO = sig
 
   type error =
     | Unknown_key of string
+    | Failure of string
 
   include DEVICE
     with type error := error
@@ -987,7 +988,7 @@ module type KV_RO = sig
       value associated with [key]. If less data is returned than
       requested, this indicates the end of the value. *)
 
-  val mem: t -> string -> bool
+  val mem: t -> string -> [ `Ok of bool | `Error of error ] io
   (** [mem t key] returns [true] if a value is set for [key] in [t], and [false] if not so. *)
 
   val size: t -> string -> [`Error of error | `Ok of int64] io


### PR DESCRIPTION
It frequently happens that a KV_RO implementor can have failures other than `Unknown_key`.  Allow for a blanket `Failure` type to communicate these to the user.  Currently implementors tend to return `Unknown_key` for all underlying failure types, which is often erroneous and may lead the user to believe that some action on their part might make the problem go away.

Also, require implementors of KV_RO to include a `mem` function indicating whether the given key is present in the key-value store.

Fixes #147 .

Relevant PRs in other libraries:
- [x] crunch https://github.com/mirage/ocaml-crunch/pull/18
- [x] fat-filesystem https://github.com/mirage/ocaml-fat/pull/46
- [x] mirage-fs-unix https://github.com/mirage/mirage-fs-unix/pull/23
- [x] tar-format https://github.com/mirage/ocaml-tar/pull/27
- [ ] ocaml-9p https://github.com/mirage/ocaml-9p/pull/99
- [ ] irmin https://github.com/mirage/irmin/pull/369

A `mirage-skeleton` build in this universe can be seen at https://travis-ci.org/yomimono/mirage-skeleton/builds/164427007 .  To test for yourself, you can `opam remote add mirage-dev-kvro_mem https://github.com/yomimono/mirage-dev.git#mem-in-kvro` to get the set of pins for an internally consistent universe.
