### PR TITLE
mirage: add ocamlbuild and ocamlfind dependencies

### DIFF
--- a/mirage.opam
+++ b/mirage.opam
@@ -15,6 +15,8 @@ build: [
 ]
 
 depends: [
+  "ocamlbuild"
+  "ocamlfind"
   "jbuilder"   {build & >= "1.0+beta10"}
   "ipaddr"             {>= "2.6.0"}
   "functoria"          {>= "2.2.0"}


### PR DESCRIPTION
mirage calls out to ocamlbuild during mirage build