### PR TITLE
Add Solo5 backends to CI

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -4,3 +4,5 @@ cd mirage-skeleton
 eval `opam config env`
 MODE=unix make
 MODE=xen  make
+MODE=ukvm make
+MODE=virtio make


### PR DESCRIPTION
Now that mirage/mirage CI is building against mirage-dev we should also
be building the Solo5 targets.

/cc @avsm