### PR TITLE
LICENSE.md: add title and copyright notice

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,7 @@
+ISC License
+
+Copyright (X) 2011-2018, the [MirageOS contributors](https://mirage.io/community/#team)
+
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
 copyright notice and this permission notice appear in all copies.


### PR DESCRIPTION
Although the title is not legally mandated for the license to apply, it is included in the license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license). This provides additional clarity regarding the licensing terms.

The copyright notice, however, is legally required (the text of the license even refers to "the above copyright notice"). Here I've used the link https://mirage.io/community/#team, but an alternative could be https://github.com/mirage/mirage/graphs/contributors as well. I'm also aware of #608, but it's common for FOSS projects to use something like "John Doe, James Smith and contributors", if that better reflects the authorship status. Let me know if you'd like me to change this PR.

*Note: This PR is part of a personal project to improve the consistency and visibility of the ISC license. See https://github.com/github/choosealicense.com/issues/377 for more details.*