### PR TITLE
docs: change the base to an Ubuntu 16.04 build

### DIFF
--- a/Dockerfile.doc
+++ b/Dockerfile.doc
@@ -1,4 +1,4 @@
-FROM ocaml/opam:debian-stable_ocaml-4.03.0
+FROM ocaml/opam:ubuntu-16.04_ocaml-4.03.0
 RUN cd /home/opam/opam-repository && git pull origin master && opam update
 RUN opam remote add mirage-dev https://github.com/mirage/mirage-dev.git
 RUN opam pin add -n odig https://github.com/dbuenzli/odig.git


### PR DESCRIPTION
This gives us a more modern depext base (e.g. for gsl).  I'll
eventually make it work on Debian Stable and Alpine, but there
are a few blocking packages there.