### PR TITLE
Call depext with the --update flag in make depend

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1614,7 +1614,7 @@ let configure_makefile ~opam_name =
       append fmt "-include Makefile.user";
       newline fmt;
       append fmt "OPAM = opam\n\
-                  DEPEXT ?= opam depext --yes %s\n\
+                  DEPEXT ?= opam depext --yes --update %s\n\
                   \n\
                   .PHONY: all depend depends clean build\n\
                   all:: build\n\


### PR DESCRIPTION
This is more reliable.  The update won't be triggered if all packages are
installed.

Alternative to #840.