### PR TITLE
FS: remove `format` and `Format_unknown`

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -883,7 +883,6 @@ module Fs : sig
     | `Is_a_directory      (** Cannot read or write the contents of a directory *)
     | `No_directory_entry  (** Cannot find a directory entry *)
     | `Not_a_directory     (** Cannot create a directory entry in a file *)
-    | `Format_unknown      (** The block device appears to not be formatted *)
   ]
   type write_error = [
     | `Msg of string
@@ -921,10 +920,6 @@ module type FS = sig
     size: int64;      (** Size of the entity in bytes *)
   }
   (** The type for Per-file/directory statistics. *)
-
-  val format: t -> int64 -> (unit, error) result io
-  (** [format t size] erases the contents of [t] and creates an empty
-      filesystem of size [size] bytes. *)
 
   val create: t -> string -> (unit, write_error) result io
   (** [create t path] creates an empty file at [path]. If [path] contains


### PR DESCRIPTION
`format` is similar to `connect` which we removed previously from the common interface: it is likely to be implementation-specific (e.g. number of inodes, number of superblocks etc etc)

Furthermore it seems strange to have to acquire a `FS.t` handle in order to be able to format a filesystem. This requires that implementations track whether the `FS.t` is formatted or not (e.g. with a Some or None) and then all operations may return `Format_unknown` (which they currently can't). Removing `format` and `Format_error` fixes this problem.

With this change, `Fs.error` is a proper subset of `Fs.write_error`.

Signed-off-by: David Scott <dave@recoil.org>