### PR TITLE
move mirage-types.lwt to mirage-types-lwt

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1801,8 +1801,8 @@ module Project = struct
         let l = [
           (* XXX: use %%VERSION_NUM%% here instead of hardcoding a version? *)
           package "lwt";
-          package ~ocamlfind:[] "mirage-types-lwt";
-          package ~sublibs:["lwt"] ~min:"3.0.0"  "mirage-types";
+          package ~min:"3.0.0" "mirage-types-lwt";
+          package ~min:"3.0.0" "mirage-types";
           package ~min:"3.0.0" "mirage-runtime" ;
           package ~build:true "ocamlfind" ;
           package ~build:true "ocamlbuild" ;

--- a/mirage-types-lwt.opam
+++ b/mirage-types-lwt.opam
@@ -6,6 +6,7 @@ bug-reports:  "https://github.com/mirage/mirage/issues/"
 dev-repo:     "https://github.com/mirage/mirage.git"
 tags:         ["org:mirage" "org:xapi-project"]
 
+build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 depends: [
   "ocamlfind" {build}
   "lwt"

--- a/mirage-types.opam
+++ b/mirage-types.opam
@@ -7,17 +7,10 @@ homepage:     "https://mirage.io/"
 bug-reports:  "https://github.com/mirage/mirage/issues/"
 dev-repo:     "https://github.com/mirage/mirage.git"
 tags:         ["org:mirage" "org:xapi-project"]
-build: [
-  "ocaml" "pkg/pkg.ml" "build" "--pkg-name" name
-  "--pinned" "%{pinned}%" "--with-lwt-types" "%{lwt+cstruct+ipaddr+io-page:installed}%" ]
+build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 depends:   [
   "ocamlbuild" {build}
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.8.0"}
   "result"
-]
-depopts: [ "lwt" "cstruct" "ipaddr" "io-page" ]
-conflicts: [
-  "cstruct" {<"1.4.0"}
-  "io-page" {<"1.4.0"}
 ]

--- a/pkg/META.mirage-types
+++ b/pkg/META.mirage-types
@@ -2,10 +2,3 @@ version = "%%VERSION_NUM%%"
 description = "Collection of module signatures for MirageOS"
 requires = ""
 exists_if = "V1.cmi"
-
-package "lwt" (
-  version = "%%VERSION_NUM%%"
-  requires = ""
-  description = "Lwt module signatures for MirageOS"
-  exists_if = "V1_LWT.cmi"
-)

--- a/pkg/META.mirage-types-lwt
+++ b/pkg/META.mirage-types-lwt
@@ -1,0 +1,4 @@
+version = "%%VERSION_NUM%%"
+description = "Collection of lwt module signatures for MirageOS"
+requires = "cstruct io-page ipaddr mirage-types"
+exists_if = "V1_LWT.cmi"

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -6,6 +6,7 @@ open Topkg
 let metas = [
   Pkg.meta_file ~install:false "pkg/META.mirage";
   Pkg.meta_file ~install:false "pkg/META.mirage-types";
+  Pkg.meta_file ~install:false "pkg/META.mirage-types-lwt";
   Pkg.meta_file ~install:false "pkg/META.mirage-runtime";
 ]
 
@@ -19,11 +20,8 @@ let opams =
     Pkg.opam_file ~install ~lint_deps_excluding "mirage-types-lwt.opam";
   ]
 
-let lwt = Conf.with_pkg ~default:false "lwt-types"
-
 let () =
   Pkg.describe ~metas ~opams "mirage" @@ fun c ->
-  let lwt = Conf.value c lwt in
   match Conf.pkg_name c with
   | "mirage" ->
     Ok [ Pkg.lib "pkg/META.mirage" ~dst:"META";
@@ -37,9 +35,10 @@ let () =
   | "mirage-types" ->
     Ok [ Pkg.lib "pkg/META.mirage-types" ~dst:"META";
          Pkg.lib "mirage-types.opam" ~dst:"opam";
-         Pkg.lib ~exts:Exts.interface "types/V1";
-         Pkg.lib ~cond:lwt ~exts:Exts.interface "types/V1_LWT"; ]
+         Pkg.lib ~exts:Exts.interface "types/V1"; ]
   | "mirage-types-lwt" ->
-    Ok [ Pkg.lib "mirage-types-lwt.opam" ~dst:"opam"; ]
+    Ok [ Pkg.lib "pkg/META.mirage-types-lwt" ~dst:"META";
+         Pkg.lib "mirage-types-lwt.opam" ~dst:"opam";
+         Pkg.lib ~exts:Exts.interface "types/V1_LWT"; ]
   | other ->
     R.error_msgf "unknown package name: %s" other


### PR DESCRIPTION
This PR solves #670 by moving `mirage-types.lwt` into the `mirage-types-lwt` package, thus we do not have any depopts anymore.  A successful build of mirage-skeleton is available at: https://travis-ci.org/hannesm/mirage-dev/builds/183748895

It affects some packages:
- [ ] https://github.com/mirage/mirage-channel/pull/15
- [ ] https://github.com/mirage/ocaml-dns/pull/112
- [ ] https://github.com/mirage/mirage-clock/pull/22
- [ ] https://github.com/mirage/mirage-console/pull/52
- [ ] https://github.com/mirage/mirage-console-solo5/pull/8
- [ ] https://github.com/mirage/mirage-flow/pull/23
- [ ] https://github.com/mirage/mirage-http/pull/31
- [ ] https://github.com/mirage/mirage-net-solo5/pull/14
- [ ] https://github.com/mirage/mirage-net-unix/pull/33
- [ ] https://github.com/mirage/mirage-net-xen/pull/53
- [ ] https://github.com/hannesm/mirage-stdlib-random/pull/1
- [ ] https://github.com/MagnusS/mirage-vnetif/pull/10
- [ ] https://github.com/mirage/mirage-tcpip/pull/273
- [ ] https://github.com/yomimono/ocaml-tls/pull/1
- [ ] https://github.com/mirage/mirage-dev/pull/254