### PR TITLE
specify ipv4/netmask as one parameter in the "network" key.

### DIFF
--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -284,8 +284,7 @@ val ipv6: ipv6 typ
 (** The [V1.IPV6] module signature. *)
 
 type ipv4_config = {
-  address : Ipaddr.V4.t;
-  network : Ipaddr.V4.Prefix.t;
+  network : Ipaddr.V4.t * Ipaddr.V4.Prefix.t;
   gateway : Ipaddr.V4.t option;
 }
 (** Types for IPv4 manual configuration. *)

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -22,7 +22,7 @@ module Arg : sig
   include module type of struct include Functoria_key.Arg end
 
   val ipv4 : Ipaddr.V4.t converter
-  val ipv4_prefix : Ipaddr.V4.Prefix.t converter
+  val ipv4_network : (Ipaddr.V4.t * Ipaddr.V4.Prefix.t) converter
   val ipv6 : Ipaddr.V6.t converter
   val ipv6_prefix : Ipaddr.V6.Prefix.t converter
 
@@ -98,10 +98,7 @@ val interface : ?group:string -> string -> string key
 module V4 : sig
   open Ipaddr.V4
 
-  val ip : ?group:string -> t -> t key
-  (** An ip address. *)
-
-  val network : ?group:string -> Prefix.t -> Prefix.t key
+  val network : ?group:string -> (t * Prefix.t) -> (t * Prefix.t) key
   (** A network defined by an address and netmask. *)
 
   val gateway : ?group:string -> t option -> t option key

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -55,10 +55,10 @@ module Arg: sig
   (** [ip] converts IP address. *)
 
   val ipv4: Ipaddr.V4.t Cmdliner.Arg.converter
-  (** [ipv4] converts IPv4 address. *)
+  (** [ipv4] converts an IPv4 address. *)
 
-  val ipv4_prefix: Ipaddr.V4.Prefix.t Cmdliner.Arg.converter
-  (**[ipv4_prefix] converts IPv4 prefixes. *)
+  val ipv4_network: (Ipaddr.V4.t * Ipaddr.V4.Prefix.t) Cmdliner.Arg.converter
+  (** [ipv4] converts ipv4/netmask to Ipaddr.V4.t * Ipaddr.V4.Prefix.t . *)
 
   val ipv6: Ipaddr.V6.t Cmdliner.Arg.converter
   (** [ipv6]converts IPv6 address. *)


### PR DESCRIPTION
Fixes #649 .  I believe this behavior is nicer:

