### PR TITLE
mirage-runtime depends on mirage-types

### DIFF
--- a/pkg/META.mirage-runtime
+++ b/pkg/META.mirage-runtime
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "MirageOS runtime libraries"
-requires = "functoria-runtime ipaddr astring logs"
+requires = "functoria-runtime ipaddr astring logs mirage-types"
 archive(byte) = "mirage-runtime.cma"
 archive(native) = "mirage-runtime.cmxa"
 plugin(byte) = "mirage-runtime.cma"


### PR DESCRIPTION
I guess it's added by the mirage tool at some point, but it's better to keep track of it there.