### PR TITLE
Install depexts for unikernel during make depend

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1517,6 +1517,7 @@ let configure_makefile ~opam_name =
                   \n\
                   depend::\n\
                   \t$(OPAM) pin add --no-action --yes %s .\n\
+                  \t$(OPAM) depext --yes %s\n\
                   \t$(OPAM) install --yes --deps-only %s\n\
                   \t$(OPAM) pin remove --no-action %s\n\
                   \n\
@@ -1525,7 +1526,7 @@ let configure_makefile ~opam_name =
                   \n\
                   clean::\n\
                   \tmirage clean\n"
-        opam_name opam_name opam_name;
+        opam_name opam_name opam_name opam_name;
       newline fmt;
       append fmt "-include Makefile.user";
       R.ok ())


### PR DESCRIPTION
Fixes #596.

@avsm I've deliberately not used `--update` in the call to `depext`; I don't think we did that before and it can modify the user's package manager state which IMO is not good for default behaviour.