### PR TITLE
WIP: No more error

### DIFF
--- a/types/V1.mli
+++ b/types/V1.mli
@@ -141,7 +141,7 @@ module Flow : sig
 end
 
 (** {1 Connection between endpoints} *)
-module type FLOW = sig
+module type RFLOW = sig
 
   type +'a io
   (** The type for potentially blocking I/O operations. *)
@@ -153,10 +153,10 @@ module type FLOW = sig
   (** The type for flows. A flow represents the state of a single
       reliable stream that is connected to an endpoint. *)
 
-  type error = private [> Flow.error]
+  type error
   (** the type for read errors. *)
 
-  type write_error = private [> Flow.write_error]
+  type write_error
   (** the type for write errors. *)
 
   val pp_error : Format.formatter -> error -> unit
@@ -212,6 +212,10 @@ module type FLOW = sig
       and resources associated with the flow can be freed.
       *)
 end
+
+module type FLOW = RFLOW
+  with type error = private [> Flow.error]
+   and type write_error = private [> Flow.write_error]
 
 (** {1 Console input/output} *)
 module Console : sig

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -153,7 +153,19 @@ module type FLOW = sig
   (** The type for flows. A flow represents the state of a single
       reliable stream that is connected to an endpoint. *)
 
-  val read: flow -> (buffer Flow.or_eof, Flow.error) result io
+  type error = private [> Flow.error]
+  (** the type for read errors. *)
+
+  type write_error = private [> Flow.write_error]
+  (** the type for write errors. *)
+
+  val pp_error : Format.formatter -> error -> unit
+  (** a printer for errors. *)
+
+  val pp_write_error : Format.formatter -> write_error -> unit
+  (** a printer for write errors. *)
+
+  val read: flow -> (buffer Flow.or_eof, error) result io
   (** [read flow] blocks until some data is available and returns a
       fresh buffer containing it.
 
@@ -166,7 +178,7 @@ module type FLOW = sig
       called [close] and when there is no more in-flight data.
    *)
 
-  val write: flow -> buffer -> (unit, Flow.write_error) result io
+  val write: flow -> buffer -> (unit, write_error) result io
   (** [write flow buffer] writes a buffer to the flow. There is no
       indication when the buffer has actually been read and, therefore,
       it must not be reused.  The contents may be transmitted in
@@ -175,7 +187,7 @@ module type FLOW = sig
       connection is now closed and therefore the data could not be
       written.  Other errors are possible. *)
 
-  val writev: flow -> buffer list -> (unit, Flow.write_error) result io
+  val writev: flow -> buffer list -> (unit, write_error) result io
   (** [writev flow buffers] writes a sequence of buffers to the flow.
       There is no indication when the buffers have actually been read and,
       therefore, they must not be reused. The
@@ -678,6 +690,7 @@ module type TCP = sig
       type 'a io  := 'a io
   and type buffer := buffer
   and type flow   := flow
+  and type error  := Tcp.error
 
   type callback = flow -> unit io
   (** The type for application callback that receives a [flow] that it


### PR DESCRIPTION
on top of #729,  also https://github.com/mirleft/ocaml-tls/pull/348 https://github.com/mirage/mirage-console/pull/53 https://github.com/mirage/mirage-console-solo5/pull/9 https://github.com/mirage/mirage-tcpip/pull/275 https://github.com/mirage/mirage-flow/pull/24

still not very happy: the compilation of `tls` succeeds, but I'm unable to use it:
```OCaml
File "src/logs_syslog_mirage_tls.ml", line 6, characters 31-34:
Error: Signature mismatch:
       ...
       The type `error' is required but not provided
       File "types/V1.mli", line 217, characters 7-42: Expected declaration
```

where line 6 is: `module TLS = Tls_mirage.Make(TCP)`

And lots of `lift_XX` in `tls_mirage.ml`, which IMHO shouldn't be necessary.  I suspect the fundamental problem is that `error` and `write_error` in `FLOW` are unrelated (and furthermore, the `` `Msg of string `` should not be in `FLOW`)!?!  In TLS, since a `read` can lead to `write`, and `write` can lead to `read`, the distinction of reader and writer errors is rather brittle.

Maybe @yallop knows a quick way out or someone else (@talex5 @samoht @avsm) has some time to get rid of `` `Msg ``!?

client code: https://github.com/hannesm/logs-syslog/tree/no-more-error