### PR TITLE
result-y FS, KV_RO, and BLOCK module types

### DIFF
--- a/lib_runtime/mirage_pp.ml
+++ b/lib_runtime/mirage_pp.ml
@@ -42,11 +42,14 @@ let pp_flow_write_error pp = function
   | `Closed        -> say pp "attempted to write to a closed flow"
 
 let pp_block_error pp = function
-  | `Msg message -> unspecified pp message
+  | `Msg message   -> unspecified pp message
   | `Unimplemented -> say pp "operation not yet implemented"
   | `Disconnected  -> say pp "a required device was disconnected"
 
 let pp_block_write_error pp = function
+  | `Msg message   -> unspecified pp message
+  | `Unimplemented -> say pp "operation not yet implemented"
+  | `Disconnected  -> say pp "a required device was disconnected"
   | `Is_read_only  -> say pp "attempted to write to a read-only disk"
 
 let reduce = function

--- a/lib_runtime/mirage_pp.ml
+++ b/lib_runtime/mirage_pp.ml
@@ -1,14 +1,15 @@
 open Result
+let say pp = Format.fprintf pp
 
 let pp_console_error pp = function
-  | `Invalid_console str -> Format.fprintf pp "invalid console %s" str
+  | `Invalid_console str -> say pp "invalid console %s" str
 
-let unspecified pp m = Format.fprintf pp "unspecified error - %s" m
+let unspecified pp m = say pp "unspecified error - %s" m
 
 let pp_network_error pp = function
   | `Msg message   -> unspecified pp message
-  | `Unimplemented -> Format.fprintf pp "operation not yet implemented"
-  | `Disconnected  -> Format.fprintf pp "device is disconnected"
+  | `Unimplemented -> say pp "operation not yet implemented"
+  | `Disconnected  -> say pp "device is disconnected"
 
 let pp_ethif_error = pp_network_error
 
@@ -24,21 +25,29 @@ let pp_ip_error pp = function
 
 let pp_icmp_error pp = function
   | `Msg message   -> unspecified pp message
-  | `Routing message -> Format.fprintf pp "routing error: %s" message
+  | `Routing message -> say pp "routing error: %s" message
 
 let pp_udp_error pp (`Msg message) = unspecified pp message
 
 let pp_tcp_error pp = function
   | `Msg message   -> unspecified pp message
-  | `Timeout       -> Format.fprintf pp "connection attempt timed out"
-  | `Refused       -> Format.fprintf pp "connection attempt was refused"
+  | `Timeout       -> say pp "connection attempt timed out"
+  | `Refused       -> say pp "connection attempt was refused"
 
 let pp_flow_error pp = function
   | `Msg message   -> unspecified pp message
 
 let pp_flow_write_error pp = function
   | `Msg message   -> unspecified pp message
-  | `Closed        -> Format.fprintf pp "attempted to write to a closed flow"
+  | `Closed        -> say pp "attempted to write to a closed flow"
+
+let pp_block_error pp = function
+  | `Msg message -> unspecified pp message
+  | `Unimplemented -> say pp "operation not yet implemented"
+  | `Disconnected  -> say pp "a required device was disconnected"
+
+let pp_block_write_error pp = function
+  | `Is_read_only  -> say pp "attempted to write to a read-only disk"
 
 let reduce = function
   | Ok () -> Ok ()

--- a/lib_runtime/mirage_pp.ml
+++ b/lib_runtime/mirage_pp.ml
@@ -52,6 +52,26 @@ let pp_block_write_error pp = function
   | `Disconnected  -> say pp "a required device was disconnected"
   | `Is_read_only  -> say pp "attempted to write to a read-only disk"
 
+let pp_fs_error pp = function
+    | `Msg message         -> unspecified pp message
+    | `Is_a_directory      -> say pp "is a directory"
+    | `Not_a_directory     -> say pp "is not a directory"
+    | `No_directory_entry  -> say pp "a directory in the path does not exist"
+    | `Format_unknown      -> say pp "the device is not formatted for this filesystem"
+
+let pp_fs_write_error pp = function
+  | `Msg message         -> unspecified pp message
+  | `Is_a_directory      -> say pp "is a directory"
+  | `Not_a_directory     -> say pp "is not a directory"
+  | `Directory_not_empty -> say pp "directory is not empty"
+  | `No_directory_entry  -> say pp "a directory in the path does not exist"
+  | `File_already_exists -> say pp "file already exists"
+  | `No_space            -> say pp "device has no more free space"
+
+let pp_kv_ro_error pp = function
+  | `Msg message   -> unspecified pp message
+  | `Unknown_key   -> say pp "key not present in the store"
+
 let reduce = function
   | Ok () -> Ok ()
   | Error (`Msg _) as e -> e

