### PR TITLE
syslog: allow runtime configuration of log host

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -593,7 +593,7 @@ let ethernet_conf = object
   method ty = network @-> ethernet
   method name = "ethif"
   method module_name = "Ethif.Make"
-  method! packages = Key.pure [ package ~min:"3.1.0" ~sublibs:["ethif"] "tcpip" ]
+  method! packages = Key.pure [ package ~min:"3.1.0" ~max:"3.2.0" ~sublibs:["ethif"] "tcpip" ]
   method! connect _ modname = function
     | [ eth ] -> Fmt.strf "%s.connect %s" modname eth
     | _ -> failwith (connect_err "ethernet" 1)
@@ -610,7 +610,7 @@ let arpv4_conf = object
   method ty = ethernet @-> mclock @-> time @-> arpv4
   method name = "arpv4"
   method module_name = "Arpv4.Make"
-  method! packages = Key.pure [ package ~min:"3.0.0" ~sublibs:["arpv4"] "tcpip" ]
+  method! packages = Key.pure [ package ~min:"3.0.0" ~max:"3.2.0" ~sublibs:["arpv4"] "tcpip" ]
   method! connect _ modname = function
     | [ eth ; clock ; _time ] -> Fmt.strf "%s.connect %s %s" modname eth clock
     | _ -> failwith (connect_err "arpv4" 3)
@@ -674,7 +674,7 @@ let ipv4_keyed_conf ?network ?gateway () = impl @@ object
     method ty = ethernet @-> arpv4 @-> ipv4
     method name = Name.create "ipv4" ~prefix:"ipv4"
     method module_name = "Static_ipv4.Make"
-    method! packages = Key.pure [ package ~min:"3.1.0" ~sublibs:["ipv4"] "tcpip" ]
+    method! packages = Key.pure [ package ~min:"3.1.0" ~max:"3.2.0" ~sublibs:["ipv4"] "tcpip" ]
     method! keys = network @?? gateway @?? []
     method! connect _ modname = function
     | [ etif ; arp ] ->
@@ -754,7 +754,7 @@ let ipv6_conf ?addresses ?netmasks ?gateways () = impl @@ object
     method ty = ethernet @-> random @-> time @-> mclock @-> ipv6
     method name = Name.create "ipv6" ~prefix:"ipv6"
     method module_name = "Ipv6.Make"
-    method! packages = Key.pure [ package ~min:"3.1.0" ~sublibs:["ipv6"] "tcpip" ]
+    method! packages = Key.pure [ package ~min:"3.1.0" ~max:"3.2.0" ~sublibs:["ipv6"] "tcpip" ]
     method! keys = addresses @?? netmasks @?? gateways @?? []
     method! connect _ modname = function
       | [ etif ; _random ; _time ; clock ] ->
@@ -788,7 +788,7 @@ let icmpv4_direct_conf () = object
   method ty : ('a ip -> 'a icmp) typ = ip @-> icmp
   method name = "icmpv4"
   method module_name = "Icmpv4.Make"
-  method! packages = Key.pure [ package ~min:"3.0.0" ~sublibs:["icmpv4"] "tcpip" ]
+  method! packages = Key.pure [ package ~min:"3.0.0" ~max:"3.2.0" ~sublibs:["icmpv4"] "tcpip" ]
   method! connect _ modname = function
     | [ ip ] -> Fmt.strf "%s.connect %s" modname ip
     | _  -> failwith (connect_err "icmpv4" 1)
@@ -811,7 +811,7 @@ let udp_direct_conf () = object
   method ty = (ip: 'a ip typ) @-> random @-> (udp: 'a udp typ)
   method name = "udp"
   method module_name = "Udp.Make"
-  method! packages = Key.pure [ package ~min:"3.0.0" ~sublibs:["udp"] "tcpip" ]
+  method! packages = Key.pure [ package ~min:"3.0.0" ~max:"3.2.0" ~sublibs:["udp"] "tcpip" ]
   method! connect _ modname = function
     | [ ip; _random ] -> Fmt.strf "%s.connect %s" modname ip
     | _  -> failwith (connect_err "udp" 2)
