### PR TITLE
replace tap0 with default_network

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -562,7 +562,11 @@ let network_conf (intf : string Key.key) =
   end
 
 let netif ?group dev = impl (network_conf @@ Key.interface ?group dev)
-let tap0 = netif "tap0"
+let default_network =
+  match_impl Key.(value target) [
+    `Xen   , netif "0";
+    `Qubes , netif "0";
+  ] ~default:(netif "tap0")
 
 type dhcp = Dhcp_client
 let dhcp = Type Dhcp_client

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -239,8 +239,9 @@ type network
 val network: network typ
 (** Implementations of the [V1.NETWORK] signature. *)
 
-val tap0: network impl
-(** The '/dev/tap0' interface. *)
+val default_network: network impl
+(** [default_network] is a dynamic network implementatation
+ *  which attempts to do something reasonable based on the target. *)
 
 val netif: ?group:string -> string -> network impl
 (** A custom network interface. Exposes a {!Key.interface} key. *)


### PR DESCRIPTION
Fixes #644 .

Does not fix #645.

Needs changes in unikernels that previously used `tap0`; there's a [matching PR for mirage-skeleton](https://github.com/mirage/mirage-skeleton/pull/203).  To see a consistent universe, check [this fork of mirage-dev](https://github.com/yomimono/mirage-dev/tree/default-network).  Its passing tests are visible [here](https://travis-ci.org/yomimono/mirage-dev/builds/180195689).