### PR TITLE
restore opam depext to travis-ci.sh

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,3 +1,4 @@
 eval `opam config env`
+opam depext -uiy mirage
 git clone -b mirage-dev https://github.com/mirage/mirage-skeleton.git
 make -C mirage-skeleton && rm -rf mirage-skeleton


### PR DESCRIPTION
`mirage-types` tests still fail, but it's a real failure rather than a spurious one (no `tls.mirage`).