--- a/lib_runtime/mirage_pp.ml
+++ b/lib_runtime/mirage_pp.ml
@@ -1,15 +1,15 @@
 open Result
-let say pp = Format.fprintf pp
+let pf pp = Format.fprintf pp
 
 let pp_console_error pp = function
-  | `Invalid_console str -> say pp "invalid console %s" str
+  | `Invalid_console str -> pf pp "invalid console %s" str
 
-let unspecified pp m = say pp "unspecified error - %s" m
+let unspecified pp m = pf pp "unspecified error - %s" m
 
 let pp_network_error pp = function
   | `Msg message   -> unspecified pp message
-  | `Unimplemented -> say pp "operation not yet implemented"
-  | `Disconnected  -> say pp "device is disconnected"
+  | `Unimplemented -> pf pp "operation not yet implemented"
+  | `Disconnected  -> pf pp "device is disconnected"
 
 let pp_ethif_error = pp_network_error
 
@@ -25,52 +25,52 @@ let pp_ip_error pp = function
 
 let pp_icmp_error pp = function
   | `Msg message   -> unspecified pp message
-  | `Routing message -> say pp "routing error: %s" message
+  | `Routing message -> pf pp "routing error: %s" message
 
 let pp_udp_error pp (`Msg message) = unspecified pp message
 
 let pp_tcp_error pp = function
   | `Msg message   -> unspecified pp message
-  | `Timeout       -> say pp "connection attempt timed out"
-  | `Refused       -> say pp "connection attempt was refused"
+  | `Timeout       -> pf pp "connection attempt timed out"
+  | `Refused       -> pf pp "connection attempt was refused"
 
 let pp_flow_error pp = function
   | `Msg message   -> unspecified pp message
 
 let pp_flow_write_error pp = function
   | `Msg message   -> unspecified pp message
-  | `Closed        -> say pp "attempted to write to a closed flow"
+  | `Closed        -> pf pp "attempted to write to a closed flow"
 
 let pp_block_error pp = function
   | `Msg message   -> unspecified pp message
-  | `Unimplemented -> say pp "operation not yet implemented"
-  | `Disconnected  -> say pp "a required device was disconnected"
+  | `Unimplemented -> pf pp "operation not yet implemented"
+  | `Disconnected  -> pf pp "a required device was disconnected"
 
 let pp_block_write_error pp = function
   | `Msg message   -> unspecified pp message
-  | `Unimplemented -> say pp "operation not yet implemented"
-  | `Disconnected  -> say pp "a required device was disconnected"
-  | `Is_read_only  -> say pp "attempted to write to a read-only disk"
+  | `Unimplemented -> pf pp "operation not yet implemented"
+  | `Disconnected  -> pf pp "a required device was disconnected"
+  | `Is_read_only  -> pf pp "attempted to write to a read-only disk"
 
 let pp_fs_error pp = function
     | `Msg message         -> unspecified pp message
-    | `Is_a_directory      -> say pp "is a directory"
-    | `Not_a_directory     -> say pp "is not a directory"
-    | `No_directory_entry  -> say pp "a directory in the path does not exist"
-    | `Format_unknown      -> say pp "the device is not formatted for this filesystem"
+    | `Is_a_directory      -> pf pp "is a directory"
+    | `Not_a_directory     -> pf pp "is not a directory"
+    | `No_directory_entry  -> pf pp "a directory in the path does not exist"
+    | `Format_unknown      -> pf pp "the device is not formatted for this filesystem"
 
 let pp_fs_write_error pp = function
   | `Msg message         -> unspecified pp message
-  | `Is_a_directory      -> say pp "is a directory"
-  | `Not_a_directory     -> say pp "is not a directory"
-  | `Directory_not_empty -> say pp "directory is not empty"
-  | `No_directory_entry  -> say pp "a directory in the path does not exist"
-  | `File_already_exists -> say pp "file already exists"
-  | `No_space            -> say pp "device has no more free space"
+  | `Is_a_directory      -> pf pp "is a directory"
+  | `Not_a_directory     -> pf pp "is not a directory"
+  | `Directory_not_empty -> pf pp "directory is not empty"
+  | `No_directory_entry  -> pf pp "a directory in the path does not exist"
+  | `File_already_exists -> pf pp "file already exists"
+  | `No_space            -> pf pp "device has no more free space"
 
 let pp_kv_ro_error pp = function
   | `Msg message   -> unspecified pp message
-  | `Unknown_key   -> say pp "key not present in the store"
+  | `Unknown_key   -> pf pp "key not present in the store"
 
 let reduce = function
   | Ok () -> Ok ()

--- a/lib_runtime/mirage_pp.mli
+++ b/lib_runtime/mirage_pp.mli
@@ -9,10 +9,16 @@ val pp_ip_error     : Format.formatter -> Ip.error -> unit
 val pp_icmp_error   : Format.formatter -> Icmp.error -> unit
 val pp_udp_error    : Format.formatter -> Udp.error -> unit
 val pp_tcp_error    : Format.formatter -> Tcp.error -> unit
+
 val pp_flow_error   : Format.formatter -> Flow.error -> unit
 val pp_flow_write_error : Format.formatter -> Flow.write_error -> unit
 
 val pp_block_error  : Format.formatter -> Block.error -> unit
 val pp_block_write_error  : Format.formatter -> Block.write_error -> unit
+
+val pp_fs_error     : Format.formatter -> Fs.error -> unit
+val pp_fs_write_error : Format.formatter -> Fs.write_error -> unit
+
+val pp_kv_ro_error  : Format.formatter -> Kv_ro.error -> unit
 
 val reduce : (unit, [`Msg of string | `Unimplemented | `Disconnected]) Result.result -> (unit, [> `Msg of string]) Result.result

--- a/lib_runtime/mirage_pp.mli
+++ b/lib_runtime/mirage_pp.mli
@@ -13,5 +13,6 @@ val pp_flow_error   : Format.formatter -> Flow.error -> unit
 val pp_flow_write_error : Format.formatter -> Flow.write_error -> unit
 
 val pp_block_error  : Format.formatter -> Block.error -> unit
+val pp_block_write_error  : Format.formatter -> Block.write_error -> unit
 
 val reduce : (unit, [`Msg of string | `Unimplemented | `Disconnected]) Result.result -> (unit, [> `Msg of string]) Result.result

--- a/lib_runtime/mirage_pp.mli
+++ b/lib_runtime/mirage_pp.mli
@@ -12,4 +12,6 @@ val pp_tcp_error    : Format.formatter -> Tcp.error -> unit
 val pp_flow_error   : Format.formatter -> Flow.error -> unit
 val pp_flow_write_error : Format.formatter -> Flow.write_error -> unit
 
+val pp_block_error  : Format.formatter -> Block.error -> unit
+
 val reduce : (unit, [`Msg of string | `Unimplemented | `Disconnected]) Result.result -> (unit, [> `Msg of string]) Result.result

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -901,24 +901,29 @@ module type CHANNEL = sig
 
 end
 
+module Fs : sig
+  type error = [
+    | `Msg of string
+    | `Is_a_directory      (** Cannot read or write the contents of a directory *)
+    | `No_directory_entry  (** Cannot find a directory entry *)
+    | `Not_a_directory     (** Cannot create a directory entry in a file *)
+    | `Format_unknown      (** The block device appears to not be formatted *)
+  ]
+  type write_error = [
+    | `Msg of string
+    | `Is_a_directory      (** Cannot read or write the contents of a directory *)
+    | `Not_a_directory     (** Cannot create a directory entry in a file *)
+    | `Directory_not_empty (** Cannot remove a non-empty directory *)
+    | `File_already_exists (** Cannot create a file with a duplicate name *)
+    | `No_directory_entry  (** Something in the path doesn't exist *)
+    | `No_space            (** No space left on the block device *)
+  ]
+end
+
 (** {1 Filesystem} *)
 module type FS = sig
 
-  type block_device_error
-  (** The type for errors from the block layer *)
-
-  type error = [
-    | `Not_a_directory of string             (** Cannot create a directory entry in a file *)
-    | `Is_a_directory of string              (** Cannot read or write the contents of a directory *)
-    | `Directory_not_empty of string         (** Cannot remove a non-empty directory *)
-    | `No_directory_entry of string * string (** Cannot find a directory entry *)
-    | `File_already_exists of string         (** Cannot create a file with a duplicate name *)
-    | `No_space                              (** No space left on the block device *)
-    | `Format_not_recognised of string       (** The block device appears to not be formatted *)
-    | `Unknown_error of string
-    | `Block_device of block_device_error
-  ]
-  (** The type for filesystem errors. *)
+  open Fs
 
   include DEVICE
     with type error := error
@@ -926,12 +931,12 @@ module type FS = sig
   type page_aligned_buffer
   (** The type for memory buffers. *)
 
-  val read: t -> string -> int -> int -> [ `Ok of page_aligned_buffer list | `Error of error ] io
+  val read: t -> string -> int -> int -> (page_aligned_buffer list, error) result io
   (** [read t key offset length] reads up to [length] bytes from the
       value associated with [key]. If less data is returned than
       requested, this indicates the end of the value. *)
 
-  val size: t -> string -> [`Error of error | `Ok of int64] io
+  val size: t -> string -> (int64, error) result io
   (** Get the value size. *)
 
   type stat = {
@@ -942,33 +947,33 @@ module type FS = sig
   }
   (** The type for Per-file/directory statistics. *)
 
-  val format: t -> int64 -> [ `Ok of unit | `Error of error ] io
+  val format: t -> int64 -> (unit, error) result io
   (** [format t size] erases the contents of [t] and creates an empty
       filesystem of size [size] bytes. *)
 
-  val create: t -> string -> [ `Ok of unit | `Error of error ] io
+  val create: t -> string -> (unit, write_error) result io
   (** [create t path] creates an empty file at [path]. If [path] contains
       directories that do not yet exist, [create] will attempt to create them. *)
 
-  val mkdir: t -> string -> [ `Ok of unit | `Error of error ] io
+  val mkdir: t -> string -> (unit, write_error) result io
   (** [mkdir t path] creates an empty directory at [path].  If [path] contains
       intermediate directories that do not yet exist, [mkdir] will create them.
       If a directory already exists at [path], [mkdir] returns [`Ok ()] and
       takes no action. *)
 
-  val destroy: t -> string -> [ `Ok of unit | `Error of error ] io
+  val destroy: t -> string -> (unit, write_error) result io
   (** [destroy t path] removes a [path] (which may be a file or an
       empty directory) on filesystem [t]. *)
 
-  val stat: t -> string -> [ `Ok of stat | `Error of error ] io
+  val stat: t -> string -> (stat, error) result io
   (** [stat t path] returns information about file or directory at
       [path]. *)
 
-  val listdir: t -> string -> [ `Ok of string list | `Error of error ] io
+  val listdir: t -> string -> (string list, error) result io
   (** [listdir t path] returns the names of files and subdirectories
       within the directory [path]. *)
 
-  val write: t -> string -> int -> page_aligned_buffer -> [ `Ok of unit | `Error of error ] io
+  val write: t -> string -> int -> page_aligned_buffer -> (unit, write_error) result io
   (** [write t path offset data] writes [data] at [offset] in file
       [path] on filesystem [t].
 
@@ -978,12 +983,16 @@ module type FS = sig
 
 end
 
+module Kv_ro : sig
+  type error =
+    [ `Unknown_key
+    | `Msg of string ]
+end
+
 (** {1 Static Key/value store} *)
 module type KV_RO = sig
 
-  type error =
-    | Unknown_key of string
-    | Failure of string
+  open Kv_ro
 
   include DEVICE
     with type error := error
@@ -991,15 +1000,15 @@ module type KV_RO = sig
   type page_aligned_buffer
   (** The type for memory buffers.*)
 
-  val read: t -> string -> int -> int -> [ `Ok of page_aligned_buffer list | `Error of error ] io
+  val read: t -> string -> int64 -> int64 -> (page_aligned_buffer list, error) result io
   (** [read t key offset length] reads up to [length] bytes from the
       value associated with [key]. If less data is returned than
       requested, this indicates the end of the value. *)
 
-  val mem: t -> string -> [ `Ok of bool | `Error of error ] io
+  val mem: t -> string -> (bool, error) result io
   (** [mem t key] returns [true] if a value is set for [key] in [t], and [false] if not so. *)
 
-  val size: t -> string -> [`Error of error | `Ok of int64] io
+  val size: t -> string -> (int64, error) result io
   (** Get the value size. *)
 
 end

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -242,12 +242,18 @@ end
 
 module Block : sig
   type error = [
-    | `Unknown of string (** an undiagnosed error *)
+    | `Msg of string     (** an unspecified error *)
     | `Unimplemented     (** operation not yet implemented in the code *)
-    | `Is_read_only      (** you cannot write to a read/only instance *)
     | `Disconnected      (** the device has been previously disconnected *)
   ]
   (** The type for IO operation errors. *)
+
+  type write_error = [
+    | `Msg of string     (** an unspecified error *)
+    | `Unimplemented     (** operation not yet implemented in the code *)
+    | `Disconnected      (** the device has been previously disconnected *)
+    | `Is_read_only      (** attempted to write to a read-only disk *)
+  ]
 end
 
 (** {1 Sector-addressible block devices}
@@ -275,14 +281,14 @@ module type BLOCK = sig
   val get_info: t -> info io
   (** Query the characteristics of a specific block device *)
 
-  val read: t -> int64 -> page_aligned_buffer list -> (unit, error) result io
+  val read: t -> int64 -> page_aligned_buffer list -> (unit, Block.error) result io
   (** [read device sector_start buffers] reads data starting at [sector_start]
       from the block device into [buffers]. [Ok ()] means the buffers have been filled.
       [Error _] indicates an I/O error has happened and some of the buffers may not be filled.
       Each of elements in the list [buffers] must be a whole number of sectors in length.
       The list of buffers can be of any length. *)
 
-  val write: t -> int64 -> page_aligned_buffer list -> (unit, error) result io
+  val write: t -> int64 -> page_aligned_buffer list -> (unit, Block.write_error) result io
   (** [write device sector_start buffers] writes data from [buffers]
       onto the block device starting at [sector_start].
       [Ok ()] means the contents of the buffers have been written.

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -240,6 +240,16 @@ module type CONSOLE = sig
   *)
 end
 
+module Block : sig
+  type error = [
+    | `Unknown of string (** an undiagnosed error *)
+    | `Unimplemented     (** operation not yet implemented in the code *)
+    | `Is_read_only      (** you cannot write to a read/only instance *)
+    | `Disconnected      (** the device has been previously disconnected *)
+  ]
+  (** The type for IO operation errors. *)
+end
+
 (** {1 Sector-addressible block devices}
 
     Operations on sector-addressible block devices, usually used
@@ -249,14 +259,7 @@ module type BLOCK = sig
   type page_aligned_buffer
   (** The type for page-aligned memory buffers. *)
 
-  type error = [
-    | `Unknown of string (** an undiagnosed error *)
-    | `Unimplemented     (** operation not yet implemented in the code *)
-    | `Is_read_only      (** you cannot write to a read/only instance *)
-    | `Disconnected      (** the device has been previously disconnected *)
-  ]
-  (** The type for IO operation errors. *)
-
+  type error = Block.error
 
   include DEVICE with
     type error := error

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -275,14 +275,14 @@ module type BLOCK = sig
   val get_info: t -> info io
   (** Query the characteristics of a specific block device *)
 
-  val read: t -> int64 -> page_aligned_buffer list -> [ `Error of error | `Ok of unit ] io
+  val read: t -> int64 -> page_aligned_buffer list -> (unit, error) result io
   (** [read device sector_start buffers] reads data starting at [sector_start]
       from the block device into [buffers]. [Ok ()] means the buffers have been filled.
       [Error _] indicates an I/O error has happened and some of the buffers may not be filled.
       Each of elements in the list [buffers] must be a whole number of sectors in length.
       The list of buffers can be of any length. *)
 
-  val write: t -> int64 -> page_aligned_buffer list -> [ `Error of error | `Ok of unit ] io
+  val write: t -> int64 -> page_aligned_buffer list -> (unit, error) result io
   (** [write device sector_start buffers] writes data from [buffers]
       onto the block device starting at [sector_start].
       [Ok ()] means the contents of the buffers have been written.


### PR DESCRIPTION
For a consistent (with the exception of `fat-filesystem`) universe, see https://github.com/yomimono/mirage-dev/tree/fs-errors .  To see a passing test, visit https://travis-ci.org/yomimono/mirage-dev/builds/179518397 .

A number of other PRs will need to be merged once this is:

- [ ] crunch https://github.com/mirage/ocaml-crunch/pull/27
- [ ] dns https://github.com/mirage/ocaml-dns/pull/111
- [ ] mirage-block-ccm https://github.com/sg2342/mirage-block-ccm/pull/16
- [ ] mirage-block-ramdisk https://github.com/mirage/mirage-block-ramdisk/pull/9
- [ ] mirage-block-solo5 https://github.com/mirage/mirage-block-solo5/pull/6
- [ ] mirage-block-unix https://github.com/mirage/mirage-block-unix/pull/57
- [ ] mirage-block-xen https://github.com/mirage/mirage-block-xen/pull/58
- [ ] mirage-block https://github.com/mirage/mirage-block/pull/20
- [ ] mirage-fs-unix https://github.com/mirage/mirage-fs-unix/pull/27
- [ ] shared-block-ring https://github.com/mirage/shared-block-ring/pull/49
- [ ] ocaml-tar https://github.com/mirage/ocaml-tar/pull/35
- [ ] tls
- [ ] mirage-skeleton https://github.com/mirage/mirage-skeleton/pull/201
