### PR TITLE
fix incorrect connect string for create_ipv6

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -727,14 +727,14 @@ let ipv6_conf ?addresses ?netmasks ?gateways () = impl @@ object
     method packages = Key.pure [package ~sublibs:["ipv6"] "tcpip"]
     method keys = addresses @?? netmasks @?? gateways @?? []
     method connect _ modname = function
-      | [ etif ; _time ; _clock ] ->
+      | [ etif ; _time ; clock ] ->
         Fmt.strf
-          "%s.connect@[@ %a@ %a@ %a@ %s@@]"
+          "%s.connect@[@ %a@ %a@ %a@ %s@ %s@]"
           modname
           (opt_key "ip") addresses
           (opt_key "netmask") netmasks
           (opt_key "gateways") gateways
-          etif
+          etif clock
       | _ -> failwith "The ipv6 connect should receive exactly three arguments."
   end
 


### PR DESCRIPTION
Without these changes, create_ipv6 generates code that contains a stray
@ and also fails to pass the required `clock` parameter to Ipv6.connect .