### PR TITLE
pass MODE to container when testing

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,4 +1,3 @@
 eval `opam config env`
-rm -rf mirage-skeleton
 git clone -b mirage-dev https://github.com/mirage/mirage-skeleton.git
-make -C mirage-skeleton
+make -C mirage-skeleton && rm -rf mirage-skeleton

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,7 +1,4 @@
-opam depext -uiy mirage
-git clone -b mirage-dev https://github.com/mirage/mirage-skeleton.git
-cd mirage-skeleton
 eval `opam config env`
-find . -name _build | xargs rm -rf
-find . -name _build-ukvm | xargs rm -rf
-make
+rm -rf mirage-skeleton
+git clone -b mirage-dev https://github.com/mirage/mirage-skeleton.git
+make -C mirage-skeleton

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -3,4 +3,5 @@ git clone -b mirage-dev https://github.com/mirage/mirage-skeleton.git
 cd mirage-skeleton
 eval `opam config env`
 find . -name _build | xargs rm -rf
+find . -name _build-ukvm | xargs rm -rf
 make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 install: wget https://raw.githubusercontent.com/yomimono/ocaml-ci-scripts/pass-mode/.travis-docker.sh
 script: bash -ex .travis-docker.sh
+sudo: required
 services:
   - docker
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+install: wget https://raw.githubusercontent.com/yomimono/ocaml-ci-scripts/pass-mode/.travis-docker.sh
 script: bash -ex .travis-docker.sh
 services:
   - docker


### PR DESCRIPTION
In the mainline `.travis-docker.sh`, the `MODE` environment variable isn't passed to the container which runs the tests, resulting in `make` in `mirage-skeleton` defaulting to `unix`.  (See https://github.com/ocaml/ocaml-ci-scripts/issues/136 .)  Use a branch which passes `MODE` to the container.