### PR TITLE
Use both lib/ and share/ for PKG_CONFIG_PATH

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1395,10 +1395,13 @@ let rec expand_name ~lib param =
 
 (* Invoke pkg-config and return output if successful. *)
 let pkg_config pkgs args =
-  match Cmd.read "PKG_CONFIG_PATH=$(opam config var lib)/pkgconfig \
-    pkg-config %s %s" pkgs args with
-  | Ok s -> String.trim s
+  match Cmd.read "opam config var prefix" with
   | Error e -> failwith e
+  | Ok prefix ->
+    match Cmd.read "PKG_CONFIG_PATH=%s/lib/pkgconfig:%s/share/pkgconfig \
+                    pkg-config %s %s" prefix prefix pkgs args with
+    | Ok s -> String.trim s
+    | Error e -> failwith e
 
 (* Get the linker flags for any extra C objects we depend on.
  * This is needed when building a Xen/Solo5 image as we do the link manually. *)


### PR DESCRIPTION
Thanks to @mato investigation [in mirage-solo5](https://github.com/mirage/mirage-solo5/pull/15), pc files should be installed into `share/pkgconfig` rather than `lib/pkgconfig` (which is not possible with `.install` files, but only with shell scripts and hacks).

The `lib/pkgconfig` path was hardcoded by several opam packages:
- [ ] https://github.com/mirage/mirage-solo5/pull/15 https://github.com/mato/mirage-solo5/pull/1
- [ ] https://github.com/mirage/ocaml-freestanding/pull/13
- [ ] https://github.com/Solo5/solo5/pull/122
- [x] https://github.com/pqwy/ocb-stubblr/pull/6
- [ ] https://github.com/talex5/mini-os/pull/2
- [ ] https://github.com/mirage/mirage-xen-minios/pull/21
- [ ] https://github.com/mirage/mirage-platform/pull/176
- [ ] https://github.com/mirage/mirage-dev/pull/210 (including: minios-xen, mirage-xen-minios, gmp-xen, gmp-freestanding, ocb-stubblr, mirage-xen-posix)

The xen part (minios-xen or mirage-xen-minios) somewhat breaks, and I cannot get much debug information from travis... someone with a test setup please test and fix it, should be straightforward.

A mirage-dev travis run with working unix + solo5 builds is available at https://github.com/mirage/mirage-dev/pull/209

Update: none of the PRs needs to be merged, ocb-stubblr and this PR here now use both `share/pkgconfig` and `lib/pkgconfig` as search PATH.