@@ -829,7 +829,7 @@ let udpv4_socket_conf ipv4_key = object
   method module_name = "Udpv4_socket"
   method! keys = [ Key.abstract ipv4_key ]
   method! packages =
-    Key.(if_ is_unix) [ package ~min:"3.0.0" ~sublibs:["udpv4-socket"] "tcpip" ] []
+    Key.(if_ is_unix) [ package ~min:"3.0.0" ~max:"3.2.0" ~sublibs:["udpv4-socket"] "tcpip" ] []
   method! configure i =
     match get_target i with
     | `Unix | `MacOSX -> R.ok ()
@@ -853,7 +853,7 @@ let tcp_direct_conf () = object
   method ty = (ip: 'a ip typ) @-> time @-> mclock @-> random @-> (tcp: 'a tcp typ)
   method name = "tcp"
   method module_name = "Tcp.Flow.Make"
-  method! packages = Key.pure [ package ~min:"3.1.0" ~sublibs:["tcp"] "tcpip" ]
+  method! packages = Key.pure [ package ~min:"3.1.0" ~max:"3.2.0" ~sublibs:["tcp"] "tcpip" ]
   method! connect _ modname = function
     | [ip; _time; clock; _random] -> Fmt.strf "%s.connect %s %s" modname ip clock
     | _ -> failwith (connect_err "direct tcp" 4)
@@ -876,7 +876,7 @@ let tcpv4_socket_conf ipv4_key = object
   method module_name = "Tcpv4_socket"
   method! keys = [ Key.abstract ipv4_key ]
   method! packages =
-    Key.(if_ is_unix) [ package ~min:"3.0.0" ~sublibs:["tcpv4-socket"] "tcpip" ] []
+    Key.(if_ is_unix) [ package ~min:"3.0.0" ~max:"3.2.0" ~sublibs:["tcpv4-socket"] "tcpip" ] []
   method! configure i =
     match get_target i with
     | `Unix | `MacOSX -> R.ok ()
@@ -900,7 +900,7 @@ let stackv4_direct_conf ?(group="") () = impl @@ object
     val name = add_suffix "stackv4_" ~suffix:group
     method name = name
     method module_name = "Tcpip_stack_direct.Make"
-    method! packages = Key.pure [ package ~min:"3.0.0" ~sublibs:["stack-direct"] "tcpip" ]
+    method! packages = Key.pure [ package ~min:"3.0.0" ~max:"3.2.0" ~sublibs:["stack-direct"] "tcpip" ]
     method! connect _i modname = function
       | [ _t; _r; interface; ethif; arp; ip; icmp; udp; tcp ] ->
         Fmt.strf
@@ -951,7 +951,7 @@ let stackv4_socket_conf ?(group="") interfaces = impl @@ object
     method name = name
     method module_name = "Tcpip_stack_socket"
     method! keys = [ Key.abstract interfaces ]
-    method! packages = Key.pure [ package ~min:"3.0.0" ~sublibs:["stack-socket"] "tcpip" ]
+    method! packages = Key.pure [ package ~min:"3.0.0" ~max:"3.2.0" ~sublibs:["stack-socket"] "tcpip" ]
     method! deps = [abstract (socket_udpv4 None); abstract (socket_tcpv4 None)]
     method! connect _i modname = function
       | [ udpv4 ; tcpv4 ] ->
@@ -1001,8 +1001,8 @@ let tcp_conduit_connector = impl @@ object
     method module_name = "Conduit_mirage.With_tcp"
     method! packages =
       Key.pure [
-        package ~min:"2.3.0" ~ocamlfind:[] "mirage-conduit";
-        package ~min:"0.15.0" ~sublibs:["mirage"] "conduit"
+        package ~min:"2.3.0" ~max:"3.0.0" ~ocamlfind:[] "mirage-conduit";
+        package ~min:"0.15.0" ~max:"1.0.0" ~sublibs:["mirage"] "conduit"
       ]
     method! connect _ modname = function
       | [ stack ] -> Fmt.strf "Lwt.return (%s.connect %s)@;" modname stack
