### PR TITLE
Remove io-page-unix from Ukvm and Virtio

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 * add a --block configure flag for picking ramdisk or file-backed disk
 * add lower bounds on packages
 * fallback to system `$PKG_CONFIG_PATH`
-* update for mirage-qubes-ipv4, io-page-unix, io-page-xen
+* update for mirage-qubes-ipv4
 
 ### 3.0.2 (2017-03-15)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-### 3.0.3 (2017-06-14)
+### 3.0.4 (2017-06-15)
 * add a --block configure flag for picking ramdisk or file-backed disk
 * add lower bounds on packages
 * fallback to system `$PKG_CONFIG_PATH`

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1936,11 +1936,9 @@ module Project = struct
         | `Xen | `Qubes -> [ package ~min:"3.0.0" "mirage-xen";
                              package "io-page-xen" ] @ common
         | `Virtio -> [ package ~min:"0.2.1" ~ocamlfind:[] "solo5-kernel-virtio" ;
-                       package ~min:"0.2.0" "mirage-solo5";
-                       package "io-page-unix" ] @ common
+                       package ~min:"0.2.0" "mirage-solo5" ] @ common
         | `Ukvm -> [ package ~min:"0.2.1" ~ocamlfind:[] "solo5-kernel-ukvm" ;
-                     package ~min:"0.2.0" "mirage-solo5";
-                     package "io-page-unix"; ] @ common
+                     package ~min:"0.2.0" "mirage-solo5" ] @ common
         | `Unix | `MacOSX -> [ package ~min:"3.0.0" "mirage-unix" ;
                                package "io-page-unix"; ] @ common
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1933,14 +1933,12 @@ module Project = struct
           package ~build:true "ocamlbuild" ;
         ] in
         Key.match_ Key.(value target) @@ function
-        | `Xen | `Qubes -> [ package ~min:"3.0.0" "mirage-xen";
-                             package "io-page-xen" ] @ common
+        | `Xen | `Qubes -> [ package ~min:"3.0.0" "mirage-xen" ] @ common
         | `Virtio -> [ package ~min:"0.2.1" ~ocamlfind:[] "solo5-kernel-virtio" ;
                        package ~min:"0.2.0" "mirage-solo5" ] @ common
         | `Ukvm -> [ package ~min:"0.2.1" ~ocamlfind:[] "solo5-kernel-ukvm" ;
                      package ~min:"0.2.0" "mirage-solo5" ] @ common
-        | `Unix | `MacOSX -> [ package ~min:"3.0.0" "mirage-unix" ;
-                               package "io-page-unix"; ] @ common
+        | `Unix | `MacOSX -> [ package ~min:"3.0.0" "mirage-unix" ] @ common
 
       method build = build
       method configure = configure


### PR DESCRIPTION
Neither of these backends should need or can use the Unix stub.

I built these using
```
opam init git://github.com/djs55/opam-repository#io-page
opam pin mirage .
git clone git://github.com/mirage/mirage-skeleton
cd mirage-skeleton
make clean && make MODE=xen
make clean && make MODE=unix
make clean && make MODE=virtio
make clean && make MODE=ukvm
```
(I notice the CI only does `xen` and `unix`)
```
