### PR TITLE
Do not use LD from pkg-config, but just the system one

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1632,13 +1632,6 @@ let configure_makefile ~target ~root ~name ~warn_error info =
               OPAM   = opam\n\n\
               export OPAMVERBOSE=1\n\
               export OPAMYES=1";
-  let ld = match target with
-   | `Ukvm -> pkg_config "solo5-kernel-ukvm" "--variable=ld"
-   | `Virtio -> pkg_config "solo5-kernel-virtio" "--variable=ld"
-   | `Xen | `Qubes | `MacOSX | `Unix -> "ld"
-  in
-  newline fmt;
-  append fmt "LD=%s" ld;
   newline fmt;
   let pkg_config_deps =
     match target with


### PR DESCRIPTION
This hack was needed at some time on FreeBSD, but is no longer -- cleaning up

This complements https://github.com/Solo5/solo5/pull/123 waiting for @mato