### PR TITLE
don't pass io-page module to ocaml-fat FS.make

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -435,16 +435,16 @@ let fs = Type FS
 
 let fat_conf = impl @@ object
     inherit base_configurable
-    method ty = (block @-> io_page @-> fs)
+    method ty = (block @-> fs)
     method packages = Key.pure [ package "fat-filesystem" ]
     method name = "fat"
     method module_name = "Fat.FS"
     method connect _ modname l = match l with
-      | [ block_name ; _iop ] -> Fmt.strf "%s.connect %s" modname block_name
-      | _ -> failwith (connect_err "fat" 2)
+      | [ block_name ] -> Fmt.strf "%s.connect %s" modname block_name
+      | _ -> failwith (connect_err "fat" 1)
   end
 
-let fat ?(io_page=default_io_page) block = fat_conf $ block $ io_page
+let fat block = fat_conf $ block
 
 let fat_block ?(dir=".") ?(regexp="*") () =
   let name =

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -205,7 +205,7 @@ type fs
 val fs: fs typ
 (** Implementations of the [Mirage_types.FS] signature. *)
 
-val fat: ?io_page:io_page impl -> block impl -> fs impl
+val fat: block impl -> fs impl
 (** Consider a raw block device as a FAT filesystem. *)
 
 val fat_of_files: ?dir:string -> ?regexp:string -> unit -> fs impl


### PR DESCRIPTION
As of https://github.com/mirage/ocaml-fat/commit/45b521b4d0254cbf5c1bbcb573fa2af79f4805d7 , ocaml-fat no longer expects to take an Io_page module argument.  Don't try to pass it one.