### PR TITLE
improvements to ipv4 configuration

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,5 +1,5 @@
 opam depext -uiy mirage
-git clone -b mirage-dev https://github.com/mirage/mirage-skeleton.git
+git clone -b normalize-ipv4 https://github.com/yomimono/mirage-skeleton.git
 cd mirage-skeleton
 eval `opam config env`
 find . -name _build | xargs rm -rf

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 sudo: false
 env:
  global:
-   - EXTRA_REMOTES="git://github.com/mirage/mirage-dev.git"
+   - EXTRA_REMOTES="git://github.com/yomimono/mirage-dev.git#normalize-ipv4"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="sh ./.travis-ci.sh"
  matrix:

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -611,7 +611,7 @@ let dhcp time net = dhcp_conf $ time $ net
 let ipv4_of_dhcp dhcp ethif arp = ipv4_dhcp_conf $ dhcp $ ethif $ arp
 
 let create_ipv4
-    ?group _net etif arp =
+    ?group etif arp =
   let address = Key.V4.ip ?group () in
   let network = Key.V4.network ?group () in
   let gateway = Key.V4.gateway ?group () in
@@ -647,8 +647,7 @@ let ipv6_conf ?addresses ?netmasks ?gateways () = impl @@ object
 let create_ipv6
     ?(time = default_time)
     ?(clock = default_monotonic_clock)
-    ?group net { addresses ; netmasks ; gateways } =
-  let etif = etif net in
+    ?group etif { addresses ; netmasks ; gateways } =
   let addresses = Key.V6.ips ?group addresses in
   let netmasks = Key.V6.netmasks ?group netmasks in
   let gateways = Key.V6.gateways ?group gateways in
@@ -823,7 +822,7 @@ let dhcp_stack ?group time tap =
 let keyed_stack ?group tap =
   let e = etif tap in
   let a = arp e in
-  let i = create_ipv4 tap e a in
+  let i = create_ipv4 e a in
   direct_stackv4 ?group tap e a i
 
 let stackv4_socket_conf ?(group="") interfaces = impl @@ object

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -610,11 +610,19 @@ let ipv4_dhcp_conf = impl @@ object
 let dhcp time net = dhcp_conf $ time $ net
 let ipv4_of_dhcp dhcp ethif arp = ipv4_dhcp_conf $ dhcp $ ethif $ arp
 
