### PR TITLE
Adding --gdb argument for ukvm

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1681,9 +1681,9 @@ let configure i =
   let target = Key.(get ctx target) in
   Log.info (fun m -> m "Configuring for target: %a" Key.pp_target target);
   let opam_name = unikernel_name target name in
-  let gdb = Key.(get ctx gdb) in
-  if gdb && target <> `Ukvm then
-    Log.warn (fun m -> m "--gdb not supported on this target.");
+  let target_debug = Key.(get ctx target_debug) in
+  if target_debug && target <> `Ukvm then
+    Log.warn (fun m -> m "-g not supported on this target.");
   configure_myocamlbuild () >>= fun () ->
   configure_opam ~name:opam_name i >>= fun () ->
   configure_makefile ~opam_name >>= fun () ->
@@ -1800,7 +1800,7 @@ let ldflags pkg = pkg_config pkg ["--variable=ldflags"]
 
 let ldpostflags pkg = pkg_config pkg ["--variable=ldpostflags"]
 
-let link info name target gdb =
+let link info name target target_debug =
   let libs = Info.libraries info in
   match target with
   | `Unix | `MacOSX ->
@@ -1864,7 +1864,7 @@ let link info name target gdb =
         | "mirage-net-solo5" -> "net" :: acc
         | "mirage-block-solo5" -> "blk" :: acc
         | _ -> acc)
-        [] libs @ (if gdb then ["gdb"] else [])
+        [] libs @ (if target_debug then ["gdb"] else [])
     in
     pkg_config "solo5-kernel-ukvm" ["--variable=libdir"] >>= function
     | [ libdir ] ->
@@ -1881,10 +1881,10 @@ let build i =
   let warn_error = Key.(get ctx warn_error) in
   let target = Key.(get ctx target) in
   let libs = Info.libraries i in
-  let gdb = Key.(get ctx gdb) in
+  let target_debug = Key.(get ctx target_debug) in
   check_entropy libs >>= fun () ->
   compile libs warn_error target >>= fun () ->
-  link i name target gdb >>| fun out ->
+  link i name target target_debug >>| fun out ->
   Log.info (fun m -> m "Build succeeded: %s" out)
 
 let clean i =
@@ -1931,7 +1931,7 @@ module Project = struct
       method keys = [
         Key.(abstract target);
         Key.(abstract warn_error);
-        Key.(abstract gdb);
+        Key.(abstract target_debug);
       ]
       method packages =
         let common = [

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1683,7 +1683,7 @@ let configure i =
   let opam_name = unikernel_name target name in
   let target_debug = Key.(get ctx target_debug) in
   if target_debug && target <> `Ukvm then
-    Log.warn (fun m -> m "-g not supported on this target.");
+    Log.warn (fun m -> m "-g not supported for target: %a" Key.pp_target target);
   configure_myocamlbuild () >>= fun () ->
   configure_opam ~name:opam_name i >>= fun () ->
   configure_makefile ~opam_name >>= fun () ->

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -156,6 +156,12 @@ let warn_error =
   let key = Arg.(opt ~stage:`Configure bool false doc) in
   Key.create "warn_error" key
 
+let gdb =
+  let doc = "Start a gdb server (only available for ukvm)." in
+  let doc = Arg.info ~docs:mirage_section ~docv:"GDB" ~doc ["g";"gdb"] in
+  let key = Arg.flag ~stage:`Configure doc in
+  Key.create "gdb" key
+
 (** {3 Tracing} *)
 
 let tracing_size default =

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -156,11 +156,12 @@ let warn_error =
   let key = Arg.(opt ~stage:`Configure bool false doc) in
   Key.create "warn_error" key
 
-let gdb =
-  let doc = "Start a gdb server (only available for ukvm)." in
-  let doc = Arg.info ~docs:mirage_section ~docv:"GDB" ~doc ["g";"gdb"] in
+let target_debug =
+  let doc = "Enables target-specific support for debugging. Supported \
+             targets: ukvm (compiles ukvm-bin with GDB server support)." in
+  let doc = Arg.info ~docs:mirage_section ~docv:"DEBUG" ~doc ["g"] in
   let key = Arg.flag ~stage:`Configure doc in
-  Key.create "gdb" key
+  Key.create "target_debug" key
 
 (** {3 Tracing} *)
 

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -50,8 +50,8 @@ val warn_error: bool key
 (** [--warn-error]. Enable {i -warn-error} for OCaml sources. Set to [false] by
     default, but might might enabled by default in later releases. *)
 
-val gdb: bool key
-(** Start a GDB server. *)
+val target_debug: bool key
+(** Enables target-specific support for debugging. *)
 
 val tracing_size: int -> int key
 (** [--tracing-size]: Key setting the tracing ring buffer size. *)

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -50,6 +50,9 @@ val warn_error: bool key
 (** [--warn-error]. Enable {i -warn-error} for OCaml sources. Set to [false] by
     default, but might might enabled by default in later releases. *)
 
+val gdb: bool key
+(** Start a GDB server. *)
+
 val tracing_size: int -> int key
 (** [--tracing-size]: Key setting the tracing ring buffer size. *)
 


### PR DESCRIPTION
ukvm has a `gdb` module that starts a GDB server so debuggers can attach to it. Linking the `gdb` module is defined in `Makefile.ukvm` which is generated by mirage for every `ukvm` unikernel. This change adds a mirage `--gdb` flag that defines whether to add the `gdb` module to `Makefile.ukvm`. Additionally, this change also moves the generation of `Makefile.ukvm` to the mirage configure phase.

Here is the proposed flag, for the ukvm target:
```
$ mirage configure --gdb -t ukvm
$
```
and this for all others (just a warning):
```
$ mirage configure --gdb -t unix
mirage: [WARNING] --gdb not supported on this target.
$
```
You might have to pin the lastest solo5.

@mato