### PR TITLE
allow directly specifying xenstore ids for block devices

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -372,6 +372,38 @@ let make_block_t =
       end in
     b
 
+let xen_block_packages =
+  [ package ~min:"1.5.0" ~sublibs:["front"] "mirage-block-xen" ]
+
+(* this class takes a string rather than an int as `id` to allow the user to
+   pass stuff like "/dev/xvdi1", which mirage-block-xen also understands *)
+class xenstore_conf id =
+  let name = Name.create id ~prefix:"block" in
+  object
+    inherit base_configurable
+    method ty = block
+    method name = name
+    method module_name = "Block"
+    method! packages = Key.pure xen_block_packages
+    method! configure i =
+      match get_target i with
+      | `Qubes | `Xen -> R.ok ()
+      | _ -> R.error_msg "XenStore IDs are only valid ways of specifying block \
+                          devices when the target is Xen or Qubes."
+    method! connect _ s _ =
+      Fmt.strf "%s.connect %S" s id
+  end
+
+let block_of_xenstore_id id = impl (new xenstore_conf id)
+
+(* calculate the XenStore ID for the nth available block device.
+   Taken from https://github.com/mirage/mirage-block-xen/blob/
+   a64d152586c7ebc1d23c5adaa4ddd440b45a3a83/lib/device_number.ml#L64 . *)
+let xenstore_id_of_index number =
+        (if number < 16
+         then (202 lsl 8) lor (number lsl 4)
+         else (1 lsl 28)  lor (number lsl 8))
+
 class block_conf file =
   let b = make_block_t file in
   let name = Name.create file ~prefix:"block" in
@@ -382,7 +414,7 @@ class block_conf file =
     method module_name = "Block"
     method! packages =
       Key.match_ Key.(value target) @@ function
-      | `Xen | `Qubes -> [ package ~min:"1.5.0" ~sublibs:["front"] "mirage-block-xen" ]
+      | `Xen | `Qubes -> xen_block_packages
       | `Virtio | `Ukvm -> [ package ~min:"0.2.1" "mirage-block-solo5" ]
       | `Unix | `MacOSX -> [ package ~min:"2.5.0" "mirage-block-unix" ]
 
@@ -391,12 +423,7 @@ class block_conf file =
       | `Unix | `MacOSX | `Virtio | `Ukvm ->
         Fpath.(to_string (root / b.filename)) (* open the file directly *)
       | `Xen | `Qubes ->
-        (* We need the xenstore id *)
-        (* Taken from https://github.com/mirage/mirage-block-xen/blob/
-           a64d152586c7ebc1d23c5adaa4ddd440b45a3a83/lib/device_number.ml#L64 *)
-        (if b. number < 16
-         then (202 lsl 8) lor (b.number lsl 4)
-         else (1 lsl 28)  lor (b.number lsl 8)) |> string_of_int
+        xenstore_id_of_index b.number |> string_of_int
 
     method! connect i s _ =
       Fmt.strf "%s.connect %S" s
@@ -423,6 +450,7 @@ let ramdisk rname = impl (new ramdisk_conf rname)
 
 let generic_block ?(key = Key.value @@ Key.block ()) name =
   match_impl key [
+    `XenstoreId, block_of_xenstore_id name;
     `BlockFile, block_of_file name;
     `Ramdisk, ramdisk name;
   ] ~default:(ramdisk name)

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -391,9 +391,12 @@ class block_conf file =
       | `Unix | `MacOSX | `Virtio | `Ukvm ->
         Fpath.(to_string (root / b.filename)) (* open the file directly *)
       | `Xen | `Qubes ->
-        (* don't try to infer anything about this filename - let
-           mirage-block-xen do that for us; it has better heuristics *)
-        b.filename
+        (* We need the xenstore id *)
+        (* Taken from https://github.com/mirage/mirage-block-xen/blob/
+           a64d152586c7ebc1d23c5adaa4ddd440b45a3a83/lib/device_number.ml#L64 *)
+        (if b. number < 16
+         then (202 lsl 8) lor (b.number lsl 4)
+         else (1 lsl 28)  lor (b.number lsl 8)) |> string_of_int
 
     method! connect i s _ =
       Fmt.strf "%s.connect %S" s

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -171,13 +171,16 @@ val block: block typ
 (** Implementations of the [Mirage_types.BLOCK] signature. *)
 
 val block_of_file: string -> block impl
-(** Use the given filen as a raw block device. *)
+(** Use the given file as a raw block device. *)
+
+val block_of_xenstore_id: string -> block impl
+(** Use the given XenStore ID (ex: [/dev/xvdi1] or [51760]) as a raw block device. *)
 
 val ramdisk: string -> block impl
 (** Use a ramdisk with the given name. *)
 
 val generic_block:
-  ?key:[ `BlockFile | `Ramdisk ] value -> string -> block impl
+  ?key:[ `XenstoreId | `BlockFile | `Ramdisk ] value -> string -> block impl
 
 (** {2 Static key/value stores} *)
 

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -198,18 +198,20 @@ let kv_ro ?group () =
 let block ?group () =
   let conv =
     Cmdliner.Arg.enum [
+      "xenstore", `XenstoreId;
       "file", `BlockFile;
       "ramdisk", `Ramdisk;
     ]
   in
   let serialize = Fmt.of_to_string @@ function
+    | `XenstoreId -> "`XenstoreId"
     | `BlockFile -> "`BlockFile"
     | `Ramdisk   -> "`Ramdisk"
   in
   let conv = Arg.conv ~conv ~serialize ~runtime_conv:"block" in
   let doc =
     Fmt.strf
-      "Use a $(i,ramdisk) or $(i,file) pass-through \
+      "Use a $(i,ramdisk), $(i,xenstore), or $(i,file) pass-through \
        implementation for %a."
       pp_group group
   in

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -76,7 +76,7 @@ val kv_ro : ?group:string -> unit -> [ `Archive | `Crunch | `Direct | `Fat ] key
     Is one of ["archive"], ["crunch"], ["direct"], or ["fat"]. *)
 
 (** {3 Block device keys} *)
-val block : ?group:string -> unit -> [ `BlockFile | `Ramdisk ] key
+val block : ?group:string -> unit -> [ `XenstoreId | `BlockFile | `Ramdisk ] key
 
 (** {3 PRNG key} *)
 


### PR DESCRIPTION
This patch reverts #874 to fix #878 .  It also tries to solve the original problem #874 addressed by giving the user handles to directly specify a XenStore ID for block devices.  This can be called directly from `config.ml` with `block_of_xenstore_id` or invoked via the configuration language with `generic_block` in `config.ml` and `--block=xenstore`.  Attempting to use `--block=xenstore` with a Unix-y or Solo5-y target will result in a configure-time error.

/cc @cfcs .