### PR TITLE
Restore 4.02 compilation of the runtime library

### DIFF
--- a/lib_runtime/mirage_pp.mli
+++ b/lib_runtime/mirage_pp.mli
@@ -11,4 +11,4 @@ val pp_tcp_error    : Format.formatter -> Tcp.error -> unit
 val pp_flow_error   : Format.formatter -> Flow.error -> unit
 val pp_flow_write_error : Format.formatter -> Flow.write_error -> unit
 
-val reduce : (unit, [`Msg of string | `Unimplemented | `Disconnected]) result -> (unit, [> `Msg of string]) result
+val reduce : (unit, [`Msg of string | `Unimplemented | `Disconnected]) Result.result -> (unit, [> `Msg of string]) Result.result


### PR DESCRIPTION
While we do not normally support OCaml 4.02 in Mirage, this is
a fairly easy change to make to maintain compilation support
vi using `Result.result` instead of `result`.