### PR TITLE
use a path pin when making depends

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1697,7 +1697,7 @@ let configure_makefile ~opam_name =
                   all:: build\n\
                   \n\
                   depend depends::\n\
-                  \t$(OPAM) pin add --no-action --yes %s .\n\
+                  \t$(OPAM) pin add -k path --no-action --yes %s .\n\
                   \t$(DEPEXT)\n\
                   \t$(OPAM) install --yes --deps-only %s\n\
                   \t$(OPAM) pin remove --no-action %s\n\


### PR DESCRIPTION
Otherwise `make depend` when using opam version 2 has some surprising behavior.

/cc @mato 