### PR TITLE
mirage-types-lwt: minor fixes

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -7,6 +7,8 @@ PKG astring logs bos mirage-runtime
 PKG mirage-device mirage-time mirage-time-lwt mirage-random
 PKG mirage-flow mirage-flow-lwt mirage-console mirage-console-lwt
 PKG mirage-block-lwt mirage-net-lwt mirage-fs-lwt mirage-kv-lwt
+PKG mirage-clock mirage-clock-lwt mirage-stack mirage-stack-lwt
+PKG mirage-protocols mirage-protocols-lwt mirage-channel mirage-channel-lwt
 
 FLG -w +A-4-6-7-9-40-42-44-48
 FLG -strict_sequence -safe_string

--- a/_tags
+++ b/_tags
@@ -8,8 +8,7 @@ true: keep_locs
 <lib/*>: package(ipaddr logs astring functoria functoria.app mirage-runtime bos)
 
 # Force the runtime to be unix-independent.
-<lib_runtime/*>: package(functoria-runtime ipaddr astring logs mirage-types)
-<lib_runtime/*>: package(mirage-device)
+<lib_runtime/*>: package(functoria-runtime ipaddr astring logs mirage-types fmt)
 <lib_runtime/*>: dontlink(unix str num threads)
 
 <types/mirage_types.*>: package(mirage-device mirage-time mirage-random mirage-flow)

--- a/_tags
+++ b/_tags
@@ -12,7 +12,7 @@ true: keep_locs
 <lib_runtime/*>: package(mirage-device)
 <lib_runtime/*>: dontlink(unix str num threads)
 
-<types/mirage_types.*>: package(result mirage-device mirage-time mirage-random mirage-flow)
+<types/mirage_types.*>: package(mirage-device mirage-time mirage-random mirage-flow)
 <types/mirage_types.*>: package(mirage-console mirage-block mirage-clock mirage-net)
 <types/mirage_types.*>: package(mirage-kv mirage-fs mirage-channel)
 <types/mirage_types.*>: package(mirage-protocols mirage-stack)

--- a/_tags
+++ b/_tags
@@ -8,7 +8,7 @@ true: keep_locs
 <lib/*>: package(ipaddr logs astring functoria functoria.app mirage-runtime bos)
 
 # Force the runtime to be unix-independent.
-<lib_runtime/*>: package(functoria-runtime ipaddr astring logs mirage-types fmt)
+<lib_runtime/*>: package(functoria-runtime ipaddr astring logs fmt)
 <lib_runtime/*>: dontlink(unix str num threads)
 
 <types/mirage_types.*>: package(mirage-device mirage-time mirage-random mirage-flow)

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -20,6 +20,5 @@ depends: [
   "fmt"
   "astring"
   "logs"
-  "mirage-types"       {>= "3.0.0"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -20,7 +20,6 @@ depends: [
   "fmt"
   "astring"
   "logs"
-  "mirage-types"
-  "mirage-device"
+  "mirage-types"       {>= "3.0.0"}
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/mirage-types-lwt.opam
+++ b/mirage-types-lwt.opam
@@ -8,8 +8,8 @@ tags:         ["org:mirage" "org:xapi-project"]
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 depends: [
-  "ocamlfind" {build}
   "ocamlfind"  {build}
+  "ocamlbuild" {build}
   "topkg"      {build & >= "0.8.0"}
   "lwt"
   "cstruct" {>="1.4.0"}

--- a/mirage-types-lwt.opam
+++ b/mirage-types-lwt.opam
@@ -9,6 +9,8 @@ tags:         ["org:mirage" "org:xapi-project"]
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--pinned" "%{pinned}%"]
 depends: [
   "ocamlfind" {build}
+  "ocamlfind"  {build}
+  "topkg"      {build & >= "0.8.0"}
   "lwt"
   "cstruct" {>="1.4.0"}
   "io-page" {>="1.4.0"}

--- a/mirage-types.opam
+++ b/mirage-types.opam
@@ -12,7 +12,6 @@ depends:   [
   "ocamlbuild" {build}
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.8.0"}
-  "result"
   "mirage-device"
   "mirage-time"
   "mirage-clock" {>= "1.2.0"}

--- a/mirage.opam
+++ b/mirage.opam
@@ -20,7 +20,7 @@ depends: [
   "bos"
   "astring"
   "logs"
-  "mirage-runtime"
+  "mirage-runtime"     {>= "3.0.0"}
 ]
 conflicts: [
   "nocrypto" {< "0.4.0"}

--- a/pkg/META.mirage
+++ b/pkg/META.mirage
@@ -1,6 +1,6 @@
 description = "MirageOS configuration tool"
 version = "%%VERSION_NUM%%"
-requires = "ipaddr functoria functoria.app logs mirage-runtime bos"
+requires = "ipaddr functoria functoria.app logs mirage-runtime bos astring"
 archive(byte) = "mirage.cma"
 archive(native) = "mirage.cmxa"
 plugin(byte) = "mirage.cma"

--- a/pkg/META.mirage-runtime
+++ b/pkg/META.mirage-runtime
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "MirageOS runtime libraries"
-requires = "functoria-runtime fmt ipaddr astring logs mirage-types"
+requires = "functoria-runtime fmt ipaddr astring logs"
 archive(byte) = "mirage-runtime.cma"
 archive(native) = "mirage-runtime.cmxa"
 plugin(byte) = "mirage-runtime.cma"

--- a/pkg/META.mirage-runtime
+++ b/pkg/META.mirage-runtime
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "MirageOS runtime libraries"
-requires = "functoria-runtime ipaddr astring logs mirage-types"
+requires = "functoria-runtime fmt ipaddr astring logs mirage-types"
 archive(byte) = "mirage-runtime.cma"
 archive(native) = "mirage-runtime.cmxa"
 plugin(byte) = "mirage-runtime.cma"

--- a/pkg/META.mirage-types
+++ b/pkg/META.mirage-types
@@ -1,3 +1,3 @@
 version = "%%VERSION_NUM%%"
 description = "Collection of module signatures for MirageOS"
-requires = "result mirage-device mirage-time mirage-random mirage-flow mirage-console mirage-block mirage-clock mirage-net mirage-kv mirage-fs mirage-channel mirage-protocols mirage-stack"
+requires = "mirage-device mirage-time mirage-random mirage-flow mirage-console mirage-block mirage-clock mirage-net mirage-kv mirage-fs mirage-channel mirage-protocols mirage-stack"

--- a/pkg/META.mirage-types
+++ b/pkg/META.mirage-types
@@ -1,3 +1,3 @@
 version = "%%VERSION_NUM%%"
 description = "Collection of module signatures for MirageOS"
-requires = "result mirage-device mirage-time mirage-random mirage-flow mirage-console mirage-block mirage-clock mirage-net mirage-kv mirage-fs mirage-channel"
+requires = "result mirage-device mirage-time mirage-random mirage-flow mirage-console mirage-block mirage-clock mirage-net mirage-kv mirage-fs mirage-channel mirage-protocols mirage-stack"

--- a/pkg/META.mirage-types-lwt
+++ b/pkg/META.mirage-types-lwt
@@ -1,3 +1,3 @@
 version = "%%VERSION_NUM%%"
 description = "Collection of lwt module signatures for MirageOS"
-requires = "cstruct io-page ipaddr mirage-types mirage-time-lwt mirage-random mirage-flow-lwt mirage-console-lwt mirage-block-lwt mirage-clock-lwt mirage-kv-lwt mirage-fs-lwt mirage-net-lwt mirage-channel-lwt"
+requires = "cstruct io-page ipaddr mirage-types mirage-time-lwt mirage-random mirage-flow-lwt mirage-console-lwt mirage-block-lwt mirage-clock-lwt mirage-kv-lwt mirage-fs-lwt mirage-net-lwt mirage-channel-lwt mirage-stack-lwt mirage-protocols-lwt"

--- a/types/mirage_types.mli
+++ b/types/mirage_types.mli
@@ -16,8 +16,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
-
 (** MirageOS Signatures.
 
     This module defines the basic signatures that functor parameters

--- a/types/mirage_types_lwt.mli
+++ b/types/mirage_types_lwt.mli
@@ -20,9 +20,10 @@
 
     {e Release %%VERSION%% } *)
 
-open Mirage_types
-
 module type TIME = Mirage_time_lwt.S
+module type MCLOCK = Mirage_clock_lwt.MCLOCK
+module type PCLOCK = Mirage_clock_lwt.PCLOCK
+
 module type RANDOM = Mirage_random.C
 module type FLOW = Mirage_flow_lwt.S
 


### PR DESCRIPTION
- adjust merlin
- add mirage-stack{-lwt} mirage-protocols{-lwt} to META of mirage-types{-lwt}
- export Mirage_types_lwt.{PCLOCK, MCLOCK} (provided by mirage-clock-lwt)

imho straightforward @yomimono 