### PR TITLE
docs: build mirage-entropy instead of mirage-entropy-xen

### DIFF
--- a/Dockerfile.doc
+++ b/Dockerfile.doc
@@ -44,7 +44,7 @@ RUN opam depext -uivj 3 \
   mirage-clock-xen \
   mirage-console \
   mirage-dns \
-  mirage-entropy-xen \
+  mirage-entropy \
   mirage-flow \
   mirage-fs-unix \
   mirage-http \


### PR DESCRIPTION
requires mirage/mirage-dev#179