@@ -1020,8 +1020,8 @@ let tls_conduit_connector = impl @@ object
         package "mirage-flow-lwt";
         package "mirage-kv-lwt";
         package "mirage-clock";
-        package ~min:"2.3.0" ~ocamlfind:[] "mirage-conduit" ;
-        package ~min:"0.15.0" ~sublibs:["mirage"] "conduit"
+        package ~min:"2.3.0" ~max:"3.0.0" ~ocamlfind:[] "mirage-conduit" ;
+        package ~min:"0.15.0" ~max:"1.0.0" ~sublibs:["mirage"] "conduit"
       ]
     method! deps = [ abstract nocrypto ]
     method! connect _ _ _ = "Lwt.return Conduit_mirage.with_tls"
@@ -1037,8 +1037,8 @@ let conduit_with_connectors connectors = impl @@ object
     method module_name = "Conduit_mirage"
     method! packages =
       Key.pure [
-        package ~min:"2.3.0" ~ocamlfind:[] "mirage-conduit";
-        package ~min:"0.15.0" ~sublibs:["mirage"] "conduit"
+        package ~min:"2.3.0" ~max:"3.0.0" ~ocamlfind:[] "mirage-conduit";
+        package ~min:"0.15.0" ~max:"1.0.0" ~sublibs:["mirage"] "conduit"
       ]
     method! deps = abstract nocrypto :: List.map abstract connectors
 
@@ -1076,8 +1076,8 @@ let resolver_unix_system = impl @@ object
     method module_name = "Resolver_lwt"
     method! packages =
       Key.(if_ is_unix)
-        [ package ~min:"2.3.0" ~ocamlfind:[] "mirage-conduit" ;
-          package ~min:"0.15.0" ~sublibs:["mirage";"lwt-unix"] "conduit" ]
+        [ package ~min:"2.3.0" ~max:"3.0.0" ~ocamlfind:[] "mirage-conduit" ;
+          package ~min:"0.15.0" ~max:"1.0.0" ~sublibs:["mirage";"lwt-unix"] "conduit" ]
         []
     method! configure i =
       match get_target i with
@@ -1093,8 +1093,8 @@ let resolver_dns_conf ~ns ~ns_port = impl @@ object
     method module_name = "Resolver_mirage.Make_with_stack"
     method! packages =
       Key.pure [
-        package ~min:"2.3.0" ~ocamlfind:[] "mirage-conduit" ;
-        package ~min:"0.15.0" ~sublibs:["mirage"] "conduit"
+        package ~min:"2.3.0" ~max:"3.0.0" ~ocamlfind:[] "mirage-conduit" ;
+        package ~min:"0.15.0" ~max:"1.0.0" ~sublibs:["mirage"] "conduit"
       ]
     method! connect _ modname = function
       | [ _t ; stack ] ->

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1115,18 +1115,18 @@ let resolver_dns ?ns ?ns_port ?(time = default_time) stack =
 
 type syslog_config = {
   hostname : string;
-  server   : Ipaddr.V4.t;
+  server   : Ipaddr.V4.t option;
   port     : int option;
   truncate : int option;
 }
 
