### PR TITLE
doc updates: remove odig pin, trim package list, pin cstruct

### DIFF
--- a/Dockerfile.doc
+++ b/Dockerfile.doc
@@ -1,7 +1,5 @@
 FROM ocaml/opam:ubuntu-16.04_ocaml-4.03.0
 RUN cd /home/opam/opam-repository && git pull origin master && opam update
-RUN opam pin add -n odig https://github.com/dbuenzli/odig.git
-RUN opam depext -uivy -j 2 odig odoc
 RUN opam depext -uivj 3 \
   alcotest \
   angstrom \
@@ -21,7 +19,7 @@ RUN opam depext -uivj 3 \
   cowabloga \
   cpuid \
   crunch \
-  cstruct \
+  cstruct.3.0.2 \
   ctypes \
   ctypes-foreign \
   depyt \
@@ -97,7 +95,6 @@ RUN opam depext -uivj 3 \
   opam-file-format \
   opam-lib \
   otr \
-  owl \
   parse-argv \
   pbkdf \
   pcap-format \
@@ -115,7 +112,6 @@ RUN opam depext -uivj 3 \
   syslog-message \
   tcpip \
   tls \
-  tlstunnel \
   tyre \
   topkg \
   tuntap \
@@ -134,7 +130,8 @@ RUN opam depext -uivj 3 \
   yojson \
   xenstore \
   zarith-freestanding
-# to fix: dns-forward nbd qcow vhd-format datakit-ci tar-format ezirmin datakit hvsock mirage-block-ccm git-mirage topkg-care git-unix irmin websocket charrua-core charrua-unix fat-filesystem ansi-parse
+# to fix: dns-forward nbd qcow vhd-format datakit-ci tar-format ezirmin datakit hvsock mirage-block-ccm git-mirage topkg-care git-unix irmin websocket charrua-core charrua-unix fat-filesystem ansi-parse tlstunnel
+# not relevant: owl
 RUN opam config exec -- odig ocamldoc --docdir-href ../_doc
 RUN opam config exec -- odig odoc --docdir-href _doc
 RUN ln -s /home/opam/.opam/4.03.0/var/cache/odig/ocamldoc /home/opam/.opam/4.03.0/var/cache/odig/odoc/_ocamldoc


### PR DESCRIPTION
pinning cstruct ensures that we can cull packages that are
lagging behind the dependency cone. This is just tlstunnel
for the moment.