### PR TITLE
add missing } to `connect` code generation for socket stack

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -852,7 +852,7 @@ let stackv4_socket_conf ?(group="") interfaces = impl @@ object
         Fmt.strf
           "let config =@[@ \
            { V1_LWT.name = %S;@ \
-           interface = %a ;@] in@ \
+           interface = %a ;}@] in@ \
            %s.connect config %s %s"
           name
           pp_key interfaces


### PR DESCRIPTION
Without this change, attempting to build stacks with `--net=socket` generates a broken `main.ml`.