### PR TITLE
library for mirage-bootvar-xen is now mirage-bootvar-xen

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1010,7 +1010,7 @@ let argv_xen = impl @@ object
     method name = "argv_xen"
     method module_name = "Bootvar"
     method packages = Key.pure [ "mirage-bootvar-xen" ]
-    method libraries = Key.pure [ "mirage-bootvar" ]
+    method libraries = Key.pure [ "mirage-bootvar-xen" ]
     method connect _ _ _ = "Bootvar.argv ()"
   end
 


### PR DESCRIPTION
See https://github.com/mirage/mirage-dev/pull/175 . `solo5` is still `mirage-bootvar`, at least for the moment.