### PR TITLE
Make "0" the default network interface on non-Unix targets

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -564,9 +564,9 @@ let network_conf (intf : string Key.key) =
 let netif ?group dev = impl (network_conf @@ Key.interface ?group dev)
 let default_network =
   match_impl Key.(value target) [
-    `Xen   , netif "0";
-    `Qubes , netif "0";
-  ] ~default:(netif "tap0")
+    `Unix   , netif "tap0";
+    `MacOSX , netif "tap0";
+  ] ~default:(netif "0")
 
 type dhcp = Dhcp_client
 let dhcp = Type Dhcp_client


### PR DESCRIPTION
Followup to #715. Solo5 does not currently care about the string passed
to Netif, so just use "0" for all non-Unix targets.