### PR TITLE
use a result type for arp query

### DIFF
--- a/lib_runtime/mirage_pp.ml
+++ b/lib_runtime/mirage_pp.ml
@@ -12,6 +12,9 @@ let pp_network_error pp = function
 
 let pp_ethif_error = pp_network_error
 
+let pp_arp_error pp = function
+  | `Timeout -> Format.fprintf pp "Dynamic ARP timed out"
+
 let pp_ip_error = pp_ethif_error
 
 let pp_icmp_error pp = function

--- a/lib_runtime/mirage_pp.mli
+++ b/lib_runtime/mirage_pp.mli
@@ -4,6 +4,7 @@ val pp_console_error: Format.formatter -> Console.error -> unit
 
 val pp_network_error: Format.formatter -> Network.error -> unit
 val pp_ethif_error  : Format.formatter -> Ethif.error -> unit
+val pp_arp_error    : Format.formatter -> Arp.error -> unit
 val pp_ip_error     : Format.formatter -> Ip.error -> unit
 val pp_icmp_error   : Format.formatter -> Icmp.error -> unit
 val pp_udp_error    : Format.formatter -> Udp.error -> unit

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -539,17 +539,19 @@ module type IP = sig
 
 end
 
+module Arp : sig
+  type error = [
+    `Timeout
+  ]
+end
+
 module type ARP = sig
-  include DEVICE
+  include DEVICE with type error := Arp.error
 
   type ipaddr
   type buffer
   type macaddr
   type repr
-
-  (** Type of the result of an ARP query.  One of `Ok macaddr (for successful
-      queries) or `Timeout (for attempted queries that received no response). *)
-  type result = [ `Ok of macaddr | `Timeout ]
 
   (** Prettyprint cache contents *)
   val to_repr : t -> repr io
@@ -575,7 +577,7 @@ module type ARP = sig
   (** [query arp ip] queries the cache in [arp] for an ARP entry
       corresponding to [ip], which may result in the sender sleeping
       waiting for a response. *)
-  val query : t -> ipaddr -> result io
+  val query : t -> ipaddr -> (macaddr, Arp.error) result io
 
   (** [input arp frame] will handle an ARP frame. If it is a response,
       it will update its cache, otherwise will try to satisfy the


### PR DESCRIPTION
Requires changes in `tcpip`, `arp`, and any other implementors of `V1.ARP`.