### PR TITLE
[WIP] Refactor CHANNEL types to be exception-less and use `result`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-install: wget https://raw.githubusercontent.com/yomimono/ocaml-ci-scripts/pass-mode/.travis-docker.sh
+install: wget https://raw.githubusercontent.com/avsm/ocaml-ci-scripts/extra-env/.travis-docker.sh
 script: bash -ex .travis-docker.sh
 sudo: required
 services:
@@ -11,15 +11,15 @@ env:
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="sh ./.travis-ci.sh"
  matrix:
-   - PACKAGE=mirage-types DISTRO=debian-testing OCAML_VERSION=4.03.0 MODE=unix
-   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.03.0 MODE=xen
-   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.03.0 MODE=ukvm
-   - PACKAGE=mirage DISTRO=debian-unstable OCAML_VERSION=4.03.0 MODE=virtio
-   - PACKAGE=mirage-types DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0 MODE=unix
-   - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0 MODE=virtio
-   - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.03.0 MODE=xen
-   - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.03.0 MODE=ukvm
-   - PACKAGE=mirage-types DISTRO=ubuntu-16.04 OCAML_VERSION=4.04.0 MODE=unix
-   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.04.0 MODE=xen
-   - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.04.0 MODE=ukvm
-   - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.04.0 MODE=virtio
+   - PACKAGE=mirage-types DISTRO=debian-testing OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=unix"
+   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=xen"
+   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=ukvm"
+   - PACKAGE=mirage DISTRO=debian-unstable OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=virtio"
+   - PACKAGE=mirage-types DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=unix"
+   - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=virtio"
+   - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=xen"
+   - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=ukvm"
+   - PACKAGE=mirage-types DISTRO=ubuntu-16.04 OCAML_VERSION=4.04.0 EXTRA_ENV="MODE=unix"
+   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.04.0 EXTRA_ENV="MODE=xen"
+   - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.04.0 EXTRA_ENV="MODE=ukvm"
+   - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.04.0 EXTRA_ENV="MODE=virtio"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
    - EXTRA_REMOTES="git://github.com/mirage/mirage-dev.git"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="sh ./.travis-ci.sh"
+   - PINS="mirage-types:https://github.com/avsm/mirage.git#channel-result mirage-channel:https://github.com/avsm/mirage-channel.git#channel-result mirage-http:https://github.com/avsm/mirage-http.git"
+
  matrix:
    - PACKAGE=mirage-types DISTRO=debian-testing OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=unix"
    - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=xen"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
    - EXTRA_REMOTES="git://github.com/mirage/mirage-dev.git"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="sh ./.travis-ci.sh"
-   - PINS="mirage-types:https://github.com/avsm/mirage.git#channel-result mirage-channel:https://github.com/avsm/mirage-channel.git#channel-result mirage-http:https://github.com/avsm/mirage-http.git"
-
  matrix:
    - PACKAGE=mirage-types DISTRO=debian-testing OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=unix"
    - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=xen"

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -156,14 +156,14 @@ end
 module type FLOW = sig
 
   type +'a io
-  (** The type for potentially blocking I/O operation *)
+  (** The type for potentially blocking I/O operations. *)
 
   type buffer
   (** The type for memory buffer. *)
 
   type flow
   (** The type for flows. A flow represents the state of a single
-      stream that is connected to an endpoint. *)
+      reliable stream that is connected to an endpoint. *)
 
   val read: flow -> (buffer Flow.or_eof, Flow.error) result io
   (** [read flow] blocks until some data is available and returns a

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -144,6 +144,10 @@ module Flow : sig
     | `Closed
     | `Msg of string
   ]
+  type 'a or_eof = [
+    | `Data of 'a
+    | `Eof
+  ]
 end
 
 (** {1 Connection between endpoints} *)
@@ -159,7 +163,7 @@ module type FLOW = sig
   (** The type for flows. A flow represents the state of a single
       stream that is connected to an endpoint. *)
 
