### PR TITLE
Arp result types

### DIFF
--- a/lib_runtime/mirage_pp.ml
+++ b/lib_runtime/mirage_pp.ml
@@ -12,6 +12,9 @@ let pp_network_error pp = function
 
 let pp_ethif_error = pp_network_error
 
+let pp_arp_error pp = function
+  | `Timeout -> Format.fprintf pp "Dynamic ARP timed out"
+
 let pp_ip_error = pp_ethif_error
 
 let pp_icmp_error pp = function

--- a/lib_runtime/mirage_pp.ml
+++ b/lib_runtime/mirage_pp.ml
@@ -15,7 +15,12 @@ let pp_ethif_error = pp_network_error
 let pp_arp_error pp = function
   | `Timeout -> Format.fprintf pp "Dynamic ARP timed out"
 
-let pp_ip_error = pp_ethif_error
+let pp_ip_error pp = function
+  | `Msg message   -> unspecified pp message
+  | `Unimplemented -> Format.fprintf pp "operation not yet implemented"
+  | `Disconnected  -> Format.fprintf pp "device is disconnected"
+  | `No_route      -> Format.fprintf pp "no route to destination"
+
 
 let pp_icmp_error pp = function
   | `Msg message   -> unspecified pp message

--- a/lib_runtime/mirage_pp.mli
+++ b/lib_runtime/mirage_pp.mli
@@ -4,6 +4,7 @@ val pp_console_error: Format.formatter -> Console.error -> unit
 
 val pp_network_error: Format.formatter -> Network.error -> unit
 val pp_ethif_error  : Format.formatter -> Ethif.error -> unit
+val pp_arp_error    : Format.formatter -> Arp.error -> unit
 val pp_ip_error     : Format.formatter -> Ip.error -> unit
 val pp_icmp_error   : Format.formatter -> Icmp.error -> unit
 val pp_udp_error    : Format.formatter -> Udp.error -> unit

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -383,6 +383,7 @@ end
 module Ip : sig
   type error = [
     | `Msg of string     (** an undiagnosed error *)
+    | `No_route          (** can't send a message to that destination *)
     | `Unimplemented     (** operation not yet implemented in the code *)
     | `Disconnected      (** the device has been previously disconnected *)
   ]

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -539,17 +539,19 @@ module type IP = sig
 
 end
 
+module Arp : sig
+  type error = [
+    `Timeout
+  ]
+end
+
 module type ARP = sig
-  include DEVICE
+  include DEVICE with type error := Arp.error
 
   type ipaddr
   type buffer
   type macaddr
   type repr
-
-  (** Type of the result of an ARP query.  One of `Ok macaddr (for successful
-      queries) or `Timeout (for attempted queries that received no response). *)
-  type result = [ `Ok of macaddr | `Timeout ]
 
   (** Prettyprint cache contents *)
   val to_repr : t -> repr io
@@ -575,7 +577,7 @@ module type ARP = sig
   (** [query arp ip] queries the cache in [arp] for an ARP entry
       corresponding to [ip], which may result in the sender sleeping
       waiting for a response. *)
-  val query : t -> ipaddr -> result io
+  val query : t -> ipaddr -> (macaddr, Arp.error) result io
 
   (** [input arp frame] will handle an ARP frame. If it is a response,
       it will update its cache, otherwise will try to satisfy the


### PR DESCRIPTION
Include an ARP error variant; it can be returned as an error result from `query` in module type `ARP`.  (For reals this time.)

Requires changes to `tcpip` which you can see at https://github.com/mirage/mirage-tcpip/pull/269 .

To see passing tests, check out the results for the `mirage-dev` universe including this branch and the matching `tcpip` one: https://travis-ci.org/yomimono/mirage-dev/builds/179917304