### PR TITLE
prng key

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -173,6 +173,12 @@ end
 
 let nocrypto_random = impl nocrypto_random_conf
 
+let default_random =
+  match_impl (Key.value @@ Key.prng ()) [
+    `Stdlib  , stdlib_random;
+    `Nocrypto, nocrypto_random;
+  ] ~default:stdlib_random
+
 type console = CONSOLE
 let console = Type CONSOLE
 
@@ -751,7 +757,7 @@ end
 let tcp_direct_func () = impl (tcp_direct_conf ())
 
 let direct_tcp
-    ?(clock=default_monotonic_clock) ?(random=stdlib_random) ?(time=default_time) ip =
+    ?(clock=default_monotonic_clock) ?(random=default_random) ?(time=default_time) ip =
   tcp_direct_func () $ ip $ time $ clock $ random
 
 let tcpv4_socket_conf ipv4_key = object
@@ -809,7 +815,7 @@ let stackv4_direct_conf ?(group="") () = impl @@ object
 
 let direct_stackv4
     ?(clock=default_monotonic_clock)
-    ?(random=stdlib_random)
+    ?(random=default_random)
     ?(time=default_time)
     ?group
     network eth arp ip =

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -117,6 +117,12 @@ val stdlib_random: random impl
 val nocrypto_random: random impl
 (** Passthrough to the Fortuna PRNG implemented in nocrypto. *)
 
+val default_random: random impl
+(** Default PRNG device to be used in unikernels.  It defaults to {!stdlib}, but
+    users can override using the {!Key.prng} command line argument.
+*)
+
+
 
 (** {2 Consoles} *)
 

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -192,6 +192,27 @@ let kv_ro ?group () =
   in
   create_simple ~doc ?group ~stage:`Configure ~default:`Crunch conv "kv_ro"
 
+(** {3 PRNG key} *)
+let prng ?group () =
+  let conv =
+    Cmdliner.Arg.enum [
+      "stdlib"  , `Stdlib ;
+      "nocrypto", `Nocrypto ;
+      "fortuna" , `Nocrypto ;
+    ]
+  in
+  let serialize = Fmt.of_to_string @@ function
+    | `Stdlib   -> "`Stdlib"
+    | `Nocrypto -> "`Nocrypto"
+  in
+  let conv = Arg.conv ~conv ~serialize ~runtime_conv:"prng" in
+  let doc =
+    Fmt.strf
+      "Use a $(i,stdlib) or $(i,nocrypto) PRNG implementation for %a."
+      pp_group group
+  in
+  create_simple ~doc ?group ~stage:`Configure ~default:`Stdlib conv "prng"
+
 (** {3 Stack keys} *)
 
 let dhcp ?group () =

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -76,6 +76,12 @@ val kv_ro : ?group:string -> unit -> [ `Archive | `Crunch | `Direct | `Fat ] key
 (** The type of key value store.
     Is one of ["archive"], ["crunch"], ["direct"], or ["fat"]. *)
 
+(** {3 PRNG key} *)
+
+val prng : ?group:string -> unit -> [ `Stdlib | `Nocrypto ] key
+(** The type of pseudo random number generator to use by default.
+    Is one of ["stdlib"] (lagged Fibonacci), or ["nocrypto"] (Fortuna). *)
+
 (** {3 Stack keys} *)
 
 val dhcp : ?group:string -> unit -> bool key


### PR DESCRIPTION
The goal is to have a `prng` configuration time key to select which PRNG to use by default (for all devices which need random numbers).  A `config.ml` can manually specify `stdlib_random` or `nocrypto_random` if insisting on a specific PRNG (but nearly all use cases should use `default_random ()`).

@Drup I implemented a `prng` key, filling a `default_random ()` value.. now, if multiple `stack`s are used; or I use a stack and `default_random ()` both in `config.ml`, I get an assertion failure from functoria https://github.com/mirage/functoria/issues/70 ...