-let syslog_config ?port ?truncate hostname server = {
+let syslog_config ?port ?truncate ?server hostname = {
   hostname ; server ; port ; truncate
 }
 
 let default_syslog_config =
   let hostname = "no_name"
-  and server = Ipaddr.V4.of_string_exn "10.0.0.1"
+  and server = None
   and port = None
   and truncate = None
   in
@@ -1154,16 +1154,20 @@ let syslog_udp_conf config =
     method! connect _i modname = function
       | [ console ; pclock ; stack ] ->
         Fmt.strf
-          "let port = %a in \
-           let reporter = \
-             %s.create %s %s %s ~hostname:%a ?port %a %a () \
-           in \
-           Logs.set_reporter reporter; \
-           Lwt.return_unit"
+          "@[<v 2>\
+           match %a with@ \
+           | None -> Lwt.return_unit@ \
+           | Some server ->@ \
+             let port = %a in@ \
+             let reporter =@ \
+               %s.create %s %s %s ~hostname:%a ?port server %a ()@ \
+             in@ \
+             Logs.set_reporter reporter;@ \
+             Lwt.return_unit@]"
+          pp_key endpoint
           pp_key port
           modname console pclock stack
           pp_key hostname
-          pp_key endpoint
           (opt_int "truncate") config.truncate
       | _ -> failwith (connect_err "syslog udp" 3)
   end
@@ -1186,14 +1190,18 @@ let syslog_tcp_conf config =
     method! connect _i modname = function
       | [ console ; pclock ; stack ] ->
         Fmt.strf
-          "let port = %a in \
-           %s.create %s %s %s ~hostname:%a ?port %a %a () >>= function \
-           | Ok reporter -> Logs.set_reporter reporter; Lwt.return_unit \
-           | Error e -> invalid_arg e"
+          "@[<v 2>\
+           match %a with@ \
+           | None -> Lwt.return_unit@ \
+           | Some server ->@ \
+             let port = %a in@ \
+             %s.create %s %s %s ~hostname:%a ?port server %a () >>= function@ \
+             | Ok reporter -> Logs.set_reporter reporter; Lwt.return_unit@ \
+             | Error e -> invalid_arg e@]"
+          pp_key endpoint
           pp_key port
           modname console pclock stack
           pp_key hostname
-          pp_key endpoint
           (opt_int "truncate") config.truncate
       | _ -> failwith (connect_err "syslog tcp" 3)
   end
@@ -1216,14 +1224,18 @@ let syslog_tls_conf ?keyname config =
     method! connect _i modname = function
       | [ console ; pclock ; stack ; kv ] ->
         Fmt.strf
-          "let port = %a in\
-           %s.create %s %s %s %s ~hostname:%a ?port %a %a %a () >>= function \
-           | Ok reporter -> Logs.set_reporter reporter; Lwt.return_unit \
-           | Error e -> invalid_arg e"
+          "@[<v 2>\
+           match %a with@ \
+           | None -> Lwt.return_unit@ \
+           | Some server ->@ \
+             let port = %a in@ \
+             %s.create %s %s %s %s ~hostname:%a ?port server %a %a () >>= function@ \
+             | Ok reporter -> Logs.set_reporter reporter; Lwt.return_unit@ \
+             | Error e -> invalid_arg e@]"
+          pp_key endpoint
           pp_key port
           modname console pclock stack kv
           pp_key hostname
-          pp_key endpoint
           (opt_int "truncate") config.truncate
           (opt_string "keyname") keyname
       | _ -> failwith (connect_err "syslog tls" 4)

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -441,16 +441,13 @@ type syslog
 val syslog: syslog typ
 (** Implementation of the {!syslog} type. *)
 
-val syslog_udp: syslog_config -> ?console:console impl -> ?clock:pclock impl ->
-  stackv4 impl -> syslog impl
+val syslog_udp: ?config:syslog_config -> ?console:console impl -> ?clock:pclock impl -> stackv4 impl -> syslog impl
 (** Emit log messages via UDP to the configured host. *)
 
-val syslog_tcp: syslog_config -> ?console:console impl -> ?clock:pclock impl ->
-  stackv4 impl -> syslog impl
+val syslog_tcp: ?config:syslog_config -> ?console:console impl -> ?clock:pclock impl -> stackv4 impl -> syslog impl
 (** Emit log messages via TCP to the configured host. *)
 
-val syslog_tls: syslog_config -> ?keyname:string -> ?console:console impl ->
-  ?clock:pclock impl -> stackv4 impl -> kv_ro impl -> syslog impl
+val syslog_tls: ?config:syslog_config -> ?keyname:string -> ?console:console impl -> ?clock:pclock impl -> stackv4 impl -> kv_ro impl -> syslog impl
 (** Emit log messages via TLS to the configured host, using the credentials
     (private ekey, certificate, trust anchor) provided in the KV_RO using the
     [keyname]. *)

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -427,12 +427,12 @@ val resolver_unix_system: resolver impl
 
 type syslog_config = {
   hostname : string;
-  server   : Ipaddr.V4.t;
+  server   : Ipaddr.V4.t option;
   port     : int option;
   truncate : int option
 }
 
-val syslog_config: ?port:int -> ?truncate:int -> string -> Ipaddr.V4.t -> syslog_config
+val syslog_config: ?port:int -> ?truncate:int -> ?server:Ipaddr.V4.t -> string -> syslog_config
 (** Helper for constructing a {!syslog_config}. *)
 
 type syslog

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -317,7 +317,7 @@ end
 
 let syslog default =
   let doc = Fmt.strf "syslog server" in
-  create_simple ~doc ~default Arg.ipv4_address "syslog"
+  create_simple ~doc ~default Arg.(some ipv4_address) "syslog"
 
 let syslog_port default =
   let doc = Fmt.strf "syslog server port" in

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -53,7 +53,7 @@ module Arg = struct
       Format.fprintf fmt "(Ipaddr.V4.Prefix.of_address_string_exn \"%s\")"
       @@ Ipaddr.V4.Prefix.to_address_string prefix ip
     in
-    let print fmt (prefix, ip) = 
+    let print fmt (prefix, ip) =
       Format.fprintf fmt "%s" @@ Ipaddr.V4.Prefix.to_address_string prefix ip
     in
     let parse str =
@@ -314,6 +314,18 @@ module V6 = struct
     create_simple ~doc ~default ?group Arg.(list ipv6) "gateways"
 
 end
+
+let syslog default =
+  let doc = Fmt.strf "syslog server" in
+  create_simple ~doc ~default Arg.ipv4_address "syslog"
+
+let syslog_port default =
+  let doc = Fmt.strf "syslog server port" in
+  create_simple ~doc ~default Arg.(some int) "syslog-port"
+
+let syslog_hostname default =
+  let doc = Fmt.strf "hostname to report to syslog" in
+  create_simple ~doc ~default Arg.string "syslog-hostname"
 
 let pp_level ppf = function
   | Logs.Error    -> Fmt.string ppf "Logs.Error"

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -130,7 +130,7 @@ module V6 : sig
 
 end
 
-val syslog: Ipaddr.V4.t -> Ipaddr.V4.t key
+val syslog: Ipaddr.V4.t option -> Ipaddr.V4.t option key
 (** The address to send syslog frames to. *)
 
 val syslog_port: int option -> int option key

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -130,4 +130,13 @@ module V6 : sig
 
 end
 
+val syslog: Ipaddr.V4.t -> Ipaddr.V4.t key
+(** The address to send syslog frames to. *)
+
+val syslog_port: int option -> int option key
+(** The port to send syslog frames to. *)
+
+val syslog_hostname: string -> string key
+(** The hostname to use in syslog frames. *)
+
 val logs: Mirage_runtime.log_threshold list key


### PR DESCRIPTION
previously, no keys were defined for configuring syslog, but all had to be done
in config.ml.  now, the config argument to syslog_udp/tcp/tls is optional, and
three keys are available:
--syslog=IPv4
--syslog-port=int
--syslog-hostname=string

the specific protocol to use (UDP/TCP/TLS) has to be provided at configuration
time (which is sensible because the specific library has to be linked into the
unikernel)