### PR TITLE
Prepare to release 3.0.6

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,5 +1,5 @@
 eval `opam config env`
 opam depext -uiy mirage
 cd ~
-git clone https://github.com/mirage/mirage-skeleton.git
+git clone -b mirage-dev https://github.com/mirage/mirage-skeleton.git
 make -C mirage-skeleton && rm -rf mirage-skeleton

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ env:
    - TESTS=false #testing via travis-ci.sh
  matrix:
    - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=xen"
-   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=ukvm"
-   - PACKAGE=mirage DISTRO=debian-unstable OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=unix"
+   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=ukvm"
+   - PACKAGE=mirage DISTRO=debian-unstable OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=unix"
    - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=xen"
-   - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=ukvm"
+   - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=ukvm"
    - PACKAGE=mirage DISTRO=centos-7 OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=virtio"
    - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=xen"
    - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=ukvm"
-   - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0 EXTRA_ENV="MODE=virtio"
+   - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.04.2 EXTRA_ENV="MODE=virtio"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### 3.0.6 (2017-11-16)
+
+* remove macOS < yosemite support (#860 by @hannesm)
+* rename `mirage-http` to `cohttp-mirage` (#863 by @djs55)
+  See [mirage/ocaml-cohttp#572]
+* opam: require OCaml 4.04.2+ (#867 by @hannesm)
+
 ### 3.0.5 (2017-08-08)
 
 * Allow runtime configuration of syslog via config keys `--syslog`,


### PR DESCRIPTION
This is a point release needed by rename of `mirage-http` to `cohttp-mirage` in [mirage/ocaml-cohttp#572] (due to be released in `cohttp.1.0.0` and `cohttp-mirage.3.0.0`)