### PR TITLE
docs: pin odig to a building branch to refresh our docs

### DIFF
--- a/Dockerfile.doc
+++ b/Dockerfile.doc
@@ -1,6 +1,6 @@
 FROM ocaml/opam:ubuntu-16.04_ocaml-4.03.0
 RUN cd /home/opam/opam-repository && git pull origin master && opam update
-RUN opam pin add -n odig https://github.com/dbuenzli/odig.git
+RUN opam pin add -n odig https://github.com/avsm/odig.git#mtime-1.0
 RUN opam depext -uivy -j 2 odig odoc
 RUN opam pin add cmdliner 1.0.0
 RUN opam depext -uivj 3 \


### PR DESCRIPTION
Needed for mtime.1.0 support.
The upstream issue for odig is https://github.com/dbuenzli/odig/pull/27