### PR TITLE
Automatically require io-page-{xen,unix} on Xen and Unix

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1933,12 +1933,14 @@ module Project = struct
           package ~build:true "ocamlbuild" ;
         ] in
         Key.match_ Key.(value target) @@ function
-        | `Xen | `Qubes -> [ package ~min:"3.0.0" "mirage-xen" ] @ common
+        | `Xen | `Qubes -> [ package ~min:"3.0.0" "mirage-xen";
+                             package "io-page-xen" ] @ common
         | `Virtio -> [ package ~min:"0.2.1" ~ocamlfind:[] "solo5-kernel-virtio" ;
                        package ~min:"0.2.0" "mirage-solo5" ] @ common
         | `Ukvm -> [ package ~min:"0.2.1" ~ocamlfind:[] "solo5-kernel-ukvm" ;
                      package ~min:"0.2.0" "mirage-solo5" ] @ common
-        | `Unix | `MacOSX -> [ package ~min:"3.0.0" "mirage-unix" ] @ common
+        | `Unix | `MacOSX -> [ package ~min:"3.0.0" "mirage-unix" ;
+                               package "io-page-unix"; ] @ common
 
       method build = build
       method configure = configure


### PR DESCRIPTION
Previously the correct stubs were found because `io-page` was in the
dependency list and everything was in the same `META` file with global
`xen_linkopts`. [mirage/io-page#46] splits `io-page` into 3 packages
and hence 3 distinct `META` files. Therefore we must depend explicitly
on `io-page-xen` to discover the `xen_linkopts`. This patch also adds
a dependency on `io-page-unix` to the `Unix` target for symmetry, although
there is no `xen_linkopts`: the OCaml compiler figures that out for itself.

Signed-off-by: David Scott <dave@recoil.org>