### PR TITLE
fix resolver depends (uses conduit, not dns)

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1069,7 +1069,8 @@ let resolver_dns_conf ~ns ~ns_port = impl @@ object
     method name = "resolver"
     method module_name = "Resolver_mirage.Make_with_stack"
     method packages =
-      Key.pure [ package ~sublibs:["mirage"] "dns"; package "tcpip" ]
+      Key.pure [ package ~ocamlfind:[] "mirage-conduit" ;
+        package ~sublibs:["mirage"] "conduit" ]
     method connect _ modname = function
       | [ _t ; stack ] ->
         let meta_ns = Fmt.Dump.option meta_ipv4 in


### PR DESCRIPTION
`dns` provides `Dns_resolver_mirage.Make` , not `Resolver_mirage.Make_with_stack` and doesn't look like the right fit for the generated code.