### PR TITLE
conflict with jbuilder 1.0+beta18

### DIFF
--- a/mirage.opam
+++ b/mirage.opam
@@ -28,5 +28,6 @@ conflicts: [
   "cstruct"  {< "1.0.1"}
   "io-page"  {< "1.4.0"}
   "crunch"   {< "1.2.2"}
+  "jbuilder" {= "1.0+beta18"}
 ]
 available: [ocaml-version >= "4.04.2"]


### PR DESCRIPTION
see https://github.com/ocaml/dune/issues/567 , which explains the issue
with jbuilder 1.0+beta18 in more detail.  This broke our ability to use cohttp
(at least, maybe more), and it's (IMO) easiest just to conflict with it.