### PR TITLE
add result types for FLOW & most `write`-like functions in networking components

### DIFF
--- a/lib_runtime/mirage_pp.ml
+++ b/lib_runtime/mirage_pp.ml
@@ -1,8 +1,37 @@
-
 let pp_console_error pp = function
   | `Invalid_console str -> Format.fprintf pp "invalid console %s" str
 
+let unspecified pp m = Format.fprintf pp "unspecified error - %s" m
+
 let pp_network_error pp = function
-  | `Msg message     -> Format.fprintf pp "unspecified error - %s" message
-  | `Unimplemented   -> Format.fprintf pp "operation not yet implemented"
-  | `Disconnected    -> Format.fprintf pp "device is disconnected"
+  | `Msg message   -> unspecified pp message
+  | `Unimplemented -> Format.fprintf pp "operation not yet implemented"
+  | `Disconnected  -> Format.fprintf pp "device is disconnected"
+
+let pp_ethif_error = pp_network_error
+
+let pp_ip_error = pp_ethif_error
+
+let pp_icmp_error pp = function
+  | `Msg message   -> unspecified pp message
+  | `Routing message -> Format.fprintf pp "routing error: %s" message
+
+let pp_udp_error pp (`Msg message) = unspecified pp message
+
+let pp_tcp_error pp = function
+  | `Msg message   -> unspecified pp message
+  | `Timeout       -> Format.fprintf pp "connection attempt timed out"
+  | `Refused       -> Format.fprintf pp "connection attempt was refused"
+
+let pp_flow_error pp = function
+  | `Msg message   -> unspecified pp message
+
+let pp_flow_write_error pp = function
+  | `Msg message   -> unspecified pp message
+  | `Closed        -> Format.fprintf pp "attempted to write to a closed flow"
+
+let reduce = function
+  | Ok () -> Ok ()
+  | Error (`Msg _) as e -> e
+  | Error `Unimplemented -> Error (`Msg "unimplemented functionality discovered")
+  | Error `Disconnected -> Error (`Msg "a required device was disconnected")

--- a/lib_runtime/mirage_pp.ml
+++ b/lib_runtime/mirage_pp.ml
@@ -3,6 +3,6 @@ let pp_console_error pp = function
   | `Invalid_console str -> Format.fprintf pp "invalid console %s" str
 
 let pp_network_error pp = function
-  | `Unknown message -> Format.fprintf pp "undiagnosed error - %s" message
+  | `Msg message     -> Format.fprintf pp "unspecified error - %s" message
   | `Unimplemented   -> Format.fprintf pp "operation not yet implemented"
   | `Disconnected    -> Format.fprintf pp "device is disconnected"

--- a/lib_runtime/mirage_pp.mli
+++ b/lib_runtime/mirage_pp.mli
@@ -3,3 +3,12 @@ open V1
 val pp_console_error: Format.formatter -> Console.error -> unit
 
 val pp_network_error: Format.formatter -> Network.error -> unit
+val pp_ethif_error  : Format.formatter -> Ethif.error -> unit
+val pp_ip_error     : Format.formatter -> Ip.error -> unit
+val pp_icmp_error   : Format.formatter -> Icmp.error -> unit
+val pp_udp_error    : Format.formatter -> Udp.error -> unit
+val pp_tcp_error    : Format.formatter -> Tcp.error -> unit
+val pp_flow_error   : Format.formatter -> Flow.error -> unit
+val pp_flow_write_error : Format.formatter -> Flow.write_error -> unit
+
+val reduce : (unit, [`Msg of string | `Unimplemented | `Disconnected]) result -> (unit, [> `Msg of string]) result

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -306,7 +306,7 @@ end
 
 module Network : sig
   type error = [
-    | `Unknown of string (** an undiagnosed error *)
+    | `Msg of string     (** an unspecified error *)
     | `Unimplemented     (** operation not yet implemented in the code *)
     | `Disconnected      (** the device has been previously disconnected *)
   ]


### PR DESCRIPTION
Confession: I'm not very happy with this PR, but it and the corresponding upstream universe at https://github.com/yomimono/mirage-dev/tree/higherlevel-error are probably the best I'm going to do without more outside input.  Things it does:

* continues the pattern set by @hannesm in the earlier work adding result types to `write` functions in the `NETWORK` module type for `ETHERNET`, `IP`, `ARP`, `ICMP`, `UDP`, and `TCP`.  `TCP.create_connection` also now returns a result type.  As in the earlier PR, error types are defined in `V1` and printers in `Mirage_pp`.
* refactors the `FLOW` module type to use result types for both `read` and `write`.

Things it doesn't do:
* anything with the storage stack
* provide nice combinators
* anything with `input` types

PRs for users of these interfaces:
- [ ] channel - https://github.com/mirage/mirage-channel/pull/13
- [ ] conduit - https://github.com/mirage/ocaml-conduit/pull/166
- [ ] dns - https://github.com/mirage/ocaml-dns/pull/108
- [ ] mirage-console - https://github.com/mirage/mirage-console/pull/51
- [ ] mirage-flow - https://github.com/mirage/mirage-flow/pull/21
- [ ] mirage-net-unix - https://github.com/mirage/mirage-net-unix/pull/32
- [ ] mirage-qubes - https://github.com/mirage/mirage-qubes/pull/4
- [ ] tcpip - https://github.com/mirage/mirage-tcpip/pull/267
- [ ] vchan - https://github.com/mirage/ocaml-vchan/pull/90

Packages that are known to be affected, but for which there is no PR yet:
* ocaml-tls