### PR TITLE
mirage-block-ccm works with new MirageOS

### DIFF
--- a/Dockerfile.doc
+++ b/Dockerfile.doc
@@ -65,6 +65,7 @@ RUN opam depext -uivj 3 \
   merlin \
   mirage \
   mirage-block \
+  mirage-block-ccm \
   mirage-block-lwt \
   mirage-block-ramdisk \
   mirage-block-solo5 \
@@ -150,7 +151,7 @@ RUN opam depext -uivj 3 \
   yojson \
   xenstore \
   zarith-freestanding
-# to fix: dns-forward nbd qcow vhd-format datakit-ci mirage-block-ccm tar-format ezirmin
+# to fix: dns-forward nbd qcow vhd-format datakit-ci tar-format ezirmin
 RUN opam config exec -- odig ocamldoc --docdir-href ../_doc
 RUN opam pin add -n octavius git://github.com/ocaml-doc/octavius
 RUN opam pin add -n doc-ock git://github.com/ocaml-doc/doc-ock

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.8.0"}
   "ipaddr"             {>= "2.6.0"}
-  "functoria-runtime"
+  "functoria-runtime"  {>= "2.0.0"}
   "fmt"
   "astring"
   "logs"

--- a/mirage.opam
+++ b/mirage.opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"  {build}
   "topkg"      {build & >= "0.8.0"}
   "ipaddr"             {>= "2.6.0"}
-  "functoria"          {>= "1.1.0"}
+  "functoria"          {>= "2.0.0"}
   "bos"
   "astring"
   "logs"


### PR DESCRIPTION
(see https://github.com/sg2342/mirage-block-ccm/pull/21)