```
4.04.0🐫  ((detached from origin/mirage-dev)) mirageos:~/mirage-skeleton/network$ mirage clean && mirage configure --net=direct -t unix
# Detecting depexts using flags: x86_64 linux debian
# The following system packages are needed:
#  - debianutils
#  - m4
#  - ncurses-dev
#  - pkg-config
#  - time
# All required OS packages found.

=-=- Synchronising pinned packages =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[mirage-types] /home/user/mirage#ipv4-network-one-key updated
[mirage-types-lwt] /home/user/mirage#ipv4-network-one-key updated
[NOTE] Package functoria-runtime is already installed (current version is dev~mirage).
[NOTE] Package lwt is already installed (current version is 2.6.0).
[NOTE] Package mirage-clock-unix is already installed (current version is dev~mirage).
[NOTE] Package mirage-console-unix is already installed (current version is dev~mirage).
[NOTE] Package mirage-logs is already installed (current version is dev~mirage).
[NOTE] Package mirage-net-unix is already installed (current version is dev~mirage).
[NOTE] Package mirage-stdlib-random is already installed (current version is dev~mirage).
[NOTE] Package mirage-types is already installed (current version is dev~mirage).
[NOTE] Package mirage-types-lwt is already installed (current version is dev~mirage).
[NOTE] Package mirage-unix is already installed (current version is dev~mirage).
[NOTE] Package tcpip is already installed (current version is dev~mirage).
4.04.0🐫  ((detached from origin/mirage-dev)) mirageos:~/mirage-skeleton/network$ make
ocamlbuild -use-ocamlfind -tags "predicate(mirage_unix)" -pkgs functoria-runtime,mirage-clock-unix,mirage-console-unix,mirage-logs,mirage-net-unix,mirage-runtime,mirage-stdlib-random,mirage-types,mirage-types.lwt,mirage-unix,tcpip.arpv4,tcpip.ethif,tcpip.icmpv4,tcpip.ipv4,tcpip.stack-direct,tcpip.tcp,tcpip.udp -tags "warn(A-4-41-42-44),debug,bin_annot,strict_sequence,principal,safe_string" -tag-line "<static*.*>: warn(-32-34)" -r -cflag -g -lflags -g,-linkpkg main.native
Finished, 10 targets (0 cached) in 00:00:00.
ln -nfs _build/main.native mir-network
4.04.0🐫  ((detached from origin/mirage-dev)) mirageos:~/mirage-skeleton/network$ sudo ./mir-network
Netif: plugging into tap0 with mac ee:f5:0e:a7:5b:34
Netif: connect tap0
2016-11-29 09:39:25 -06:00: INF [ethif] Connected Ethernet interface ee:f5:0e:a7:5b:34
2016-11-29 09:39:25 -06:00: INF [arpv4] Connected arpv4 device on ee:f5:0e:a7:5b:34
2016-11-29 09:39:25 -06:00: INF [udp] UDP interface connected on 10.0.0.2
2016-11-29 09:39:25 -06:00: INF [tcpip-stack-direct] stack assembled: mac=ee:f5:0e:a7:5b:34,ip=10.0.0.2
^C4.04.0🐫  ((detached from origin/mirage-dev)) mirageos:~/mirage-skeleton/network$ sudo ./mir-network --network 192.168.3.10/24
Netif: plugging into tap0 with mac aa:2f:1b:89:ea:10
Netif: connect tap0
2016-11-29 09:39:33 -06:00: INF [ethif] Connected Ethernet interface aa:2f:1b:89:ea:10
2016-11-29 09:39:33 -06:00: INF [arpv4] Connected arpv4 device on aa:2f:1b:89:ea:10
2016-11-29 09:39:33 -06:00: INF [udp] UDP interface connected on 192.168.3.10
2016-11-29 09:39:33 -06:00: INF [tcpip-stack-direct] stack assembled: mac=aa:2f:1b:89:ea:10,ip=192.168.3.10
4.04.0🐫  ((detached from origin/mirage-dev)) mirageos:~/mirage-skeleton/network$ mirage clean && mirage configure --net=direct -t unix --network 192.168.3.10/24
# Detecting depexts using flags: x86_64 linux debian
# The following system packages are needed:
#  - debianutils
#  - m4
#  - ncurses-dev
#  - pkg-config
#  - time
# All required OS packages found.

=-=- Synchronising pinned packages =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[mirage-types] /home/user/mirage#ipv4-network-one-key already up-to-date
[mirage-types-lwt] /home/user/mirage#ipv4-network-one-key already up-to-date
[NOTE] Package functoria-runtime is already installed (current version is dev~mirage).
[NOTE] Package lwt is already installed (current version is 2.6.0).
[NOTE] Package mirage-clock-unix is already installed (current version is dev~mirage).
[NOTE] Package mirage-console-unix is already installed (current version is dev~mirage).
[NOTE] Package mirage-logs is already installed (current version is dev~mirage).
[NOTE] Package mirage-net-unix is already installed (current version is dev~mirage).
[NOTE] Package mirage-stdlib-random is already installed (current version is dev~mirage).
[NOTE] Package mirage-types is already installed (current version is dev~mirage).
[NOTE] Package mirage-types-lwt is already installed (current version is dev~mirage).
[NOTE] Package mirage-unix is already installed (current version is dev~mirage).
[NOTE] Package tcpip is already installed (current version is dev~mirage).
4.04.0🐫  ((detached from origin/mirage-dev)) mirageos:~/mirage-skeleton/network$ make
ocamlbuild -use-ocamlfind -tags "predicate(mirage_unix)" -pkgs functoria-runtime,mirage-clock-unix,mirage-console-unix,mirage-logs,mirage-net-unix,mirage-runtime,mirage-stdlib-random,mirage-types,mirage-types.lwt,mirage-unix,tcpip.arpv4,tcpip.ethif,tcpip.icmpv4,tcpip.ipv4,tcpip.stack-direct,tcpip.tcp,tcpip.udp -tags "warn(A-4-41-42-44),debug,bin_annot,strict_sequence,principal,safe_string" -tag-line "<static*.*>: warn(-32-34)" -r -cflag -g -lflags -g,-linkpkg main.native
Finished, 10 targets (0 cached) in 00:00:00.
ln -nfs _build/main.native mir-network
4.04.0🐫  ((detached from origin/mirage-dev)) mirageos:~/mirage-skeleton/network$ sudo ./mir-network
Netif: plugging into tap0 with mac 0a:91:e3:38:e9:66
Netif: connect tap0
2016-11-29 09:40:03 -06:00: INF [ethif] Connected Ethernet interface 0a:91:e3:38:e9:66
2016-11-29 09:40:03 -06:00: INF [arpv4] Connected arpv4 device on 0a:91:e3:38:e9:66
2016-11-29 09:40:03 -06:00: INF [udp] UDP interface connected on 192.168.3.10
2016-11-29 09:40:03 -06:00: INF [tcpip-stack-direct] stack assembled: mac=0a:91:e3:38:e9:66,ip=192.168.3.10
^C4.04.0🐫  ((detached from origin/mirage-dev)) mirageos:~/mirage-skeleton/network$ sudo ./mir-network --network 192.168.3.11/24
network: option `--network': 192.168.3.11/2/24 is not a valid IPv4 address
         and netmask
Usage: network [OPTION]... 
Try `network --help' for more information.
Fatal error: exception (Failure "Key initialization failed")
Raised at file "pervasives.ml", line 32, characters 17-33
Called from file "main.ml", line 134, characters 9-96
Called from file "camlinternalLazy.ml", line 27, characters 17-27
Re-raised at file "camlinternalLazy.ml", line 34, characters 4-11
Called from file "main.ml", line 177, characters 4-19
Called from file "src/core/lwt.ml" (inlined), line 672, characters 16-24
Called from file "main.ml", line 175, characters 2-162
4.04.0🐫  ((detached from origin/mirage-dev)) mirageos:~/mirage-skeleton/network$ sudo ./mir-network --network 192.168.3.11/24
Netif: plugging into tap0 with mac 7e:48:5f:53:e8:78
Netif: connect tap0
2016-11-29 09:40:18 -06:00: INF [ethif] Connected Ethernet interface 7e:48:5f:53:e8:78
2016-11-29 09:40:18 -06:00: INF [arpv4] Connected arpv4 device on 7e:48:5f:53:e8:78
2016-11-29 09:40:18 -06:00: INF [udp] UDP interface connected on 192.168.3.11
2016-11-29 09:40:18 -06:00: INF [tcpip-stack-direct] stack assembled: mac=7e:48:5f:53:e8:78,ip=192.168.3.11
^C4.04.0🐫  ((detached from origin/mirage-dev)) mirageos:~/mirage-skeleton/network$ 
```