### PR TITLE
Refactors errors and split signatures into their own opam packages

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -4,6 +4,9 @@ S lib_runtime/*
 S lib_test/*
 PKG ipaddr unix dynlink lwt cmdliner mirage-types.lwt functoria rresult fmt
 PKG astring logs bos mirage-runtime
+PKG mirage-device mirage-time mirage-time-lwt mirage-random
+PKG mirage-flow mirage-flow-lwt mirage-console mirage-console-lwt
+PKG mirage-block-lwt
 
 FLG -w +A-4-6-7-9-40-42-44-48
 FLG -strict_sequence -safe_string

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 sudo: false
 env:
  global:
-   - EXTRA_REMOTES="git://github.com/mirage/mirage-dev.git"
+   - EXTRA_REMOTES="git://github.com/samoht/mirage-dev.git"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="sh ./.travis-ci.sh"
  matrix:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 all:
-	ocaml pkg/pkg.ml build --pkg-name mirage-types
-	ocaml pkg/pkg.ml build --pkg-name mirage
+	ocaml pkg/pkg.ml build --pkg-name mirage-types -q
+	ocaml pkg/pkg.ml build --pkg-name mirage-types-lwt -q
+	ocaml pkg/pkg.ml build --pkg-name mirage-runtime -q
+	ocaml pkg/pkg.ml build --pkg-name mirage -q
 
 clean:
-	ocaml pkg/pkg.ml clean --pkg-name mirage-types
-	ocaml pkg/pkg.ml clean --pkg-name mirage
+	ocaml pkg/pkg.ml clean

--- a/_tags
+++ b/_tags
@@ -9,7 +9,12 @@ true: keep_locs
 
 # Force the runtime to be unix-independent.
 <lib_runtime/*>: package(functoria-runtime ipaddr astring logs mirage-types)
+<lib_runtime/*>: package(mirage-device)
 <lib_runtime/*>: dontlink(unix str num threads)
 
-<types/V1.*>: package(result)
-<types/V1_LWT.*>: package(cstruct io-page lwt ipaddr)
+<types/V1.*>: package(result mirage-device mirage-time mirage-random mirage-flow)
+<types/V1.*>: package(mirage-console mirage-block mirage-clock)
+
+<types/V1_LWT.*>: package(cstruct io-page lwt ipaddr mirage-types)
+<types/V1_LWT.*>: package(mirage-time-lwt mirage-random mirage-flow-lwt)
+<types/V1_LWT.*>: package(mirage-console-lwt mirage-block-lwt mirage-clock-lwt)

--- a/lib_runtime/mirage_pp.ml
+++ b/lib_runtime/mirage_pp.ml
@@ -17,6 +17,10 @@ let pp_tcp_error ppf = function
   | `Timeout -> Fmt.string ppf "connection attempt timed out"
   | `Refused -> Fmt.string ppf "connection attempt was refused"
 
+let pp_tcp_write_error ppf = function
+  | #Mirage_flow.write_error as e -> Mirage_flow.pp_write_error ppf e
+  | #V1.Tcp.error as e            -> pp_tcp_error ppf e
+
 let pp_fs_error ppf = function
     | `Is_a_directory      -> Fmt.string ppf "is a directory"
     | `Not_a_directory     -> Fmt.string ppf "is not a directory"

--- a/lib_runtime/mirage_pp.ml
+++ b/lib_runtime/mirage_pp.ml
@@ -1,79 +1,33 @@
-open Result
-let pf pp = Format.fprintf pp
+open V1
 
-let pp_console_error pp = function
-  | `Invalid_console str -> pf pp "invalid console %s" str
+let pp_network_error = Mirage_device.pp_error
+let pp_ethif_error = Mirage_device.pp_error
 
-let unspecified pp m = pf pp "unspecified error - %s" m
+let pp_arp_error ppf = function
+  | `Timeout -> Fmt.string ppf "Dynamic ARP timed out"
 
-let pp_network_error pp = function
-  | `Msg message   -> unspecified pp message
-  | `Unimplemented -> pf pp "operation not yet implemented"
-  | `Disconnected  -> pf pp "device is disconnected"
+let pp_ip_error ppf = function
+  | #Mirage_device.error as e -> Mirage_device.pp_error ppf e
+  | `No_route -> Fmt.string ppf "no route to destination"
 
-let pp_ethif_error = pp_network_error
+let pp_icmp_error ppf = function
+  | `Routing message -> Fmt.pf ppf "routing error: %s" message
 
-let pp_arp_error pp = function
-  | `Timeout -> Format.fprintf pp "Dynamic ARP timed out"
+let pp_tcp_error ppf = function
+  | `Timeout -> Fmt.string ppf "connection attempt timed out"
+  | `Refused -> Fmt.string ppf "connection attempt was refused"
 
-let pp_ip_error pp = function
-  | `Msg message   -> unspecified pp message
-  | `Unimplemented -> Format.fprintf pp "operation not yet implemented"
-  | `Disconnected  -> Format.fprintf pp "device is disconnected"
-  | `No_route      -> Format.fprintf pp "no route to destination"
+let pp_fs_error ppf = function
+    | `Is_a_directory      -> Fmt.string ppf "is a directory"
+    | `Not_a_directory     -> Fmt.string ppf "is not a directory"
+    | `No_directory_entry  ->
+      Fmt.string ppf "a directory in the path does not exist"
 
+let pp_fs_write_error ppf = function
+  | #Fs.error as e       -> pp_fs_error ppf e
+  | `Directory_not_empty -> Fmt.string ppf "directory is not empty"
+  | `File_already_exists -> Fmt.string ppf "file already exists"
+  | `No_space            -> Fmt.string ppf "device has no more free space"
 
-let pp_icmp_error pp = function
-  | `Msg message   -> unspecified pp message
-  | `Routing message -> pf pp "routing error: %s" message
-
-let pp_udp_error pp (`Msg message) = unspecified pp message
-
-let pp_tcp_error pp = function
-  | `Msg message   -> unspecified pp message
-  | `Timeout       -> pf pp "connection attempt timed out"
-  | `Refused       -> pf pp "connection attempt was refused"
-
-let pp_flow_error pp = function
-  | `Msg message   -> unspecified pp message
-
-let pp_flow_write_error pp = function
-  | `Msg message   -> unspecified pp message
-  | `Closed        -> pf pp "attempted to write to a closed flow"
-
-let pp_block_error pp = function
-  | `Msg message   -> unspecified pp message
-  | `Unimplemented -> pf pp "operation not yet implemented"
-  | `Disconnected  -> pf pp "a required device was disconnected"
-
-let pp_block_write_error pp = function
-  | `Msg message   -> unspecified pp message
-  | `Unimplemented -> pf pp "operation not yet implemented"
-  | `Disconnected  -> pf pp "a required device was disconnected"
-  | `Is_read_only  -> pf pp "attempted to write to a read-only disk"
-
-let pp_fs_error pp = function
-    | `Msg message         -> unspecified pp message
-    | `Is_a_directory      -> pf pp "is a directory"
-    | `Not_a_directory     -> pf pp "is not a directory"
-    | `No_directory_entry  -> pf pp "a directory in the path does not exist"
-    | `Format_unknown      -> pf pp "the device is not formatted for this filesystem"
-
-let pp_fs_write_error pp = function
-  | `Msg message         -> unspecified pp message
-  | `Is_a_directory      -> pf pp "is a directory"
-  | `Not_a_directory     -> pf pp "is not a directory"
-  | `Directory_not_empty -> pf pp "directory is not empty"
-  | `No_directory_entry  -> pf pp "a directory in the path does not exist"
-  | `File_already_exists -> pf pp "file already exists"
-  | `No_space            -> pf pp "device has no more free space"
-
-let pp_kv_ro_error pp = function
-  | `Msg message   -> unspecified pp message
-  | `Unknown_key   -> pf pp "key not present in the store"
-
-let reduce = function
-  | Ok () -> Ok ()
-  | Error (`Msg _) as e -> e
-  | Error `Unimplemented -> Error (`Msg "unimplemented functionality discovered")
-  | Error `Disconnected -> Error (`Msg "a required device was disconnected")
+let pp_kv_ro_error ppf = function
+  | `Unknown_key k -> Fmt.pf ppf "key %s not present in the store" k

--- a/lib_runtime/mirage_pp.mli
+++ b/lib_runtime/mirage_pp.mli
@@ -6,6 +6,7 @@ val pp_arp_error: Arp.error Fmt.t
 val pp_ip_error: Ip.error Fmt.t
 val pp_icmp_error: Icmp.error Fmt.t
 val pp_tcp_error: Tcp.error Fmt.t
+val pp_tcp_write_error: Tcp.write_error Fmt.t
 
 val pp_fs_error: Fs.error Fmt.t
 val pp_fs_write_error: Fs.write_error Fmt.t

--- a/lib_runtime/mirage_pp.mli
+++ b/lib_runtime/mirage_pp.mli
@@ -1,24 +1,13 @@
 open V1
 
-val pp_console_error: Format.formatter -> Console.error -> unit
+val pp_network_error: Network.error Fmt.t
+val pp_ethif_error: Ethif.error Fmt.t
+val pp_arp_error: Arp.error Fmt.t
+val pp_ip_error: Ip.error Fmt.t
+val pp_icmp_error: Icmp.error Fmt.t
+val pp_tcp_error: Tcp.error Fmt.t
 
-val pp_network_error: Format.formatter -> Network.error -> unit
-val pp_ethif_error  : Format.formatter -> Ethif.error -> unit
-val pp_arp_error    : Format.formatter -> Arp.error -> unit
-val pp_ip_error     : Format.formatter -> Ip.error -> unit
-val pp_icmp_error   : Format.formatter -> Icmp.error -> unit
-val pp_udp_error    : Format.formatter -> Udp.error -> unit
-val pp_tcp_error    : Format.formatter -> Tcp.error -> unit
+val pp_fs_error: Fs.error Fmt.t
+val pp_fs_write_error: Fs.write_error Fmt.t
 
-val pp_flow_error   : Format.formatter -> Flow.error -> unit
-val pp_flow_write_error : Format.formatter -> Flow.write_error -> unit
-
-val pp_block_error  : Format.formatter -> Block.error -> unit
-val pp_block_write_error  : Format.formatter -> Block.write_error -> unit
-
-val pp_fs_error     : Format.formatter -> Fs.error -> unit
-val pp_fs_write_error : Format.formatter -> Fs.write_error -> unit
-
-val pp_kv_ro_error  : Format.formatter -> Kv_ro.error -> unit
-
-val reduce : (unit, [`Msg of string | `Unimplemented | `Disconnected]) Result.result -> (unit, [> `Msg of string]) Result.result
+val pp_kv_ro_error: Kv_ro.error Fmt.t

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -17,6 +17,7 @@ depends: [
   "topkg"      {build & >= "0.8.0"}
   "ipaddr"             {>= "2.6.0"}
   "functoria-runtime"
+  "fmt"
   "astring"
   "logs"
   "mirage-types"

--- a/mirage-types-lwt.opam
+++ b/mirage-types-lwt.opam
@@ -14,4 +14,10 @@ depends: [
   "io-page" {>="1.4.0"}
   "ipaddr"
   "mirage-types" {>="3.0.0"}
+  "mirage-clock-lwt"
+  "mirage-time-lwt"
+  "mirage-random"
+  "mirage-flow-lwt"
+  "mirage-console-lwt" {>= "1.2.0"}
+  "mirage-block-lwt" {>= "1.0.0"}
 ]

--- a/mirage-types.opam
+++ b/mirage-types.opam
@@ -13,4 +13,11 @@ depends:   [
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.8.0"}
   "result"
+  "mirage-device"
+  "mirage-time"
+  "mirage-clock" {>= "1.2.0"}
+  "mirage-random"
+  "mirage-flow"
+  "mirage-console"
+  "mirage-block" {>= "1.0.0"}
 ]

--- a/pkg/META.mirage-types
+++ b/pkg/META.mirage-types
@@ -1,4 +1,3 @@
 version = "%%VERSION_NUM%%"
 description = "Collection of module signatures for MirageOS"
-requires = ""
-exists_if = "V1.cmi"
+requires = "result mirage-device mirage-time mirage-random mirage-flow mirage-console mirage-block mirage-clock"

--- a/pkg/META.mirage-types-lwt
+++ b/pkg/META.mirage-types-lwt
@@ -1,4 +1,3 @@
 version = "%%VERSION_NUM%%"
 description = "Collection of lwt module signatures for MirageOS"
-requires = "cstruct io-page ipaddr mirage-types"
-exists_if = "V1_LWT.cmi"
+requires = "cstruct io-page ipaddr mirage-types mirage-time-lwt mirage-random mirage-flow-lwt mirage-console-lwt mirage-block-lwt mirage-clock-lwt"

--- a/types/V1.mli
+++ b/types/V1.mli
@@ -442,6 +442,7 @@ end
 (** TCP errors. *)
 module Tcp : sig
   type error = [ `Timeout | `Refused]
+  type write_error = [ error | Mirage_flow.write_error]
 end
 
 (** A TCP stack that can send and receive reliable streams using the
@@ -451,7 +452,7 @@ module type TCP = sig
   type error = private [> Tcp.error]
   (** The type for TCP errors. *)
 
-  type write_error = private [> Mirage_flow.write_error | Tcp.error]
+  type write_error = private [> Tcp.write_error]
   (** The type for TCP write errors. *)
 
   type buffer

--- a/types/V1_LWT.mli
+++ b/types/V1_LWT.mli
@@ -22,21 +22,15 @@
 
 open V1
 
-module type TIME = TIME
-  with type 'a io = 'a Lwt.t
+module type TIME = Mirage_time_lwt.S
+module type RANDOM = Mirage_random.C
+module type FLOW = Mirage_flow_lwt.S
 
-module type RANDOM = RANDOM
-  with type buffer = Cstruct.t
+(** Consoles *)
+module type CONSOLE = Mirage_console_lwt.S
 
-module type FLOW = FLOW
-  with type 'a io = 'a Lwt.t
-   and type buffer = Cstruct.t
-
-module type MCLOCK = MCLOCK
-  with type 'a io = 'a Lwt.t
-
-module type PCLOCK = PCLOCK
-  with type 'a io = 'a Lwt.t
+(** Block devices *)
+module type BLOCK = Mirage_block_lwt.S
 
 (** Network *)
 module type NETWORK = NETWORK
@@ -124,16 +118,6 @@ module type CHANNEL = CHANNEL
 
 (** KV RO *)
 module type KV_RO = KV_RO
-  with type 'a io = 'a Lwt.t
-   and type page_aligned_buffer = Cstruct.t
-
-(** Consoles *)
-module type CONSOLE = CONSOLE
-  with type 'a io = 'a Lwt.t
-   and type buffer = Cstruct.t
-
-(** Block devices *)
-module type BLOCK = BLOCK
   with type 'a io = 'a Lwt.t
    and type page_aligned_buffer = Cstruct.t
 


### PR DESCRIPTION
Following the discussions we had with @talex5, @yallop and @hannesm last week, I implemented the new error scheme using private rows. After finding [2](https://caml.inria.fr/mantis/view.php?id=7437) [bugs](https://caml.inria.fr/mantis/view.php?id=7438) in the compiler, I finally managed to get something working. Here is the full set of patches:

### new repos with new signatures
- mirage-device (DEVICE): [GitHub - mirage/mirage-device: Mirage device](https://github.com/mirage/mirage-device)
- mirage-time (TIME):  [GitHub - mirage/mirage-time: Time signatures for MirageOS](https://github.com/mirage/mirage-time)
- mirage-random (RANDOM) : [GitHub - mirage/mirage-random: Random-related devices for MirageOS](https://github.com/mirage/mirage-random)

### move V1 signatures in existing repo:
- mirage-console (CONSOLE) + errors: [Update the new error scheme in mirage-types and import CONSOLE sigs from V1 by samoht · Pull Request #55 · mirage/mirage-console · GitHub](https://github.com/mirage/mirage-console/pull/55)
- mirage-block (BLOCK) + errors:  [Modernize build, import V1.BLOCK from mirage-types by samoht · Pull Request #25 · mirage/mirage-block · GitHub](https://github.com/mirage/mirage-block/pull/25)
- mirage-flow (FLOW) + errors: [modernize the build, split into 3 packages + adapt to the new error scheme by samoht · Pull Request #25 · mirage/mirage-flow · GitHub](https://github.com/mirage/mirage-flow/pull/25)
- mirage-clock (MCLOCK, PCLOCK): [Import V1.MCLOCK and V1.PCLOCK from mirage-types by samoht · Pull Request #24 · mirage/mirage-clock · GitHub](https://github.com/mirage/mirage-clock/pull/24)

### Use the new split sigs only
- mirage-logs: [Use the new mirage-clock instead of mirage-types by samoht · Pull Request #8 · mirage/mirage-logs · GitHub](https://github.com/mirage/mirage-logs/pull/8)

### Adapt to the new error scheme + use the new split sigs	
- mirage-vnetif: [Use topkg, use the new mirage-time and mirage-clock module, adapt to the new error scheme by samoht · Pull Request #11 · MagnusS/mirage-vnetif · GitHub](https://github.com/MagnusS/mirage-vnetif/pull/11)
- mirage-net-unix: [Adapt to the new error scheme in mirage-types by samoht · Pull Request #35 · mirage/mirage-net-unix · GitHub](https://github.com/mirage/mirage-net-unix/pull/35)
- mirage-net-macosx: [Adapt to the new error scheme by samoht · Pull Request #16 · mirage/mirage-net-macosx · GitHub](https://github.com/mirage/mirage-net-macosx/pull/16)
- mirage-channel: [Adapt to the new error scheme by samoht · Pull Request #17 · mirage/mirage-channel · GitHub](https://github.com/mirage/mirage-channel/pull/17)
- ocaml-dns: [Adapt to the new error scheme by samoht · Pull Request #116 · mirage/ocaml-dns · GitHub](https://github.com/mirage/ocaml-dns/pull/116)
- ocaml-tls: [mirage: update the the new error scheme by samoht · Pull Request #349 · mirleft/ocaml-tls · GitHub](https://github.com/mirleft/ocaml-tls/pull/349)
- ocaml-conduit: [Adapt to the new error scheme + depends on mirage-flow instead of mirage-types by samoht · Pull Request #182 · mirage/ocaml-conduit · GitHub](https://github.com/mirage/ocaml-conduit/pull/182)
- mirage-http: [Use the new error scheme by samoht · Pull Request #32 · mirage/mirage-http · GitHub](https://github.com/mirage/mirage-http/pull/32)
- ocaml-crunch: [Adapt to the new error scheme by samoht · Pull Request #31 · mirage/ocaml-crunch · GitHub](https://github.com/mirage/ocaml-crunch/pull/31)
- mirage-console-solo5: [Adapt to the new error scheme by samoht · Pull Request #10 · mirage/mirage-console-solo5 · GitHub](https://github.com/mirage/mirage-console-solo5/pull/10)
- mirage-net-solo5: [Adapt to the new error scheme by samoht · Pull Request #15 · mirage/mirage-net-solo5 · GitHub](https://github.com/mirage/mirage-net-solo5/pull/15)
- mirage-net-xen: [Adapt to the new error scheme by samoht · Pull Request #54 · mirage/mirage-net-xen · GitHub](https://github.com/mirage/mirage-net-xen/pull/54)
- ocaml-vchan: [Adapt to the new error scheme, use mirage-flow and mirage-console instead of mirage-types by samoht · Pull Request #97 · mirage/ocaml-vchan · GitHub](https://github.com/mirage/ocaml-vchan/pull/97)
- mirage-block-solo5: [Adapt to the new error scheme, use mirage-block instead of mirage-types by samoht · Pull Request #7 · mirage/mirage-block-solo5 · GitHub](https://github.com/mirage/mirage-block-solo5/pull/7)
- mirage-block-xen: [Adapt to the new error scheme by samoht · Pull Request #59 · mirage/mirage-block-xen · GitHub](https://github.com/mirage/mirage-block-xen/pull/59)
- mirage-block-ramdisk: [Import the tests from mirage-block, use the new Mirage_block.S by samoht · Pull Request #12 · mirage/mirage-block-ramdisk · GitHub](https://github.com/mirage/mirage-block-ramdisk/pull/12)

### Fix pre-existing errors
- charrua-client: [Link with mirage-types-lwt instead of mirage-types.lwt by samoht · Pull Request #7 · yomimono/charrua-client · GitHub](https://github.com/yomimono/charrua-client/pull/7)
- mirage-platform: [xen: really remove the dependency to mirage-types by samoht · Pull Request #181 · mirage/mirage-platform · GitHub](https://github.com/mirage/mirage-platform/pull/181)

### Meta
- mirage: [Refactors errors and split signatures into their own opam packages by samoht · Pull Request #743 · mirage/mirage · GitHub](https://github.com/mirage/mirage/pull/743)
- mirage-dev: [do not merge Adapt to the new error scheme by samoht · Pull Request #273 · mirage/mirage-dev · GitHub](https://github.com/mirage/mirage-dev/pull/273)
- mirage-skeleton: [Update to new error scheme in mirage-types by samoht · Pull Request #213 · mirage/mirage-skeleton · GitHub](https://github.com/mirage/mirage-skeleton/pull/213)

### Add new constraints

- ocaml-dns-forward: [Add a constraint for the version of mirage-flow to use by samoht · Pull Request #50 · djs55/ocaml-dns-forward · GitHub](https://github.com/djs55/ocaml-dns-forward/pull/50)
