### PR TITLE
don't make xen config documents for target qubes

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1774,7 +1774,7 @@ let configure i =
   configure_opam ~name:opam_name i >>= fun () ->
   configure_makefile ~opam_name >>= fun () ->
   match target with
-  | `Xen | `Qubes ->
+  | `Xen ->
     configure_main_xl "xl" i >>= fun () ->
     configure_main_xl ~substitutions:[] "xl.in" i >>= fun () ->
     configure_main_xe ~root ~name >>= fun () ->


### PR DESCRIPTION
In Qubes, the hypervisor has its own logic and rules for configuring
guests which needs to be configured out-of-band, so these files aren't
useful.