### PR TITLE
respect ld from pkg-config

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1937,8 +1937,6 @@ let link info name target target_debug =
       | [ libdir ] ->
         Bos.OS.Cmd.run Bos.Cmd.(v "ukvm-configure" % (libdir ^ "/src/ukvm") %% of_list ukvm_mods) >>= fun () ->
         Bos.OS.Cmd.run Bos.Cmd.(v "make" % "-f" % "Makefile.ukvm" % "ukvm-bin") >>= fun () ->
-        Log.info (fun m -> m "linking with %a" Bos.Cmd.pp linker);
-        Bos.OS.Cmd.run linker >>= fun () ->
         Ok out
       | _ -> R.error_msg ("pkg-config " ^ pkg ^ " --variable=libdir failed")
     else

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1856,25 +1856,28 @@ let ldflags pkg = pkg_config pkg ["--variable=ldflags"]
 
 let ldpostflags pkg = pkg_config pkg ["--variable=ldpostflags"]
 
-let find_ld = function
-  | `Xen | `Qubes | `MacOSX | `Unix -> Ok [ "ld" ]
-  | `Ukvm -> pkg_config "solo5-kernel-ukvm" ["--variable=ld"]
-  | `Virtio -> pkg_config "solo5-kernel-virtio" ["--variable=ld"]
-  | `Muen -> pkg_config "solo5-kernel-muen" ["--variable=ld"]
+let find_ld pkg =
+  match pkg_config pkg ["--variable=ld"] with
+  | Ok (ld::_) ->
+    Log.warn (fun m -> m "using %s as ld (pkg-config %s --variable=ld)" ld pkg) ;
+    ld
+  | Ok [] ->
+    Log.warn (fun m -> m "pkg-config %s --variable=ld returned nothing, using ld" pkg) ;
+    "ld"
+  | Error msg ->
+    Log.warn (fun m -> m "error %a while pkg-config %s --variable=ld, using ld"
+                 Rresult.R.pp_msg msg pkg) ;
+    "ld"
+
+let solo5_pkg = function
+  | `Virtio -> "solo5-kernel-virtio", ".virtio"
+  | `Muen -> "solo5-kernel-muen", ".muen"
+  | `Ukvm -> "solo5-kernel-ukvm", ".ukvm"
+  | `Unix | `MacOSX | `Xen | `Qubes ->
+    invalid_arg "solo5_kernel only defined for solo5 targets"
 
 let link info name target target_debug =
   let libs = Info.libraries info in
-  let ld = match find_ld target with
-    | Ok (ld::_) ->
-      Log.warn (fun m -> m "using %s as ld (pkg-config --variable=ld)" ld) ;
-      ld
-    | Ok [] ->
-      Log.warn (fun m -> m "pkg-config --variable=ld returned empty list, using ld") ;
-      "ld"
-    | Error msg ->
-      Log.warn (fun m -> m "error %a while pkg-config --variable=ld, using ld" Rresult.R.pp_msg msg) ;
-      "ld"
-  in
   match target with
   | `Unix | `MacOSX ->
     Bos.OS.Cmd.run Bos.Cmd.(v "ln" % "-nfs" % "_build/main.native" % name) >>= fun () ->
@@ -1883,7 +1886,7 @@ let link info name target target_debug =
     extra_c_artifacts "xen" libs >>= fun c_artifacts ->
     static_libs "mirage-xen" >>= fun static_libs ->
     let linker =
