### PR TITLE
doc: swap the ocamldoc/odoc default so that odoc is default

### DIFF
--- a/Dockerfile.doc
+++ b/Dockerfile.doc
@@ -156,6 +156,6 @@ RUN opam pin add -n doc-ock-html git://github.com/ocaml-doc/doc-ock-html
 RUN opam pin add -n odoc git://github.com/ocaml-doc/odoc
 RUN opam depext -uivy -j 2 odoc
 RUN opam config exec -- odig odoc
-RUN ln -s /home/opam/.opam/4.03.0/var/cache/odig/odoc /home/opam/.opam/4.03.0/var/cache/odig/ocamldoc/odoc
+RUN ln -s /home/opam/.opam/4.03.0/var/cache/odig/ocamldoc /home/opam/.opam/4.03.0/var/cache/odig/odoc/ocamldoc
 EXPOSE 8080
-ENTRYPOINT opam config exec -- cohttp-server-lwt /home/opam/.opam/4.03.0/var/cache/odig/ocamldoc
+ENTRYPOINT opam config exec -- cohttp-server-lwt /home/opam/.opam/4.03.0/var/cache/odig/odoc


### PR DESCRIPTION
ocamldoc is now available from the /ocamldoc sub-url but we have
cross-referencing by default