### PR TITLE
Doc

### DIFF
--- a/Dockerfile.doc
+++ b/Dockerfile.doc
@@ -144,14 +144,15 @@ RUN opam depext -uivj 3 \
   xenstore \
   zarith-freestanding
 # to fix: dns-forward nbd qcow vhd-format git datakit-server hvsock datakit-github datakit-ci mirage-block-ccm tar-format ezirmin irmin conduit
-RUN opam config exec -- odig ocamldoc
+RUN opam config exec -- odig ocamldoc --docdir-href ../_doc
 RUN opam pin add -n octavius git://github.com/ocaml-doc/octavius
 RUN opam pin add -n doc-ock git://github.com/ocaml-doc/doc-ock
 RUN opam pin add -n doc-ock-xml git://github.com/ocaml-doc/doc-ock-xml
 RUN opam pin add -n doc-ock-html git://github.com/ocaml-doc/doc-ock-html
 RUN opam pin add -n odoc git://github.com/ocaml-doc/odoc
 RUN opam depext -uivy -j 2 odoc
-RUN opam config exec -- odig odoc
+RUN opam config exec -- odig odoc --docdir-href _doc
 RUN ln -s /home/opam/.opam/4.03.0/var/cache/odig/ocamldoc /home/opam/.opam/4.03.0/var/cache/odig/odoc/_ocamldoc
+RUN ln -s /home/opam/.opam/4.03.0/doc /home/opam/.opam/4.03.0/var/cache/odig/odoc/_doc
 EXPOSE 8080
 ENTRYPOINT opam config exec -- cohttp-server-lwt /home/opam/.opam/4.03.0/var/cache/odig/odoc

--- a/Dockerfile.doc
+++ b/Dockerfile.doc
@@ -152,6 +152,6 @@ RUN opam pin add -n doc-ock-html git://github.com/ocaml-doc/doc-ock-html
 RUN opam pin add -n odoc git://github.com/ocaml-doc/odoc
 RUN opam depext -uivy -j 2 odoc
 RUN opam config exec -- odig odoc
-RUN ln -s /home/opam/.opam/4.03.0/var/cache/odig/ocamldoc /home/opam/.opam/4.03.0/var/cache/odig/odoc/ocamldoc_
+RUN ln -s /home/opam/.opam/4.03.0/var/cache/odig/ocamldoc /home/opam/.opam/4.03.0/var/cache/odig/odoc/_ocamldoc
 EXPOSE 8080
 ENTRYPOINT opam config exec -- cohttp-server-lwt /home/opam/.opam/4.03.0/var/cache/odig/odoc


### PR DESCRIPTION
This should allow to dereference distribution documentation on http://docs.mirage.io. I also changed the address of publication of the `ocamldoc` doc set to make sure there can't be any clash with an existing package.