### PR TITLE
mainly cosmetics

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -790,7 +790,7 @@ let udpv4_socket_conf ipv4_key = object
   method configure i =
     match get_target i with
     | `MacOSX | `Unix -> R.ok ()
-    | _ -> R.error_msg "UDPv4 socket invoked for non-UNIX target."
+    | _ -> R.error_msg "UDPv4 socket not supported on non-UNIX targets."
   method connect _ modname _ = Fmt.strf "%s.connect %a" modname pp_key ipv4_key
 end
 
@@ -837,7 +837,7 @@ let tcpv4_socket_conf ipv4_key = object
   method configure i =
     match get_target i with
     | `Unix | `MacOSX -> R.ok ()
-    | _  -> R.error_msg "TCPv4 socket invoked for non-UNIX target."
+    | _  -> R.error_msg "TCPv4 socket not supported on non-UNIX targets."
   method connect _ modname _ = Fmt.strf "%s.connect %a" modname pp_key ipv4_key
 end
 
@@ -1036,7 +1036,7 @@ let resolver_unix_system = impl @@ object
     method configure i =
       match get_target i with
       | `Unix | `MacOSX -> R.ok ()
-      | _ -> R.error_msg "Resolver_unix not supported on unikernel"
+      | _ -> R.error_msg "Unix resolver not supported on non-UNIX targets."
     method connect _ _modname _ = "Lwt.return Resolver_lwt_unix.system"
   end
 


### PR DESCRIPTION
- remove all raise from `method package`
- in case a device is not suitable for the target, `configure` emits an error
- don't Log.err _and_ R.error_msg, only use the latter
- unify connect error message
- use Fmt.strf all over instead of partially Printf.a/sprintf
- crunch has a build-dep on crunch, no need to verify manually that crunch is
  around during build time
- when matching target, don't use wildcards
- massage code to 80 columns