-      Bos.Cmd.(v ld % "-d" % "-static" % "-nostdlib" % "_build/main.native.o" %%
+      Bos.Cmd.(v "ld" % "-d" % "-static" % "-nostdlib" % "_build/main.native.o" %%
                of_list c_artifacts %% of_list static_libs)
     in
     let out = name ^ ".xen" in
@@ -1907,12 +1910,14 @@ let link info name target target_debug =
       Bos.OS.Cmd.run link >>= fun () ->
       Ok out
     end
-  | `Virtio ->
+  | `Virtio | `Muen | `Ukvm ->
+    let pkg, post = solo5_pkg target in
     extra_c_artifacts "freestanding" libs >>= fun c_artifacts ->
     static_libs "mirage-solo5" >>= fun static_libs ->
-    ldflags "solo5-kernel-virtio" >>= fun ldflags ->
-    ldpostflags "solo5-kernel-virtio" >>= fun ldpostflags ->
-    let out = name ^ ".virtio" in
+    ldflags pkg >>= fun ldflags ->
+    ldpostflags pkg >>= fun ldpostflags ->
+    let out = name ^ post in
+    let ld = find_ld pkg in
     let linker =
       Bos.Cmd.(v ld %% of_list ldflags % "_build/main.native.o" %%
                of_list c_artifacts %% of_list static_libs % "-o" % out
@@ -1920,47 +1925,24 @@ let link info name target target_debug =
     in
     Log.info (fun m -> m "linking with %a" Bos.Cmd.pp linker);
     Bos.OS.Cmd.run linker >>= fun () ->
-    Ok out
-  | `Muen ->
-    extra_c_artifacts "freestanding" libs >>= fun c_artifacts ->
-    static_libs "mirage-solo5" >>= fun static_libs ->
-    ldflags "solo5-kernel-muen" >>= fun ldflags ->
-    ldpostflags "solo5-kernel-muen" >>= fun ldpostflags ->
-    let out = name ^ ".muen" in
-    let linker =
-      Bos.Cmd.(v ld %% of_list ldflags % "_build/main.native.o" %%
-               of_list c_artifacts %% of_list static_libs % "-o" % out
-               %% of_list ldpostflags)
-    in
-    Log.info (fun m -> m "linking with %a" Bos.Cmd.pp linker);
-    Bos.OS.Cmd.run linker >>= fun () ->
-    Ok out
-  | `Ukvm ->
-    extra_c_artifacts "freestanding" libs >>= fun c_artifacts ->
-    static_libs "mirage-solo5" >>= fun static_libs ->
-    ldflags "solo5-kernel-ukvm" >>= fun ldflags ->
-    ldpostflags "solo5-kernel-ukvm" >>= fun ldpostflags ->
-    let out = name ^ ".ukvm" in
-    let linker =
-      Bos.Cmd.(v ld %% of_list ldflags % "_build/main.native.o" %%
-               of_list c_artifacts %% of_list static_libs % "-o" % out
-               %% of_list ldpostflags)
-    in
-    let ukvm_mods =
-      List.fold_left (fun acc -> function
-        | "mirage-net-solo5" -> "net" :: acc
-        | "mirage-block-solo5" -> "blk" :: acc
-        | _ -> acc)
-        [] libs @ (if target_debug then ["gdb"] else [])
-    in
-    pkg_config "solo5-kernel-ukvm" ["--variable=libdir"] >>= function
-    | [ libdir ] ->
-      Bos.OS.Cmd.run Bos.Cmd.(v "ukvm-configure" % (libdir ^ "/src/ukvm") %% of_list ukvm_mods) >>= fun () ->
-      Bos.OS.Cmd.run Bos.Cmd.(v "make" % "-f" % "Makefile.ukvm" % "ukvm-bin") >>= fun () ->
-      Log.info (fun m -> m "linking with %a" Bos.Cmd.pp linker);
-      Bos.OS.Cmd.run linker >>= fun () ->
+    if target = `Ukvm then
+      let ukvm_mods =
+        List.fold_left (fun acc -> function
+            | "mirage-net-solo5" -> "net" :: acc
+            | "mirage-block-solo5" -> "blk" :: acc
+            | _ -> acc)
+          [] libs @ (if target_debug then ["gdb"] else [])
+      in
+      pkg_config pkg ["--variable=libdir"] >>= function
+      | [ libdir ] ->
+        Bos.OS.Cmd.run Bos.Cmd.(v "ukvm-configure" % (libdir ^ "/src/ukvm") %% of_list ukvm_mods) >>= fun () ->
+        Bos.OS.Cmd.run Bos.Cmd.(v "make" % "-f" % "Makefile.ukvm" % "ukvm-bin") >>= fun () ->
+        Log.info (fun m -> m "linking with %a" Bos.Cmd.pp linker);
+        Bos.OS.Cmd.run linker >>= fun () ->
+        Ok out
+      | _ -> R.error_msg ("pkg-config " ^ pkg ^ " --variable=libdir failed")
+    else
       Ok out
-    | _ -> R.error_msg "pkg-config solo5-kernel-ukvm --variable=libdir failed"
 
 let build i =
   let name = Info.name i in
@@ -2032,14 +2014,12 @@ module Project = struct
           package ~build:true "ocamlbuild" ;
         ] in
         Key.match_ Key.(value target) @@ function
-        | `Xen | `Qubes -> [ package ~min:"3.0.4" "mirage-xen" ] @ common
-        | `Virtio -> [ package ~min:"0.2.1" ~ocamlfind:[] "solo5-kernel-virtio" ;
-                       package ~min:"0.2.0" "mirage-solo5" ] @ common
-        | `Ukvm -> [ package ~min:"0.2.1" ~ocamlfind:[] "solo5-kernel-ukvm" ;
-                     package ~min:"0.2.0" "mirage-solo5" ] @ common
-        | `Muen -> [ package ~ocamlfind:[] "solo5-kernel-muen" ;
-                     package ~min:"0.2.0" "mirage-solo5" ] @ common
         | `Unix | `MacOSX -> [ package ~min:"3.0.0" "mirage-unix" ] @ common
+        | `Xen | `Qubes -> [ package ~min:"3.0.4" "mirage-xen" ] @ common
+        | `Virtio | `Ukvm | `Muen as tgt ->
+          let pkg, _ = solo5_pkg tgt in
+          [ package ~min:"0.2.1" ~ocamlfind:[] pkg ;
+            package ~min:"0.2.0" "mirage-solo5" ] @ common
 
       method! build = build
       method! configure = configure


### PR DESCRIPTION
this is needed again for OpenBSD support in solo5 (since OpenBSD's `ld` is an ancient `GNU ld`, which doesn't work with the solo5 linker script -- but their `ld.lld` (from clang/llvm) does..
//cc @adamsteen @mato

this basically reverts e0aba4dc2dac7f180517b7b129e8e890617a8e15 -- but since `ld` is no longer called via Makefile, but rather from OCaml code, it needs some adjustments.

the failure semantics (if `pkg-config` returns an error) is atm to log (on the warning channel) and call out to `ld`.