### PR TITLE
rename ipv4 to ipv4_address, ipv4_network to ipv4

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -618,7 +618,7 @@ let meta_ipv4 ppf s =
   Fmt.pf ppf "(Ipaddr.V4.of_string_exn %S)" (Ipaddr.V4.to_string s)
 
 type ipv4_config = {
-  network : Ipaddr.V4.t * Ipaddr.V4.Prefix.t;
+  network : Ipaddr.V4.Prefix.t * Ipaddr.V4.t;
   gateway : Ipaddr.V4.t option;
 }
 (** Types for IPv4 manual configuration. *)
@@ -640,7 +640,7 @@ let ipv4_keyed_conf ?network ?gateway () = impl @@ object
     method connect _ modname = function
     | [ etif ; arp ] ->
         Fmt.strf
-          "let (ip, network) = %a in @ \
+          "let (network, ip) = %a in @ \
              %s.connect@[@ ~ip ~network %a@ %s@ %s@]"
           (Fmt.option pp_key) network
           modname
@@ -685,9 +685,9 @@ let ipv4_of_dhcp dhcp ethif arp = ipv4_dhcp_conf $ dhcp $ ethif $ arp
 let create_ipv4 ?group ?config etif arp =
   let config = match config with
   | None ->
-    let default_address = Ipaddr.V4.of_string_exn "10.0.0.2" in
+    let network = Ipaddr.V4.Prefix.of_address_string_exn "10.0.0.2/24" in
     {
-      network = default_address, Ipaddr.V4.Prefix.make 24 default_address;
+      network;
       gateway = Some (Ipaddr.V4.of_string_exn "10.0.0.1");
     }
   | Some config -> config

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -284,7 +284,7 @@ val ipv6: ipv6 typ
 (** The [V1.IPV6] module signature. *)
 
 type ipv4_config = {
-  network : Ipaddr.V4.t * Ipaddr.V4.Prefix.t;
+  network : Ipaddr.V4.Prefix.t * Ipaddr.V4.t;
   gateway : Ipaddr.V4.t option;
 }
 (** Types for IPv4 manual configuration. *)

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -299,7 +299,7 @@ type ipv6_config = {
 val create_ipv4 : ?group:string ->
   ?config:ipv4_config -> ethernet impl -> arpv4 impl -> ipv4 impl
 (** Use an IPv4 address
-    Exposes the keys {!Key.V4.ip}, {!Key.V4.network} and {!Key.V4.gateway}.
+    Exposes the keys {!Key.V4.ipv4} and {!Key.V4.ipv4-gateway}.
     If provided, the values of these keys will override those supplied
     in the ipv4 configuration record, if that has been provided.
 *)
@@ -382,7 +382,7 @@ val qubes_ipv4_stack : ?group:string -> ?qubesdb : qubesdb impl -> network impl 
  *  build an ipv4, then building a stack on top of that. *)
 val dhcp_ipv4_stack : ?group:string -> ?time : time impl -> network impl -> stackv4 impl
 
-(** Build a stackv4 by checking the {Key.ip}, {Key.network}, and {Key.gateway} keys
+(** Build a stackv4 by checking the {Key.ip4}, and {Key.ipv4-gateway} keys
  *  for ipv4 configuration information, filling in unspecified information from [?config],
  *  then building a stack on top of that. *)
 val static_ipv4_stack : ?group:string -> ?config : ipv4_config -> network impl -> stackv4 impl

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -255,7 +255,7 @@ module V4 = struct
 
   let gateway ?group default =
     let doc = Fmt.strf "The gateway of %a." pp_group group in
-    create_simple ~doc ~default ?group Arg.(some ipv4_address) "gateway"
+    create_simple ~doc ~default ?group Arg.(some ipv4_address) "ipv4-gateway"
 
   let socket ?group default =
     let doc =

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -21,8 +21,8 @@
 module Arg : sig
   include module type of struct include Functoria_key.Arg end
 
-  val ipv4 : Ipaddr.V4.t converter
-  val ipv4_network : (Ipaddr.V4.t * Ipaddr.V4.Prefix.t) converter
+  val ipv4_address : Ipaddr.V4.t converter
+  val ipv4 : (Ipaddr.V4.Prefix.t * Ipaddr.V4.t) converter
   val ipv6 : Ipaddr.V6.t converter
   val ipv6_prefix : Ipaddr.V6.Prefix.t converter
 
@@ -95,7 +95,7 @@ val interface : ?group:string -> string -> string key
 module V4 : sig
   open Ipaddr.V4
 
-  val network : ?group:string -> (t * Prefix.t) -> (t * Prefix.t) key
+  val network : ?group:string -> (Prefix.t * t)-> (Prefix.t * t) key
   (** A network defined by an address and netmask. *)
 
   val gateway : ?group:string -> t option -> t option key

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -55,22 +55,16 @@ module Arg = struct
     make M.of_string M.pp_hum
 
   let ip = of_module (module Ipaddr)
-  let ipv4 = of_module (module Ipaddr.V4)
-  let ipv4_network =
-    let serialize fmt (ip, prefix) =
-      Format.fprintf fmt "\"%a/%d\"" Ipaddr.V4.pp_hum ip (Ipaddr.V4.Prefix.bits prefix)
+  let ipv4_address = of_module (module Ipaddr.V4)
+  let ipv4 =
+    let serialize fmt (prefix, ip) =
+      Format.fprintf fmt "(Ipaddr.V4.Prefix.of_address_string_exn \"%s\")"
+      @@ Ipaddr.V4.Prefix.to_address_string prefix ip
     in
     let parse str =
-      let (>>=) x f =
-        match x with
-        | None -> `Error (str ^ " is not a valid IPv4 address and netmask")
-        | Some g -> f g
-      in
-      Ipaddr.V4.Prefix.of_string str >>= fun network ->
-      (* recover the IP *)
-      Astring.String.cut ~sep:"/" str >>= fun (ip, _) ->
-      Ipaddr.V4.of_string ip >>= fun ip ->
-      `Ok (ip, network)
+      match Ipaddr.V4.Prefix.of_address_string str with
+      | None -> `Error (str ^ " is not a valid IPv4 address and netmask")
+      | Some n -> `Ok n
     in
     parse, serialize
 

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -54,10 +54,10 @@ module Arg: sig
   val ip: Ipaddr.t Cmdliner.Arg.converter
   (** [ip] converts IP address. *)
 
-  val ipv4: Ipaddr.V4.t Cmdliner.Arg.converter
+  val ipv4_address: Ipaddr.V4.t Cmdliner.Arg.converter
   (** [ipv4] converts an IPv4 address. *)
 
-  val ipv4_network: (Ipaddr.V4.t * Ipaddr.V4.Prefix.t) Cmdliner.Arg.converter
+  val ipv4: (Ipaddr.V4.Prefix.t * Ipaddr.V4.t) Cmdliner.Arg.converter
   (** [ipv4] converts ipv4/netmask to Ipaddr.V4.t * Ipaddr.V4.Prefix.t . *)
 
   val ipv6: Ipaddr.V6.t Cmdliner.Arg.converter


### PR DESCRIPTION
As requested in https://github.com/mirage/mirage/pull/707 . There was a converter named `ipv4` for plain addresses (used in interpreting `gateway`), so I've renamed that to avoid confusion.