### PR TITLE
don't add "-color always" to ocamlbuild invocation, since it breaks some scripts

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1671,7 +1671,6 @@ let compile libs warn_error target =
   let tags =
     [ Fmt.strf "predicate(%s)" (backend_predicate target);
       "warn(A-4-41-42-44)";
-      "color(always)";
       "debug";
       "bin_annot";
       "strict_sequence";


### PR DESCRIPTION
OCaml (since 4.03.0) attempts to colorise warnings and errors (in a "auto" mode
by default, which checks whether stdout is a tty).  ocamlbuild does not execute
ocaml in a tty, this is why by default there is no color.

An upstream fix to consider the environment variable OCAML_COLOR in case no
"-color" command line flag was provided is proposed, and may be included in
4.05.0.  In the meantime, revert to no colored output (as in Mirage <3.0.0).

Fixes #797 (and @haesbaert mentioned the same in some emacs script https://github.com/mirage/mirage/issues/761#issuecomment-280501942)