### PR TITLE
Reduce extraneous block config generation

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -406,7 +406,6 @@ let xenstore_id_of_index number =
          else (1 lsl 28)  lor (number lsl 8))
 
 class block_conf file =
-  let b = make_block_t file in
   let name = Name.create file ~prefix:"block" in
   object (self)
     inherit base_configurable
@@ -419,11 +418,16 @@ class block_conf file =
       | `Virtio | `Ukvm -> [ package ~min:"0.2.1" "mirage-block-solo5" ]
       | `Unix | `MacOSX -> [ package ~min:"2.5.0" "mirage-block-unix" ]
 
+    method! configure _ =
+      let _block = make_block_t file in
+      R.ok ()
+
     method private connect_name target root =
       match target with
       | `Unix | `MacOSX | `Virtio | `Ukvm ->
-        Fpath.(to_string (root / b.filename)) (* open the file directly *)
+        Fpath.(to_string (root / file)) (* open the file directly *)
       | `Xen | `Qubes ->
+        let b = make_block_t file in
         xenstore_id_of_index b.number |> string_of_int
 
     method! connect i s _ =

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1,6 +1,7 @@
 (*
  * Copyright (c) 2013 Thomas Gazagnaire <thomas@gazagnaire.org>
  * Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2018 Mindy Preston     <meetup@yomimono.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
Before, for targets which caused us to build an `.xl`, we would always generate two (!) disk configurations (one for `tar` and one for `fat`) per call to `generic_kv_ro`, regardless of which implementation was actually chosen (including `crunch`).  With this patch, we only include block configuration relevant to the final config.

By way of illustration, here's the `https.xl` generated by `mirage configure -t xen` in the `static_website_tls` directory of `mirage-skeleton`(with https://github.com/mirage/mirage-skeleton/pull/255 applied), regardless of which `--kv_ro` values are passed:

```
4.05.0🐫  (choose-kvros-separately) 18.25 ocamldev:~/mirage-skeleton/applications/static_website_tls$ make clean && mirage configure -t xen --data-kv_ro=fat --certs-kv_ro=crunch && cat https.xl
mirage clean
# Generated by mirage configure -t xen --data-kv_ro=fat --certs-kv_ro=crunch (Tue, 13 Mar 2018 23:25:51 GMT).

name = 'https'
kernel = '/home/user/mirage-skeleton/applications/static_website_tls/./https.xen'
builder = 'linux'
memory = 256
on_crash = 'preserve'

disk = [ 'format=raw, vdev=xvdb, access=rw, target=/home/user/mirage-skeleton/applications/static_website_tls/./tar_block1.img', 'format=raw, vdev=xvdd, access=rw, target=/home/user/mirage-skeleton/applications/static_website_tls/./tar_block2.img', 'format=raw, vdev=xvde, access=rw, target=/home/user/mirage-skeleton/applications/static_website_tls/./fat_block2.img', 'format=raw, vdev=xvdc, access=rw, target=/home/user/mirage-skeleton/applications/static_website_tls/./fat_block1.img' ]

# if your system uses openvswitch then either edit /etc/xen/xl.conf and set
#     vif.default.script="vif-openvswitch"
# or add "script=vif-openvswitch," before the "bridge=" below:
vif = [ 'bridge=br0' ]
4.05.0🐫  (choose-kvros-separately) 18.25 ocamldev:~/mirage-skeleton/applications/static_website_tls$ make clean && mirage configure -t xen && cat https.xl
mirage clean
# Generated by mirage configure -t xen (Tue, 13 Mar 2018 23:26:00 GMT).

name = 'https'
kernel = '/home/user/mirage-skeleton/applications/static_website_tls/./https.xen'
builder = 'linux'
memory = 256
on_crash = 'preserve'

disk = [ 'format=raw, vdev=xvdb, access=rw, target=/home/user/mirage-skeleton/applications/static_website_tls/./tar_block1.img', 'format=raw, vdev=xvdd, access=rw, target=/home/user/mirage-skeleton/applications/static_website_tls/./tar_block2.img', 'format=raw, vdev=xvde, access=rw, target=/home/user/mirage-skeleton/applications/static_website_tls/./fat_block2.img', 'format=raw, vdev=xvdc, access=rw, target=/home/user/mirage-skeleton/applications/static_website_tls/./fat_block1.img' ]

# if your system uses openvswitch then either edit /etc/xen/xl.conf and set
#     vif.default.script="vif-openvswitch"
# or add "script=vif-openvswitch," before the "bridge=" below:
vif = [ 'bridge=br0' ]
```

and after this PR:

```
4.05.0🐫  (choose-kvros-separately) 18.23 ocamldev:~/mirage-skeleton/applications/static_website_tls$ make clean && mirage configure -t xen --data-kv_ro=fat --certs-kv_ro=crunch && cat https.xl
mirage clean
# Generated by mirage configure -t xen --data-kv_ro=fat --certs-kv_ro=crunch (Tue, 13 Mar 2018 23:23:44 GMT).

name = 'https'
kernel = '/home/user/mirage-skeleton/applications/static_website_tls/./https.xen'
builder = 'linux'
memory = 256
on_crash = 'preserve'

disk = [ 'format=raw, vdev=xvdb, access=rw, target=/home/user/mirage-skeleton/applications/static_website_tls/./fat_block1.img' ]

# if your system uses openvswitch then either edit /etc/xen/xl.conf and set
#     vif.default.script="vif-openvswitch"
# or add "script=vif-openvswitch," before the "bridge=" below:
vif = [ 'bridge=br0' ]
4.05.0🐫  (choose-kvros-separately) 18.23 ocamldev:~/mirage-skeleton/applications/static_website_tls$ 
4.05.0🐫  (choose-kvros-separately) 18.23 ocamldev:~/mirage-skeleton/applications/static_website_tls$ make clean && mirage configure -t xen && cat https.xl
mirage clean
# Generated by mirage configure -t xen (Tue, 13 Mar 2018 23:24:03 GMT).

name = 'https'
kernel = '/home/user/mirage-skeleton/applications/static_website_tls/./https.xen'
builder = 'linux'
memory = 256
on_crash = 'preserve'

disk = [  ]

# if your system uses openvswitch then either edit /etc/xen/xl.conf and set
#     vif.default.script="vif-openvswitch"
# or add "script=vif-openvswitch," before the "bridge=" below:
vif = [ 'bridge=br0' ]
```