### PR TITLE
re-apply 077d852ef14cc5e00620a22a16b75f1152761f22, lost during qubes merge

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1054,8 +1054,9 @@ let resolver_unix_system = impl @@ object
     method name = "resolver_unix"
     method module_name = "Resolver_lwt"
     method packages =
-      Key.(if_ is_unix) ["mirage-conduit" ]
-      (failwith "Resolver_unix not supported on unikernel")
+      Key.match_ Key.(value target) @@ function
+      | `Unix | `MacOSX -> ["mirage-conduit" ]
+      | _ -> failwith "Resolver_unix not supported on unikernel"
     method libraries = Key.pure [ "conduit.mirage"; "conduit.lwt-unix" ]
     method connect _ _modname _ = "Lwt.return Resolver_lwt_unix.system"
   end

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1639,8 +1639,7 @@ let configure_makefile ~target ~root ~name ~warn_error info =
   let pkg_config_deps =
     match target with
     | `Xen | `Qubes -> "mirage-xen"
-    | `Virtio -> "mirage-solo5 ocaml-freestanding"
-    | `Ukvm -> "mirage-solo5 ocaml-freestanding"
+    | `Virtio | `Ukvm -> "mirage-solo5"
     | `MacOSX | `Unix -> ""
   in
   let extra_ld_flags archives =

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -126,11 +126,6 @@ let target =
   let key = Arg.opt ~stage:`Configure conv default doc in
   Key.create "target" key
 
-let is_xen =
-  Key.match_ Key.(value target) @@ function
-  | `Xen | `Qubes -> true
-  | `Unix | `MacOSX | `Virtio | `Ukvm -> false
-
 let is_unix =
   Key.match_ Key.(value target) @@ function
   | `Unix | `MacOSX -> true

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -42,9 +42,6 @@ val target: mode key
 val pp_target: mode Fmt.t
 (** Pretty printer for the mode. *)
 
-val is_xen: bool value
-(** Is true iff the {!target} keys takes the value [`Xen]. *)
-
 val is_unix: bool value
 (** Is true iff the {!target} key is a UNIXish system (["unix" or "macosx"]).
 *)


### PR DESCRIPTION
I looked through a7cff94d354af6c0824f02a34718000369fd09d9 -- looks good otherwise (I couldn't find any other unintended merges)