### PR TITLE
opam: use https://github.com/mirage/mirage as the homepage

### DIFF
--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -3,7 +3,7 @@ maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
 authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
                "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
                "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
-homepage:     "https://mirage.io/"
+homepage:     "https://github.com/mirage/mirage"
 bug-reports:  "https://github.com/mirage/mirage/issues/"
 dev-repo:     "https://github.com/mirage/mirage.git"
 tags:         ["org:mirage" "org:xapi-project"]

--- a/mirage-types.opam
+++ b/mirage-types.opam
@@ -3,7 +3,7 @@ maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
 authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
                "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
                "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
-homepage:     "https://mirage.io/"
+homepage:     "https://github.com/mirage/mirage"
 bug-reports:  "https://github.com/mirage/mirage/issues/"
 dev-repo:     "https://github.com/mirage/mirage.git"
 tags:         ["org:mirage" "org:xapi-project"]

--- a/mirage.opam
+++ b/mirage.opam
@@ -3,7 +3,7 @@ maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
 authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
                "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
                "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
-homepage:     "https://mirage.io/"
+homepage:     "https://github.com/mirage/mirage"
 bug-reports:  "https://github.com/mirage/mirage/issues/"
 dev-repo:     "https://github.com/mirage/mirage.git"
 tags:         ["org:mirage" "org:xapi-project"]


### PR DESCRIPTION
This fixes the output of `make opam-pkg`, since `topkg` assumes the
download URL is based on the `homepage`.

See for example [ocaml/opam-repository#10843]

Note that mirage-types-lwt already used github.com/mirage/mirage
(and so was inconsistent with the rest). Now all are consistent.

Signed-off-by: David Scott <dave@recoil.org>