-let create_ipv4
-    ?group etif arp =
-  let address = Key.V4.ip ?group () in
-  let network = Key.V4.network ?group () in
-  let gateway = Key.V4.gateway ?group () in
+let keyed_ipv4 ?group etif arp =
+  let default_address = Ipaddr.V4.of_string_exn "10.0.0.2" in
+  let default_network = Ipaddr.V4.Prefix.make 24 default_address in
+  let default_gateway = Some (Ipaddr.V4.of_string_exn "10.0.0.1") in
+  let address = Key.V4.ip ?group default_address in
+  let network = Key.V4.network ?group default_network in
+  let gateway = Key.V4.gateway ?group default_gateway in
+  ipv4_keyed_conf ~address ~network ~gateway () $ etif $ arp
+
+let create_ipv4 ?group { address; network; gateway } etif arp =
+  let address = Key.V4.ip ?group address in
+  let network = Key.V4.network ?group network in
+  let gateway = Key.V4.gateway ?group gateway in
   ipv4_keyed_conf ~address ~network ~gateway () $ etif $ arp
 
 type ipv6_config = {
@@ -819,10 +827,16 @@ let dhcp_stack ?group time tap =
   let i = ipv4_of_dhcp config e a in
   direct_stackv4 ?group tap e a i
 
+let static_ipv4_stack ?group config tap =
+  let e = etif tap in
+  let a = arp e in
+  let i = create_ipv4 ?group config e a in
+  direct_stackv4 ?group tap e a i
+
 let keyed_stack ?group tap =
   let e = etif tap in
   let a = arp e in
-  let i = create_ipv4 e a in
+  let i = keyed_ipv4 e a in
   direct_stackv4 ?group tap e a i
 
 let stackv4_socket_conf ?(group="") interfaces = impl @@ object

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -595,8 +595,8 @@ let ipv4_dhcp_conf = impl @@ object
     method ty = dhcp @-> ethernet @-> arpv4 @-> ipv4
     method name = Name.create "ipv4" ~prefix:"ipv4"
     method module_name = "Dhcp_ipv4.Make"
-    method packages = Key.pure ["tcpip"]
-    method libraries = Key.pure ["tcpip.ipv4"]
+    method packages = Key.pure ["charrua-client"]
+    method libraries = Key.pure ["charrua-client.mirage"]
     method connect _ modname = function
           | [ dhcp ; ethernet ; arp ] ->
         Fmt.strf

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -610,19 +610,19 @@ let ipv4_dhcp_conf = impl @@ object
 let dhcp time net = dhcp_conf $ time $ net
 let ipv4_of_dhcp dhcp ethif arp = ipv4_dhcp_conf $ dhcp $ ethif $ arp
 
-let keyed_ipv4 ?group etif arp =
-  let default_address = Ipaddr.V4.of_string_exn "10.0.0.2" in
-  let default_network = Ipaddr.V4.Prefix.make 24 default_address in
-  let default_gateway = Some (Ipaddr.V4.of_string_exn "10.0.0.1") in
-  let address = Key.V4.ip ?group default_address in
-  let network = Key.V4.network ?group default_network in
-  let gateway = Key.V4.gateway ?group default_gateway in
-  ipv4_keyed_conf ~address ~network ~gateway () $ etif $ arp
-
-let create_ipv4 ?group { address; network; gateway } etif arp =
-  let address = Key.V4.ip ?group address in
-  let network = Key.V4.network ?group network in
-  let gateway = Key.V4.gateway ?group gateway in
+let create_ipv4 ?group ?config etif arp =
+  let config = match config with
+  | None ->
+    let default_address = Ipaddr.V4.of_string_exn "10.0.0.2" in
+    { address = default_address;
+      network = Ipaddr.V4.Prefix.make 24 default_address;
+      gateway = Some (Ipaddr.V4.of_string_exn "10.0.0.1");
+    }
+  | Some config -> config
+  in
+  let address = Key.V4.ip ?group config.address in
+  let network = Key.V4.network ?group config.network in
+  let gateway = Key.V4.gateway ?group config.gateway in
   ipv4_keyed_conf ~address ~network ~gateway () $ etif $ arp
 
 type ipv6_config = {
@@ -827,16 +827,10 @@ let dhcp_stack ?group time tap =
   let i = ipv4_of_dhcp config e a in
   direct_stackv4 ?group tap e a i
 
-let static_ipv4_stack ?group config tap =
+let static_ipv4_stack ?group ?config tap =
   let e = etif tap in
   let a = arp e in
-  let i = create_ipv4 ?group config e a in
-  direct_stackv4 ?group tap e a i
-
-let keyed_stack ?group tap =
-  let e = etif tap in
-  let a = arp e in
-  let i = keyed_ipv4 e a in
+  let i = create_ipv4 ?group ?config e a in
   direct_stackv4 ?group tap e a i
 
 let stackv4_socket_conf ?(group="") interfaces = impl @@ object
@@ -873,7 +867,7 @@ let socket_stackv4 ?group ipv4s =
 (** Generic stack *)
 
 let generic_stackv4
-    ?group
+    ?group ?config
     ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
     ?(net_key = Key.value @@ Key.net ?group ())
     (tap : network impl) : stackv4 impl =
@@ -882,7 +876,7 @@ let generic_stackv4
     (socket_stackv4 ?group [Ipaddr.V4.any])
     (if_impl Key.(pure ((=) true) $ dhcp_key)
       (dhcp_stack ?group default_time tap)
-      (keyed_stack ?group tap))
+      (static_ipv4_stack ?config ?group tap))
 
 type conduit_connector = Conduit_connector
 let conduit_connector = Type Conduit_connector

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -483,7 +483,7 @@ let network_conf (intf : string Key.key) =
 
   end
 
-let netif ?group dev = impl (network_conf @@ Key.network ?group dev)
+let netif ?group dev = impl (network_conf @@ Key.interface ?group dev)
 let tap0 = netif "tap0"
 
 type ethernet = ETHERNET
@@ -525,12 +525,6 @@ let arp_func = impl arpv4_conf
 let arp ?(clock = default_monotonic_clock) ?(time = default_time) (eth : ethernet impl) =
   arp_func $ eth $ clock $ time
 
-type ('ipaddr, 'prefix) ip_config = {
-  address: 'ipaddr;
-  netmask: 'prefix;
-  gateways: 'ipaddr list;
-}
-
 type v4
 type v6
 type 'a ip = IP
@@ -550,71 +544,69 @@ let meta_triple ppx ppy ppz =
 let meta_ipv4 ppf s =
   Fmt.pf ppf "(Ipaddr.V4.of_string_exn %S)" (Ipaddr.V4.to_string s)
 
-type ipv4_config = (Ipaddr.V4.t, Ipaddr.V4.t) ip_config
+type ipv4_config = {
+  address : Ipaddr.V4.t;
+  network : Ipaddr.V4.Prefix.t;
+  gateway : Ipaddr.V4.t option;
+}
+(** Types for IPv4 manual configuration. *)
+
 
 let pp_key fmt k = Key.serialize_call fmt (Key.abstract k)
-let opt_key s = Fmt.(option @@ prefix (unit ("~"^^s)) pp_key)
+let opt_key s = Fmt.(option @@ prefix (unit ("~"^^s^^":")) pp_key)
 let opt_map f = function Some x -> Some (f x) | None -> None
 let (@?) x l = match x with Some s -> s :: l | None -> l
 let (@??) x y = opt_map Key.abstract x @? y
 
-let ipv4_conf ?address ?netmask ?gateways () = impl @@ object
+let ipv4_conf ?address ?network ?gateway () = impl @@ object
     inherit base_configurable
     method ty = ethernet @-> arpv4 @-> ipv4
     method name = Name.create "ipv4" ~prefix:"ipv4"
     method module_name = "Ipv4.Make"
     method packages = Key.pure ["tcpip"]
     method libraries = Key.pure ["tcpip.ipv4"]
-    method keys = address @?? netmask @?? gateways @?? []
+    method keys = address @?? network @?? gateway @?? []
     method connect _ modname = function
       | [ etif ; arp ] ->
         Fmt.strf
           "%s.connect@[@ %a@ %a@ %a@ %s@ %s@]"
           modname
           (opt_key "ip") address
-          (opt_key "netmask") netmask
-          (opt_key "gateways") gateways
+          (opt_key "network") network
+          (opt_key "gateway") gateway
           etif arp
       | _ -> failwith "The ipv4 connect should receive exactly two arguments."
   end
 
 let create_ipv4
-    ?(clock = default_monotonic_clock) ?(time = default_time)
-    ?group net { address ; netmask ; gateways } =
-  let etif = etif net in
-  let arp = arp ~clock ~time etif in
-  let address = Key.V4.ip ?group address in
-  let netmask = Key.V4.netmask ?group netmask in
-  let gateways = Key.V4.gateways ?group gateways in
-  ipv4_conf ~address ~netmask ~gateways () $ etif $ arp
+    ?group net etif arp =
+  let address = Key.V4.ip ?group () in
+  let network = Key.V4.network ?group () in
+  let gateway = Key.V4.gateway ?group () in
+  ipv4_conf ~address ~network ~gateway () $ etif $ arp
 
-let default_ipv4_conf =
-  let i = Ipaddr.V4.of_string_exn in
-  {
-    address  = i "10.0.0.2";
-    netmask  = i "255.255.255.0";
-    gateways = [i "10.0.0.1"];
-  }
+type ipv6_config = {
+  addresses: Ipaddr.V6.t list;
+  netmasks: Ipaddr.V6.Prefix.t list;
+  gateways: Ipaddr.V6.t list;
+}
+(** Types for IP manual configuration. *)
 
-let default_ipv4 ?group net = create_ipv4 ?group net default_ipv4_conf
-
-type ipv6_config = (Ipaddr.V6.t, Ipaddr.V6.Prefix.t list) ip_config
-
-let ipv6_conf ?address ?netmask ?gateways () = impl @@ object
+let ipv6_conf ?addresses ?netmasks ?gateways () = impl @@ object
     inherit base_configurable
     method ty = ethernet @-> time @-> mclock @-> ipv6
     method name = Name.create "ipv6" ~prefix:"ipv6"
     method module_name = "Ipv6.Make"
     method packages = Key.pure ["tcpip"]
     method libraries = Key.pure ["tcpip.ipv6"]
-    method keys = address @?? netmask @?? gateways @?? []
+    method keys = addresses @?? netmasks @?? gateways @?? []
     method connect _ modname = function
       | [ etif ; _time ; _clock ] ->
         Fmt.strf
           "%s.connect@[@ %a@ %a@ %a@ %s@@]"
           modname
-          (opt_key "ip") address
-          (opt_key "netmask") netmask
+          (opt_key "ip") addresses
+          (opt_key "netmask") netmasks
           (opt_key "gateways") gateways
           etif
       | _ -> failwith "The ipv6 connect should receive exactly three arguments."
@@ -623,12 +615,12 @@ let ipv6_conf ?address ?netmask ?gateways () = impl @@ object
 let create_ipv6
     ?(time = default_time)
     ?(clock = default_monotonic_clock)
-    ?group net { address ; netmask ; gateways } =
+    ?group net { addresses ; netmasks ; gateways } =
   let etif = etif net in
-  let address = Key.V6.ip ?group address in
-  let netmask = Key.V6.netmask ?group netmask in
+  let addresses = Key.V6.ips ?group addresses in
+  let netmasks = Key.V6.netmasks ?group netmasks in
   let gateways = Key.V6.gateways ?group gateways in
-  ipv6_conf ~address ~netmask ~gateways () $ etif $ time $ clock
+  ipv6_conf ~addresses ~netmasks ~gateways () $ etif $ time $ clock
 
 type 'a icmp = ICMP
 type icmpv4 = v4 icmp
@@ -744,13 +736,9 @@ let socket_tcpv4 ?group ip = impl (tcpv4_socket_conf @@ Key.V4.socket ?group ip)
 type stackv4 = STACKV4
 let stackv4 = Type STACKV4
 
-let pp_stackv4_config fmt = function
-  | `DHCP   -> Fmt.pf fmt "`DHCP"
-  | `IPV4 i -> Fmt.pf fmt "`IPv4 %a" (meta_triple pp_key pp_key pp_key) i
-
 let add_suffix s ~suffix = if suffix = "" then s else s^"_"^suffix
 
-let stackv4_direct_conf ?(group="") config = impl @@ object
+let stackv4_direct_conf ?(group="") () = impl @@ object
     inherit base_configurable
 
     method ty =
@@ -758,22 +746,10 @@ let stackv4_direct_conf ?(group="") config = impl @@ object
       ethernet @-> arpv4 @-> ipv4 @-> icmpv4 @-> udpv4 @-> tcpv4 @->
       stackv4
 
-    val name =
-      let base = match config with
-        | `DHCP -> "dhcp"
-        | `IPV4 _ -> "ip"
-      in add_suffix ("stackv4_" ^ base) ~suffix:group
+    val name = add_suffix "stackv4_" ~suffix:group
 
     method name = name
     method module_name = "Tcpip_stack_direct.Make"
-
-    method keys = match config with
-      | `DHCP -> []
-      | `IPV4 (addr,netm,gate) -> [
-          Key.abstract addr;
-          Key.abstract netm;
-          Key.abstract gate
-        ]
 
     method packages = Key.pure [ "tcpip" ]
     method libraries = Key.pure [ "tcpip.stack-direct" ; "mirage.runtime" ]
@@ -783,51 +759,27 @@ let stackv4_direct_conf ?(group="") config = impl @@ object
         Fmt.strf
           "@[<2>let config = {V1_LWT.@ \
            name = %S;@ \
-           interface = %s;@ mode = %a }@]@ in@ \
+           interface = %s;}@]@ in@ \
            %s.connect config@ %s %s %s %s %s %s"
-          name interface pp_stackv4_config config
+          name interface
           modname ethif arp ip icmp udp tcp
       | _ -> failwith "Wrong arguments to connect to tcpip direct stack."
 
   end
 
 
-let direct_stackv4_with_config
+let direct_stackv4
     ?(clock=default_monotonic_clock)
     ?(random=stdlib_random)
     ?(time=default_time)
     ?group
-    network config =
-  let eth = etif_func $ network in
-  let arp = arp ~clock ~time eth in
-  let ip = ipv4_conf () $ eth $ arp in
-  stackv4_direct_conf ?group config
+    network eth arp ip =
+  stackv4_direct_conf ?group ()
   $ time $ random $ network
   $ eth $ arp $ ip
   $ direct_icmpv4 ip
   $ direct_udp ip
   $ direct_tcp ~clock ~random ~time ip
-
-let direct_stackv4_with_dhcp
-    ?clock ?random ?time ?group network =
-  direct_stackv4_with_config
-    ?clock ?random ?time ?group network `DHCP
-
-let direct_stackv4_with_static_ipv4
-    ?clock ?random ?time ?group network
-    {address; netmask; gateways} =
-  let address = Key.V4.ip ?group address in
-  let netmask = Key.V4.netmask ?group netmask in
-  let gateways = Key.V4.gateways ?group gateways in
-  direct_stackv4_with_config
-    ?clock ?random ?time ?group network
-    (`IPV4 (address, netmask, gateways))
-
-let direct_stackv4_with_default_ipv4
-    ?clock ?random ?time ?group network =
-  direct_stackv4_with_static_ipv4
-    ?clock ?random ?time ?group network
-    default_ipv4_conf
 
 let stackv4_socket_conf ?(group="") interfaces = impl @@ object
     inherit base_configurable
