### PR TITLE
Random fixes

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -104,7 +104,7 @@ let stdlib_random_conf = object
   method packages = Key.pure ["mirage-stdlib-random"]
   method libraries = Key.pure ["mirage-stdlib-random"]
   method connect _ modname _args =
-    Printf.sprintf "Lwt.return (`Ok (%s.initialize ()))" modname
+    Printf.sprintf "Lwt.return (%s.initialize ())" modname
 end
 
 let stdlib_random = impl stdlib_random_conf

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -87,8 +87,11 @@ module type RANDOM = sig
   type buffer
   (** The type for memory buffer. *)
 
-  val generate: int -> buffer
-  (** [generate n] is a buffer of length [n] filled with random. *)
+  type g
+  (** The state of the generator. *)
+
+  val generate: ?g:g -> int -> buffer
+  (** [generate ~g n] generates a random buffer of length [n] using [g]. *)
 end
 
 (** {1 POSIX clock}


### PR DESCRIPTION
two changes:
- `connect` does not return a result anymore (somehow this slipped through a rebase)
- a `generator` type in `RANDOM` interface, and use it in `generate`.  this makes the signature the same as Nocrypto.Rng, and thus interoperable.