### PR TITLE
docs: also prune git-unix for now until we can carefully re-add

### DIFF
--- a/Dockerfile.doc
+++ b/Dockerfile.doc
@@ -37,7 +37,6 @@ RUN opam depext -uivj 3 \
   fat-filesystem \
   functoria \
   git \
-  git-unix \
   github \
   gmp-freestanding \
   hex \
@@ -142,7 +141,7 @@ RUN opam depext -uivj 3 \
   yojson \
   xenstore \
   zarith-freestanding
-# to fix: dns-forward nbd qcow vhd-format datakit-ci tar-format ezirmin datakit hvsock mirage-block-ccm git-mirage topkg-care
+# to fix: dns-forward nbd qcow vhd-format datakit-ci tar-format ezirmin datakit hvsock mirage-block-ccm git-mirage topkg-care git-unix
 RUN opam config exec -- odig ocamldoc --docdir-href ../_doc
 RUN opam pin add -n octavius git://github.com/ocaml-doc/octavius
 RUN opam pin add -n doc-ock git://github.com/ocaml-doc/doc-ock


### PR DESCRIPTION
This leads to an epic conflict with uuseg, git, cmdliner and the
world explodes.  I just want to rebuild docs.mirage.io and then
re-add the packages in a cmdliner 1.0 world, so disabling git-unix
for now from the docs list.