### PR TITLE
readme: Bump minimum OCaml version to 4.03.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ locally or use the Docker image.
 
 You will need the following:
 
-* a working [OCaml](https://ocaml.org) compiler (4.02.3 or higher).
+* a working [OCaml](https://ocaml.org) compiler (4.03.0 or higher).
 * the [OPAM](https://opam.ocaml.org) source package manager (1.2.2 or higher).
 * an x86\_64 or armel Linux host to compile Xen kernels, or FreeBSD, OpenBSD or
   MacOS X for the userlevel version.


### PR DESCRIPTION
Because functoria 2.0.0 requires 4.03.0 or later

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>