### PR TITLE
reword missing ocaml-crunch slightly so that it points to the missing opam package

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -237,7 +237,7 @@ let crunch dirname = impl @@ object
 
     method configure i =
       if not (Cmd.exists "ocaml-crunch") then
-        Log.error "ocaml-crunch not found, stopping."
+        Log.error "Couldn't find the ocaml-crunch binary.  Please install the opam package crunch."
       else begin
         let dir = Info.root i / dirname in
         let file = Info.root i / (name ^ ".ml") in


### PR DESCRIPTION
this was merged and reverted (due to the LD changes)