-  val read: flow -> ([`Data of buffer | `Eof ], Flow.error) result io
+  val read: flow -> (buffer Flow.or_eof, Flow.error) result io
   (** [read flow] blocks until some data is available and returns a
       fresh buffer containing it.
 
@@ -835,21 +839,21 @@ module type CHANNEL = sig
   val to_flow: t -> flow
   (** [to_flow t] returns the flow that backs this channel. *)
 
-  val read_char: t -> ([> `Data of char | `Eof ], [`Msg of string]) result io
+  val read_char: t -> (char Flow.or_eof, Flow.error) result io
   (** Reads a single character from the channel, blocking if there is
       no immediately available input data. *)
 
-  val read_some: ?len:int -> t -> ([> `Data of buffer | `Eof ], [> `Msg of string ]) result io
+  val read_some: ?len:int -> t -> (buffer Flow.or_eof, Flow.error) result io
   (** [read_some ?len t] reads up to [len] characters from the
       input channel and at most a full [buffer]. If [len] is not
       specified, it reads all available data and return that
       buffer. *)
 
-  val read_exactly: len:int -> t -> ([> `Data of buffer list | `Eof ], Flow.error) result io
+  val read_exactly: len:int -> t -> (buffer list Flow.or_eof, Flow.error) result io
   (** [read_exactly len t] reads [len] bytes from the channel [t] or fails
       with [Eof]. *)
 
-  val read_line: t -> ([> `Data of buffer list | `Eof ], [> `Msg of string ]) result io
+  val read_line: t -> (buffer list Flow.or_eof, Flow.error) result io
   (** [read_line t] reads a line of input, which is terminated
       either by a CRLF sequence, or the end of the channel (which
       counts as a line).  @return Returns a list of views that

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -28,8 +28,10 @@ open Result
     {ul
     {- errors which application programmers are expected to handle
        (e.g. connection refused or end of file) are encoded as result types
-       where [`Ok x] means the operation was succesful and returns [x] and
-       where [`Error e] means the operation has failed with error [e]. }
+       where [Ok x] means the operation was succesful and returns [x] and
+       where [Error e] means the operation has failed with error [e].
+       The error [e] uses the {!Rresult.R.msg} type for the most general
+       error message, and possibly more specific ones depending on the interface. }
     {- errors which represent programming errors such as assertion failures
        or illegal arguments are encoded as exceptions. The application may
        attempt to catch exceptions and recover or simply let the exception
@@ -846,7 +848,7 @@ module type CHANNEL = sig
   val read_some: ?len:int -> t -> (buffer Flow.or_eof, Flow.error) result io
   (** [read_some ?len t] reads up to [len] characters from the
       input channel and at most a full [buffer]. If [len] is not
-      specified, it reads all available data and return that
+      specified, it reads all available data and returns that
       buffer. *)
 
   val read_exactly: len:int -> t -> (buffer list Flow.or_eof, Flow.error) result io

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -828,9 +828,6 @@ module type CHANNEL = sig
   type +'a io
   (** The type for potentially blocking I/O operation *)
 
-  type 'a io_stream
-  (** The type for potentially blocking stream of IO requests. *)
-
   val create: flow -> t
   (** [create flow] allocates send and receive buffers and
       associates them with the given unbuffered [flow]. *)
@@ -838,31 +835,21 @@ module type CHANNEL = sig
   val to_flow: t -> flow
   (** [to_flow t] returns the flow that backs this channel. *)
 
-  val read_char: t -> char io
+  val read_char: t -> ([> `Data of char | `Eof ], [`Msg of string]) result io
   (** Reads a single character from the channel, blocking if there is
       no immediately available input data. *)
 
-  val read_until: t -> char -> (bool * buffer) io
-  (** [read_until t ch] reads from the channel until the given
-      [ch] character is found.  It returns a tuple indicating whether
-      the character was found at all ([false] indicates that an EOF
-      condition occurred before the character was encountered), and
-      the [buffer] pointing to the position immediately after the
-      character (or the complete scanned buffer if the character was
-      never encountered). *)
-
-  val read_some: ?len:int -> t -> buffer io
+  val read_some: ?len:int -> t -> ([> `Data of buffer | `Eof ], [> `Msg of string ]) result io
   (** [read_some ?len t] reads up to [len] characters from the
       input channel and at most a full [buffer]. If [len] is not
       specified, it reads all available data and return that
       buffer. *)
 
-  val read_stream: ?len:int -> t -> buffer io_stream
-  (** [read_stream ?len t] returns up to [len] characters as a
-      stream of buffers. This call will probably be removed in a
-      future revision of the API in favour of {!read_some}. *)
+  val read_exactly: len:int -> t -> ([> `Data of buffer list | `Eof ], Flow.error) result io
+  (** [read_exactly len t] reads [len] bytes from the channel [t] or fails
+      with [Eof]. *)
 
-  val read_line: t -> buffer list io
+  val read_line: t -> ([> `Data of buffer list | `Eof ], [> `Msg of string ]) result io
   (** [read_line t] reads a line of input, which is terminated
       either by a CRLF sequence, or the end of the channel (which
       counts as a line).  @return Returns a list of views that
@@ -886,11 +873,11 @@ module type CHANNEL = sig
   (** [write_line t buf] writes the string [buf] to the output
       channel and append a newline character afterwards. *)
 
-  val flush: t -> unit io
+  val flush: t -> (unit, Flow.write_error) result io
   (** [flush t] flushes the output buffer and block if necessary
       until it is all written out to the flow. *)
 
-  val close: t -> unit io
+  val close: t -> (unit, Flow.write_error) result io
   (** [close t] calls {!flush} and then close the underlying
       flow. *)
 

--- a/types/V1_LWT.mli
+++ b/types/V1_LWT.mli
@@ -120,7 +120,6 @@ module type TCPV6 = TCP
 (** Buffered TCP channel *)
 module type CHANNEL = CHANNEL
   with type 'a io = 'a Lwt.t
-   and type 'a io_stream = 'a Lwt_stream.t
    and type buffer = Cstruct.t
 
 (** KV RO *)


### PR DESCRIPTION
Changes:
- remove `read_stream` and `io_stream` as Lwt_stream is difficult to
  combine with error handling
- remove `read_until` and only expose the line handling functions.
  I'm also considering moving the line-handling functions into a
  separate signature since most consumers of CHANNEL only want the
  buffering logic.
- no more exceptions, just use `result` and propagate `FLOW.error`
  in return values.

Dependent PRs:
- [ ] mirage/mirage-channel#14
- [ ] mirage/mirage-http#30
- [x] yomimono/charrua-client#6
- [ ] mirage/ocaml-git#172