### PR TITLE
remove tcpip, charrua, and travis-docker.sh pins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-install: wget https://raw.githubusercontent.com/yomimono/ocaml-ci-scripts/extra-env/.travis-docker.sh #fork needed for extra_env, github pr#160
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
 script: bash -ex .travis-docker.sh
 sudo: required
 services:
@@ -9,15 +9,13 @@ env:
  global:
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="sh ./.travis-ci.sh"
-     # tcpip pin needed for tcpip.xen linking fix, yet unreleased -yomimono
-     # charrua pins needed until v0.9 release -yomimono
-   - PINS="tcpip.dev:--dev functoria.dev:--dev functoria-runtime.dev:--dev mirage.dev:. mirage-types.dev:. mirage-types-lwt.dev:. mirage-runtime.dev:. charrua-core.dev:--dev charrua-client.dev:https://github.com/mirage/charrua-core.git charrua-client-lwt.dev:https://github.com/mirage/charrua-core.git charrua-client-mirage.dev:https://github.com/mirage/charrua-core.git"
+   - PINS="functoria.dev:--dev functoria-runtime.dev:--dev mirage.dev:. mirage-types.dev:. mirage-types-lwt.dev:. mirage-runtime.dev:."
    - TESTS=false #testing via travis-ci.sh
  matrix:
    - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=xen"
    - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=ukvm"
    - PACKAGE=mirage DISTRO=debian-unstable OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=unix"
-     PINS="functoria.dev:--dev functoria-runtime.dev:--dev mirage.dev:. mirage-types.dev:. mirage-types-lwt.dev:. mirage-runtime.dev:. nocrypto.dev:https://github.com/samoht/ocaml-nocrypto.git#nocrypto-mirage charrua-core.dev:--dev charrua-client.dev:https://github.com/mirage/charrua-core.git charrua-client-lwt.dev:https://github.com/mirage/charrua-core.git charrua-client-mirage.dev:https://github.com/mirage/charrua-core.git tcpip.dev:--dev"
+     PINS="functoria.dev:--dev functoria-runtime.dev:--dev mirage.dev:. mirage-types.dev:. mirage-types-lwt.dev:. mirage-runtime.dev:. nocrypto.dev:https://github.com/samoht/ocaml-nocrypto.git#nocrypto-mirage"
    - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=xen"
    - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=ukvm"
    - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=virtio"


### PR DESCRIPTION
To be merged once its tests pass, which should be after tcpip 3.3.0 hits opam.