### PR TITLE
Add new Solo5-based platform `Muen

### DIFF
--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -86,6 +86,7 @@ type mode = [
   | `Xen
   | `Virtio
   | `Ukvm
+  | `Muen
   | `MacOSX
   | `Qubes
 ]
@@ -97,6 +98,7 @@ let target_conv: mode Cmdliner.Arg.converter =
     "xen"   , `Xen;
     "virtio", `Virtio;
     "ukvm"  , `Ukvm;
+    "muen"  , `Muen;
     "qubes" , `Qubes
   ]
 
@@ -113,13 +115,14 @@ let default_unix = lazy (
 let target =
   let doc =
     "Target platform to compile the unikernel for. Valid values are: \
-     $(i,xen), $(i,qubes), $(i,unix), $(i,macosx), $(i,virtio), $(i,ukvm)."
+     $(i,xen), $(i,qubes), $(i,unix), $(i,macosx), $(i,virtio), $(i,ukvm), $(i,muen)."
   in
   let serialize ppf = function
     | `Unix   -> Fmt.pf ppf "`Unix"
     | `Xen    -> Fmt.pf ppf "`Xen"
     | `Virtio -> Fmt.pf ppf "`Virtio"
     | `Ukvm   -> Fmt.pf ppf "`Ukvm"
+    | `Muen   -> Fmt.pf ppf "`Muen"
     | `MacOSX -> Fmt.pf ppf "`MacOSX"
     | `Qubes  -> Fmt.pf ppf "`Qubes"
   in
@@ -134,7 +137,7 @@ let target =
 let is_unix =
   Key.match_ Key.(value target) @@ function
   | `Unix | `MacOSX -> true
-  | `Qubes | `Xen | `Virtio | `Ukvm -> false
+  | `Qubes | `Xen | `Virtio | `Ukvm | `Muen -> false
 
 let warn_error =
   let doc = "Enable -warn-error when compiling OCaml sources." in

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -30,13 +30,14 @@ end
 
 include Functoria.KEY with module Arg := Arg
 
-type mode = [ `Unix | `Xen | `Qubes | `MacOSX | `Virtio | `Ukvm ]
+type mode = [ `Unix | `Xen | `Qubes | `MacOSX | `Virtio | `Ukvm | `Muen ]
 
 (** {2 Mirage keys} *)
 
 val target: mode key
 (** [-t TARGET]: Key setting the configuration mode for the current project.
-    Is one of ["unix"], ["macosx"], ["xen"], ["qubes"], ["virtio"] or ["ukvm"].
+    Is one of ["unix"], ["macosx"], ["xen"], ["qubes"], ["virtio"], ["ukvm"]
+    or ["muen"].
 *)
 
 val pp_target: mode Fmt.t


### PR DESCRIPTION
This change adds the Muen platform to the mirage tool so it can be chosen as a target for MirageOS unikernels. It has been tested and is actually already in use for several weeks to build and run the Muen project website (see also description [here](https://muen.sk/articles.html)).

This is the remaining puzzle piece to fully upstream Muen support for MirageOS, see also Solo5/solo5#194.

Note: the necessary adaptations on the Muen side have been merged and released as part of [v0.9](https://groups.google.com/forum/#!topic/muen-dev/FPL9sc4yaBE).