### PR TITLE
Allow qubesdb to be used under Xen

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -104,7 +104,7 @@ let qubesdb_conf = object
   method packages = Key.pure [ package "mirage-qubes" ]
   method configure i =
     match get_target i with
-    | `Qubes -> R.ok ()
+    | `Qubes | `Xen -> R.ok ()
     | _ -> R.error_msg "Qubes DB invoked for non-Qubes target."
   method connect _ modname _args = Fmt.strf "%s.connect ~domid:0 ()" modname
 end

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -105,7 +105,7 @@ let qubesdb_conf = object
   method configure i =
     match get_target i with
     | `Qubes | `Xen -> R.ok ()
-    | _ -> R.error_msg "Qubes DB invoked for non-Qubes target."
+    | _ -> R.error_msg "Qubes DB invoked for an unsupported target; qubes and xen are supported"
   method connect _ modname _args = Fmt.strf "%s.connect ~domid:0 ()" modname
 end
 


### PR DESCRIPTION
`-t qubes` is useful to run generic unikernels on Qubes, but for Qubes-specific unikernels we need to use the Xen target so that we can control the agents directly.

See e.g. https://github.com/talex5/qubes-mirage-skeleton/pull/2