@@ -848,7 +800,7 @@ let stackv4_socket_conf ?(group="") interfaces = impl @@ object
         Fmt.strf
           "let config =@[@ \
            { V1_LWT.name = %S;@ \
-           interface = %a ;@ mode = () }@] in@ \
+           interface = %a ;@] in@ \
            %s.connect config %s %s"
           name
           pp_key interfaces
@@ -866,15 +818,17 @@ let generic_stackv4
     ?group
     ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
     ?(net_key = Key.value @@ Key.net ?group ())
-    (tap : network impl) : stackv4 impl=
+    (tap : network impl) : stackv4 impl =
+  let directify () =
+    let e = etif tap in
+    let (a : arpv4 impl) = arp e in
+    let i = create_ipv4 tap e a in
+    direct_stackv4 ?group tap e a i
+  in
   if_impl
     Key.(pure ((=) `Socket) $ net_key)
     (socket_stackv4 ?group [Ipaddr.V4.any])
-    (if_impl
-       dhcp_key
-       (direct_stackv4_with_dhcp ?group tap)
-       (direct_stackv4_with_default_ipv4 ?group tap)
-    )
+    (directify ())
 
 type conduit_connector = Conduit_connector
 let conduit_connector = Type Conduit_connector

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -229,7 +229,7 @@ val tap0: network impl
 (** The '/dev/tap0' interface. *)
 
 val netif: ?group:string -> string -> network impl
-(** A custom network interface. Exposes a {!Key.network} key. *)
+(** A custom network interface. Exposes a {!Key.interface} key. *)
 
 
 
@@ -269,37 +269,31 @@ val ipv4: ipv4 typ
 val ipv6: ipv6 typ
 (** The [V1.IPV6] module signature. *)
 
-type ('ipaddr, 'prefix) ip_config = {
-  address: 'ipaddr;
-  netmask: 'prefix;
-  gateways: 'ipaddr list;
+type ipv4_config = {
+  address : Ipaddr.V4.t;
+  network : Ipaddr.V4.Prefix.t;
+  gateway : Ipaddr.V4.t option;
+}
+(** Types for IPv4 manual configuration. *)
+
+type ipv6_config = {
+  addresses : Ipaddr.V6.t list;
+  netmasks : Ipaddr.V6.Prefix.t list;
+  gateways : Ipaddr.V6.t list;
 }
 (** Types for IP manual configuration. *)
 
-type ipv4_config = (Ipaddr.V4.t, Ipaddr.V4.t) ip_config
-(** Types for IPv4 manual configuration. *)
-
 val create_ipv4:
-  ?clock:mclock impl -> ?time:time impl ->
-  ?group:string -> network impl -> ipv4_config -> ipv4 impl
+  ?group:string -> network impl -> ethernet impl -> arpv4 impl -> ipv4 impl
 (** Use an IPv4 address.
-    Exposes the keys {!Key.V4.ip}, {!Key.V4.netmask} and {!Key.V4.gateways}.
+    Exposes the keys {!Key.V4.ip}, {!Key.V4.network} and {!Key.V4.gateway}.
 *)
-
-val default_ipv4: ?group:string -> network impl -> ipv4 impl
-(** Default local IP listening on the given network interfaces:
-    - address: 10.0.0.2
-    - netmask: 255.255.255.0
-    - gateways: [10.0.0.1] *)
-
-type ipv6_config = (Ipaddr.V6.t, Ipaddr.V6.Prefix.t list) ip_config
-(** Types for IPv6 manual configuration. *)
 
 val create_ipv6:
   ?time:time impl -> ?clock:mclock impl ->
   ?group:string -> network impl -> ipv6_config -> ipv6 impl
 (** Use an IPv6 address.
-    Exposes the keys {!Key.V6.ip}, {!Key.V6.netmask} and {!Key.V6.gateways}.
+    Exposes the keys {!Key.V6.ips}, {!Key.V6.netmasks} and {!Key.V6.gateways}.
 *)
 
 
@@ -349,31 +343,14 @@ type stackv4
 val stackv4: stackv4 typ
 (** Implementation of the [V1.STACKV4] signature. *)
 
-(** Same as {!direct_stackv4_with_static_ipv4} with the default given by
-    {!default_ipv4}. *)
-val direct_stackv4_with_default_ipv4:
-  ?clock:mclock impl ->
-  ?random:random impl ->
-  ?time:time impl ->
-  ?group:string ->
-  network impl -> stackv4 impl
-
 (** Direct network stack with ip.
     Exposes the keys {!Key.V4.ip}, {!Key.V4.netmask} and {!Key.V4.gateways}. *)
-val direct_stackv4_with_static_ipv4:
+val direct_stackv4:
   ?clock:mclock impl ->
   ?random:random impl ->
   ?time:time impl ->
   ?group:string ->
-  network impl -> ipv4_config -> stackv4 impl
-
-(** Direct network stack using dhcp. *)
-val direct_stackv4_with_dhcp:
-  ?clock:mclock impl ->
-  ?random:random impl ->
-  ?time:time impl ->
-  ?group:string ->
-  network impl -> stackv4 impl
+  network impl -> ethernet impl -> arpv4 impl -> ipv4 impl -> stackv4 impl
 
 (** Network stack with sockets. Exposes the key {Key.interfaces}. *)
 val socket_stackv4:

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -283,10 +283,18 @@ type ipv6_config = {
 }
 (** Types for IP manual configuration. *)
 
-val create_ipv4:
+val keyed_ipv4:
   ?group:string -> ethernet impl -> arpv4 impl -> ipv4 impl
 (** Use an IPv4 address.
     Exposes the keys {!Key.V4.ip}, {!Key.V4.network} and {!Key.V4.gateway}.
+*)
+
+val create_ipv4 : ?group:string ->
+  ipv4_config -> ethernet impl -> arpv4 impl -> ipv4 impl
+(** Use an IPv4 address, given a specific config.
+    Exposes the keys {!Key.V4.ip}, {!Key.V4.network} and {!Key.V4.gateway}.
+    If provided, the values of these keys will override those supplied
+    in the ipv4 configuration record.
 *)
 
 val create_ipv6:

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -345,8 +345,7 @@ type stackv4
 val stackv4: stackv4 typ
 (** Implementation of the [V1.STACKV4] signature. *)
 
-(** Direct network stack with ip.
-    Exposes the keys {!Key.V4.ip}, {!Key.V4.netmask} and {!Key.V4.gateways}. *)
+(** Direct network stack with given ip. *)
 val direct_stackv4:
   ?clock:mclock impl ->
   ?random:random impl ->

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -283,18 +283,12 @@ type ipv6_config = {
 }
 (** Types for IP manual configuration. *)
 
-val keyed_ipv4:
-  ?group:string -> ethernet impl -> arpv4 impl -> ipv4 impl
-(** Use an IPv4 address.
-    Exposes the keys {!Key.V4.ip}, {!Key.V4.network} and {!Key.V4.gateway}.
-*)
-
 val create_ipv4 : ?group:string ->
-  ipv4_config -> ethernet impl -> arpv4 impl -> ipv4 impl
-(** Use an IPv4 address, given a specific config.
+  ?config:ipv4_config -> ethernet impl -> arpv4 impl -> ipv4 impl
+(** Use an IPv4 address
     Exposes the keys {!Key.V4.ip}, {!Key.V4.network} and {!Key.V4.gateway}.
     If provided, the values of these keys will override those supplied
-    in the ipv4 configuration record.
+    in the ipv4 configuration record, ifthat has been provided.
 *)
 
 val create_ipv6:
@@ -373,7 +367,7 @@ val socket_stackv4:
     [group] argument) to create it.
 *)
 val generic_stackv4 :
-  ?group:string ->
+  ?group:string -> ?config:ipv4_config ->
   ?dhcp_key:bool value ->
   ?net_key:[ `Direct | `Socket ] value ->
   network impl -> stackv4 impl

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -284,14 +284,14 @@ type ipv6_config = {
 (** Types for IP manual configuration. *)
 
 val create_ipv4:
-  ?group:string -> network impl -> ethernet impl -> arpv4 impl -> ipv4 impl
+  ?group:string -> ethernet impl -> arpv4 impl -> ipv4 impl
 (** Use an IPv4 address.
     Exposes the keys {!Key.V4.ip}, {!Key.V4.network} and {!Key.V4.gateway}.
 *)
 
 val create_ipv6:
   ?time:time impl -> ?clock:mclock impl ->
-  ?group:string -> network impl -> ipv6_config -> ipv6 impl
+  ?group:string -> ethernet impl -> ipv6_config -> ipv6 impl
 (** Use an IPv6 address.
     Exposes the keys {!Key.V6.ips}, {!Key.V6.netmasks} and {!Key.V6.gateways}.
 *)

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -218,21 +218,18 @@ let interface ?group default =
   create_simple ~doc ~default ?group Arg.string "interface"
 
 module V4 = struct
-  let default_address = Ipaddr.V4.of_string_exn "10.0.0.2"
-  let default_network = Ipaddr.V4.Prefix.make 24 default_address
-  let default_gateway = Some (Ipaddr.V4.of_string_exn "10.0.0.1")
 
-  let ip ?group () =
+  let ip ?group default =
     let doc = Fmt.strf "The ip address of %a." pp_group group in
-    create_simple ~doc ~default:default_address ?group Arg.ipv4 "ip"
+    create_simple ~doc ~default ?group Arg.ipv4 "ip"
 
-  let network ?group () =
+  let network ?group default =
     let doc = Fmt.strf "The network of %a specified as an IP address and netmask, e.g. 192.168.0.0/16 ." pp_group group in
-    create_simple ~doc ~default:default_network ?group Arg.ipv4_prefix "network"
+    create_simple ~doc ~default ?group Arg.ipv4_prefix "network"
 
-  let gateway ?group () =
+  let gateway ?group default =
     let doc = Fmt.strf "The gateway of %a." pp_group group in
-    create_simple ~doc ~default:default_gateway ?group Arg.(some ipv4) "gateway"
+    create_simple ~doc ~default ?group Arg.(some ipv4) "gateway"
 
   let socket ?group default =
     let doc =

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -22,6 +22,7 @@ module Arg : sig
   include module type of struct include Functoria_key.Arg end
 
   val ipv4 : Ipaddr.V4.t converter
+  val ipv4_prefix : Ipaddr.V4.Prefix.t converter
   val ipv6 : Ipaddr.V6.t converter
   val ipv6_prefix : Ipaddr.V6.Prefix.t converter
 
@@ -85,21 +86,21 @@ val net : ?group:string -> unit -> [ `Direct | `Socket ] key
 
 (** {3 Network keys} *)
 
-val network : ?group:string -> string -> string key
+val interface : ?group:string -> string -> string key
 (** A network interface. *)
 
 (** Ipv4 keys. *)
 module V4 : sig
   open Ipaddr.V4
 
-  val ip : ?group:string -> t -> t key
+  val ip : ?group:string -> unit -> t key
   (** An ip address. *)
 
-  val netmask : ?group:string -> t -> t key
-  (** A netmask. *)
+  val network : ?group:string -> unit -> Prefix.t key
+  (** A network defined by an address and netmask. *)
 
-  val gateways : ?group:string -> t list -> t list key
-  (** A list of gateways. *)
+  val gateway : ?group:string -> unit -> t option key
+  (** A default gateway option. *)
 
   val socket : ?group:string -> t option -> t option key
   (** An address bound by a socket. Will be none if no address is provided. *)
@@ -113,10 +114,10 @@ end
 module V6 : sig
   open Ipaddr.V6
 
-  val ip : ?group:string -> t -> t key
+  val ips : ?group:string -> t list -> t list key
   (** An ip address. *)
 
-  val netmask : ?group:string -> Prefix.t list -> Prefix.t list key
+  val netmasks : ?group:string -> Prefix.t list -> Prefix.t list key
   (** A list of netmasks. *)
 
   val gateways : ?group:string -> t list -> t list key

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -93,13 +93,13 @@ val interface : ?group:string -> string -> string key
 module V4 : sig
   open Ipaddr.V4
 
-  val ip : ?group:string -> unit -> t key
+  val ip : ?group:string -> t -> t key
   (** An ip address. *)
 
-  val network : ?group:string -> unit -> Prefix.t key
+  val network : ?group:string -> Prefix.t -> Prefix.t key
   (** A network defined by an address and netmask. *)
 
-  val gateway : ?group:string -> unit -> t option key
+  val gateway : ?group:string -> t option -> t option key
   (** A default gateway option. *)
 
   val socket : ?group:string -> t option -> t option key

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -56,6 +56,7 @@ module Arg = struct
 
   let ip = of_module (module Ipaddr)
   let ipv4 = of_module (module Ipaddr.V4)
+  let ipv4_prefix = of_module (module Ipaddr.V4.Prefix)
   let ipv6 = of_module (module Ipaddr.V6)
   let ipv6_prefix = of_module (module Ipaddr.V6.Prefix)
 

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -57,6 +57,9 @@ module Arg: sig
   val ipv4: Ipaddr.V4.t Cmdliner.Arg.converter
   (** [ipv4] converts IPv4 address. *)
 
+  val ipv4_prefix: Ipaddr.V4.Prefix.t Cmdliner.Arg.converter
+  (**[ipv4_prefix] converts IPv4 prefixes. *)
+
   val ipv6: Ipaddr.V6.t Cmdliner.Arg.converter
   (** [ipv6]converts IPv6 address. *)
 

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -486,21 +486,8 @@ module type IP = sig
 
   val get_ip: t -> ipaddr list
   (** Get the IP addresses associated with this interface. For IPv4, only
-   *  one IP address can be set at a time. *)
-
-  val set_ip_netmask: t -> prefix -> unit io
-  (** Set an IP netmask associated with this interface.  For IPv4,
-      currently only supports a single IPv4 netmask. *)
-
-  val get_ip_netmasks: t -> prefix list
-  (** Get the IP netmasks associated with this interface. For IPv4,
-   *  this can only be an empty or single-member list. *)
-
-  val set_ip_gateway: t -> ipaddr -> unit io
-  (** Set an IP gateway associated with this interface. *)
-
-  val get_ip_gateways: t -> ipaddr
-  (** Get the IP gateway associated with this interface. *)
+   *  one IP address can be set at a time, so the list will always be of
+   *  length 1 (and may be the default value, 0.0.0.0). *)
 
   type uipaddr
   (** The type for universal IP addresses. It supports all the
@@ -725,12 +712,7 @@ module type STACKV4 = sig
   (** The type for network interface that is used to transmit and
       receive traffic associated with this stack. *)
 
-  type mode
-  (** The type for configuration modes associated with this interface.
-      These can consist of the IPv4 address binding, or a DHCP
-      interface. *)
-
-  type ('netif, 'mode) config
+  type 'netif config
   (** The type for the collection of user configuration specified to
       construct a stack. *)
 

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -476,7 +476,8 @@ module type IP = sig
 
   val src: t -> dst:ipaddr -> ipaddr
   (** [src ip ~dst] is the source address to be used to send a
-      packet to [dst]. *)
+      packet to [dst].  In the case of IPv4, this will always return
+      the same IP, which is the only one set. *)
 
   val set_ip: t -> ipaddr -> unit io
   (** Set the IP address associated with this interface.  For IPv4,
@@ -484,21 +485,22 @@ module type IP = sig
       be added in a future revision. *)
 
   val get_ip: t -> ipaddr list
-  (** Get the IP addresses associated with this interface. *)
+  (** Get the IP addresses associated with this interface. For IPv4, only
+   *  one IP address can be set at a time. *)
 
   val set_ip_netmask: t -> prefix -> unit io
   (** Set an IP netmask associated with this interface.  For IPv4,
-      currently only supports a single IPv4 netmask, and aliases will
-      be added in a future revision. *)
+      currently only supports a single IPv4 netmask. *)
 
   val get_ip_netmasks: t -> prefix list
-  (** Get the IP netmasks associated with this interface. *)
+  (** Get the IP netmasks associated with this interface. For IPv4,
+   *  this can only be an empty or single-member list. *)
 
-  val set_ip_gateways: t -> ipaddr list -> unit io
-  (** Set an IP gateways associated with this interface. *)
+  val set_ip_gateway: t -> ipaddr -> unit io
+  (** Set an IP gateway associated with this interface. *)
 
-  val get_ip_gateways: t -> ipaddr list
-  (** Get the IP gateways associated with this interface. *)
+  val get_ip_gateways: t -> ipaddr
+  (** Get the IP gateway associated with this interface. *)
 
   type uipaddr
   (** The type for universal IP addresses. It supports all the

--- a/types/V1_LWT.mli
+++ b/types/V1_LWT.mli
@@ -69,7 +69,7 @@ module type IPV4 = IPV4
   with type 'a io = 'a Lwt.t
    and type buffer = Cstruct.t
    and type ipaddr = Ipaddr.V4.t
-   and type prefix = Ipaddr.V4.t (* FIXME: Use Ipaddr.V4.Prefix.t *)
+   and type prefix = Ipaddr.V4.Prefix.t
    and type uipaddr = Ipaddr.t
 
 (** IPv6 stack *)
@@ -143,23 +143,31 @@ module type FS = FS
   with type 'a io = 'a Lwt.t
    and type page_aligned_buffer = Cstruct.t
 
+(** Configuration *)
+
 type socket_stack_config =
   Ipaddr.V4.t list
 
-type direct_stack_config = [
-    `DHCP
-  | `IPv4 of Ipaddr.V4.t * Ipaddr.V4.t * Ipaddr.V4.t list
-]
+type ipv4_config = {
+  address : Ipaddr.V4.t;
+  network : Ipaddr.V4.Prefix.t;
+  gateway : Ipaddr.V4.t option;
+}
 
-type ('netif, 'mode) stackv4_config = {
+type ipv6_config = {
+  address : Ipaddr.V6.t list;
+  netmasks : Ipaddr.V6.Prefix.t list;
+  gateways : Ipaddr.V6.t list;
+}
+
+type 'netif stackv4_config = {
   name: string;
   interface: 'netif;
-  mode: 'mode;
 }
 
 (** Single network stack *)
 module type STACKV4 = STACKV4
   with type 'a io = 'a Lwt.t
-   and type ('a,'b) config = ('a,'b) stackv4_config
+   and type 'a config = 'a stackv4_config
    and type ipv4addr = Ipaddr.V4.t
    and type buffer = Cstruct.t

--- a/types/V1_LWT.mli
+++ b/types/V1_LWT.mli
@@ -165,6 +165,13 @@ type 'netif stackv4_config = {
   interface: 'netif;
 }
 
+(** {1 DHCP client}
+ *  A client which engages in lease transactions. *)
+module type DHCP_CLIENT = sig
+  type t = ipv4_config Lwt_stream.t
+end
+
+
 (** Single network stack *)
 module type STACKV4 = STACKV4
   with type 'a io = 'a Lwt.t


### PR DESCRIPTION
TL;DR : make DHCP configuration of ipv4 a first-class citizen; remove `mode`, many type signature changes.

Details:
* Use charrua-client's Dhcp_ipv4 module to configure an ipv4 impl with dhcp.
Disambiguate between the two ipv4 modules by calling the static one
ipv4_keyed_conf (because it's configured through the key system) instead
of ipv4_conf .  generic_stack will now choose between a keyed
configuration and a DHCP-based one depending on the value of the `dhcp`
key.
* change the "network" key, defining which interface a V1_LWT.NETIF
  should attempt to attach to, to "interface".
* changing V1_LWT.IPV4's prefix type to Ipaddr.V4.Prefix.t,
  addressing a longstanding FIXME.  Ipaddr.V4.Prefix.t defines a
  network, not just a netmask, so change this name and provide the
  expected converters.
* removing the ip_config type, which was a GADT over ipv4 and ipv6.
  This forced ipv4 and ipv6 configurations to assume that the same
  number of addresses, netmasks, or gateways were reasonable, which is
  not the case; see #557
* creating an ipv6_config record type (and associated Mirage_key
  functions) that stores lists of addresses, netmasks, and gateways
* creating an ipv4_config record type (and associated Mirage_key
  functions) that stores only a single address, netmask, and gateway
* exposing both ipv4_config and ipv6_config in V1_LWT
* removing the netmask and gateway getter/setter functions from the
  module type IP.  ipv4 will expect to get this information either via a
  DHCP lease or at connect time via keys, and ipv6 largely determines it
  dynamically.
* removing direct_stack_config, as the stack should receive a configured
  ipv4 argument (whether via DHCP or static configuration isn't the
  stack's concern)
* putting the default values for statically-configured ipv4 modules into
  mirage_key, where they can be nicely exposed to the user via help.
* removing direct_stackv4_with_default_ip, direct_stackv4_with_dhcp, and
  direct_stackv4_with_static_ipv4.  Instead, let functoria figure out
  which implementation should be used based on the keys supplied and
  reasonable defaults via the function direct_stackv4, which requires
  more arguments -- network, ethernet, arpv4, and ipv4, rather than just
  network.
* requiring network, ethernet, and arp implementations as arguments to
  create_ipv4 instead of just a network implementation.  Doing so means
  that an ipv4 implementation can be configured and then handed off to
  stackv4.