### PR TITLE
[WIP; RFC] error types restated privately in flow implementations

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -165,7 +165,19 @@ module type FLOW = sig
   (** The type for flows. A flow represents the state of a single
       reliable stream that is connected to an endpoint. *)
 
-  val read: flow -> (buffer Flow.or_eof, Flow.error) result io
+  type error = private [> Flow.error]
+  (** the type for read errors. *)
+
+  type write_error = private [> Flow.write_error]
+  (** the type for write errors. *)
+
+  val pp_error : Format.formatter -> error -> unit
+  (** a printer for errors. *)
+
+  val pp_write_error : Format.formatter -> write_error -> unit
+  (** a printer for write errors. *)
+
+  val read: flow -> (buffer Flow.or_eof, error) result io
   (** [read flow] blocks until some data is available and returns a
       fresh buffer containing it.
 
@@ -178,7 +190,7 @@ module type FLOW = sig
       called [close] and when there is no more in-flight data.
    *)
 
-  val write: flow -> buffer -> (unit, Flow.write_error) result io
+  val write: flow -> buffer -> (unit, write_error) result io
   (** [write flow buffer] writes a buffer to the flow. There is no
       indication when the buffer has actually been read and, therefore,
       it must not be reused.  The contents may be transmitted in
@@ -187,7 +199,7 @@ module type FLOW = sig
       connection is now closed and therefore the data could not be
       written.  Other errors are possible. *)
 
-  val writev: flow -> buffer list -> (unit, Flow.write_error) result io
+  val writev: flow -> buffer list -> (unit, write_error) result io
   (** [writev flow buffers] writes a sequence of buffers to the flow.
       There is no indication when the buffers have actually been read and,
       therefore, they must not be reused. The
@@ -701,6 +713,7 @@ module type TCP = sig
       type 'a io  := 'a io
   and type buffer := buffer
   and type flow   := flow
+  and type error  := Tcp.error
 
   type callback = flow -> unit io
   (** The type for application callback that receives a [flow] that it


### PR DESCRIPTION
A universe is in progress at https://github.com/yomimono/mirage-dev/tree/lpw-error-suggs ; it currently contains `mirage`, `tcpip`, and `mirage-flow`.

Attempts to address some concerns in #698.