### PR TITLE
Merge dev-solo5 branch into master

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -43,9 +43,9 @@ let connect_err name number =
 
 (* Mirage implementation backing the target. *)
 let backend_predicate = function
-  | `Xen | `Qubes   -> "mirage_xen"
-  | `Virtio | `Ukvm -> "mirage_solo5"
-  | `Unix | `MacOSX -> "mirage_unix"
+  | `Xen | `Qubes           -> "mirage_xen"
+  | `Virtio | `Ukvm | `Muen -> "mirage_solo5"
+  | `Unix | `MacOSX         -> "mirage_unix"
 
 (** {2 Devices} *)
 let qrexec = job
@@ -232,7 +232,7 @@ let nocrypto = impl @@ object
       | `Xen | `Qubes ->
         [ package ~min:"0.5.4" ~sublibs:["mirage"] "nocrypto";
           package ~ocamlfind:[] "zarith-xen" ]
-      | `Virtio | `Ukvm ->
+      | `Virtio | `Ukvm | `Muen ->
         [ package ~min:"0.5.4" ~sublibs:["mirage"] "nocrypto";
           package ~ocamlfind:[] "zarith-freestanding" ]
       | `Unix | `MacOSX ->
@@ -241,7 +241,7 @@ let nocrypto = impl @@ object
     method! build _ = R.ok (enable_entropy ())
     method! connect i _ _ =
       match get_target i with
-      | `Xen | `Qubes | `Virtio | `Ukvm -> "Nocrypto_entropy_mirage.initialize ()"
+      | `Xen | `Qubes | `Virtio | `Ukvm | `Muen -> "Nocrypto_entropy_mirage.initialize ()"
       | `Unix | `MacOSX -> "Nocrypto_entropy_lwt.initialize ()"
   end
 
@@ -300,7 +300,8 @@ let custom_console str =
     `Xen, console_xen str;
     `Qubes, console_xen str;
     `Virtio, console_solo5 str;
-    `Ukvm, console_solo5 str
+    `Ukvm, console_solo5 str;
+    `Muen, console_solo5 str
   ] ~default:(console_unix str)
 
 let default_console = custom_console "0"
@@ -349,7 +350,8 @@ let direct_kv_ro dirname =
     `Xen, crunch dirname;
     `Qubes, crunch dirname;
     `Virtio, crunch dirname;
-    `Ukvm, crunch dirname
+    `Ukvm, crunch dirname;
+    `Muen, crunch dirname
   ] ~default:(direct_kv_ro_conf dirname)
 
 type block = BLOCK
@@ -415,7 +417,7 @@ class block_conf file =
     method! packages =
       Key.match_ Key.(value target) @@ function
       | `Xen | `Qubes -> xen_block_packages
-      | `Virtio | `Ukvm -> [ package ~min:"0.2.1" "mirage-block-solo5" ]
+      | `Virtio | `Ukvm | `Muen -> [ package ~min:"0.2.1" "mirage-block-solo5" ]
       | `Unix | `MacOSX -> [ package ~min:"2.5.0" "mirage-block-unix" ]
 
     method! configure _ =
@@ -424,15 +426,18 @@ class block_conf file =
 
     method private connect_name target root =
       match target with
-      | `Unix | `MacOSX | `Virtio | `Ukvm ->
+      | `Unix | `MacOSX | `Virtio | `Ukvm | `Muen ->
         Fpath.(to_string (root / file)) (* open the file directly *)
       | `Xen | `Qubes ->
         let b = make_block_t file in
         xenstore_id_of_index b.number |> string_of_int
 
     method! connect i s _ =
-      Fmt.strf "%s.connect %S" s
-        (self#connect_name (get_target i) @@ Info.build_dir i)
+      match get_target i with
+      | `Muen -> failwith "Block devices not supported on Muen target."
+      | `Unix | `MacOSX | `Virtio | `Ukvm | `Xen | `Qubes ->
+        Fmt.strf "%s.connect %S" s
+          (self#connect_name (get_target i) @@ Info.build_dir i)
   end
 
 let block_of_file file = impl (new block_conf file)
@@ -600,7 +605,7 @@ let network_conf (intf : string Key.key) =
       | `MacOSX -> [ package ~min:"1.3.0" "mirage-net-macosx" ]
       | `Xen -> [ package ~min:"1.7.0" "mirage-net-xen"]
       | `Qubes -> [ package ~min:"1.7.0" "mirage-net-xen" ; package ~min:"0.4" "mirage-qubes" ]
-      | `Virtio | `Ukvm -> [ package ~min:"0.2.0" "mirage-net-solo5" ]
+      | `Virtio | `Ukvm | `Muen -> [ package ~min:"0.2.0" "mirage-net-solo5" ]
     method! connect _ modname _ =
       Fmt.strf "%s.connect %a" modname Key.serialize_call key
     method! configure i =
@@ -705,9 +710,9 @@ let (@??) x y = opt_map Key.abstract x @? y
 (* convenience function for linking tcpip.unix or .xen for checksums *)
 let right_tcpip_library ?min ?max ?ocamlfind ~sublibs pkg =
   Key.match_ Key.(value target) @@ function
-  |`MacOSX | `Unix -> [ package ?min ?max ?ocamlfind ~sublibs:("unix"::sublibs) pkg ]
-  |`Qubes  | `Xen  -> [ package ?min ?max ?ocamlfind ~sublibs:("xen"::sublibs) pkg ]
-  |`Virtio | `Ukvm -> [ package ?min ?max ?ocamlfind ~sublibs pkg ]
+  |`MacOSX | `Unix         -> [ package ?min ?max ?ocamlfind ~sublibs:("unix"::sublibs) pkg ]
+  |`Qubes  | `Xen          -> [ package ?min ?max ?ocamlfind ~sublibs:("xen"::sublibs) pkg ]
+  |`Virtio | `Ukvm | `Muen -> [ package ?min ?max ?ocamlfind ~sublibs pkg ]
 
 let ipv4_keyed_conf ?network ?gateway () = impl @@ object
     inherit base_configurable
@@ -1343,7 +1348,8 @@ let default_argv =
     `Xen, argv_xen;
     `Qubes, argv_xen;
     `Virtio, argv_solo5;
-    `Ukvm, argv_solo5
+    `Ukvm, argv_solo5;
+    `Muen, argv_solo5
   ] ~default:argv_unix
 
 (** Log reporting *)
@@ -1413,7 +1419,7 @@ let mprof_trace ~size () =
     method! packages =
       Key.match_ Key.(value target) @@ function
       | `Xen | `Qubes -> [ package "mirage-profile"; package "mirage-profile-xen" ]
-      | `Virtio | `Ukvm -> []
+      | `Virtio | `Ukvm | `Muen -> []
       | `Unix | `MacOSX -> [ package "mirage-profile"; package "mirage-profile-unix" ]
     method! build _ =
       match query_ocamlfind ["lwt.tracing"] with
@@ -1422,7 +1428,7 @@ let mprof_trace ~size () =
                      opam pin add lwt https://github.com/mirage/lwt.git#tracing"
       | Ok _ -> Ok ()
     method! connect i _ _ = match get_target i with
-      | `Virtio | `Ukvm -> failwith  "tracing is not currently implemented for solo5 targets"
+      | `Virtio | `Ukvm | `Muen -> failwith  "tracing is not currently implemented for solo5 targets"
       | `Unix | `MacOSX ->
         Fmt.strf
           "Lwt.return ())@.\
@@ -1858,12 +1864,12 @@ let compile libs warn_error target =
     (if terminal () then ["color(always)"] else [])
   and result = match target with
     | `Unix | `MacOSX -> "main.native"
-    | `Xen | `Qubes | `Virtio | `Ukvm -> "main.native.o"
+    | `Xen | `Qubes | `Virtio | `Ukvm | `Muen -> "main.native.o"
   and cflags = [ "-g" ]
   and lflags =
     let dontlink =
       match target with
-      | `Xen | `Qubes | `Virtio | `Ukvm -> ["unix"; "str"; "num"; "threads"]
+      | `Xen | `Qubes | `Virtio | `Ukvm | `Muen -> ["unix"; "str"; "num"; "threads"]
       | `Unix | `MacOSX -> []
     in
     let dont = List.map (fun k -> [ "-dontlink" ; k ]) dontlink in
@@ -1990,6 +1996,20 @@ let link info name target target_debug =
     Log.info (fun m -> m "linking with %a" Bos.Cmd.pp linker);
     Bos.OS.Cmd.run linker >>= fun () ->
     Ok out
+  | `Muen ->
+    extra_c_artifacts "freestanding" libs >>= fun c_artifacts ->
+    static_libs "mirage-solo5" >>= fun static_libs ->
+    ldflags "solo5-kernel-muen" >>= fun ldflags ->
+    ldpostflags "solo5-kernel-muen" >>= fun ldpostflags ->
+    let out = name ^ ".muen" in
+    let linker =
+      Bos.Cmd.(v "ld" %% of_list ldflags % "_build/main.native.o" %%
+               of_list c_artifacts %% of_list static_libs % "-o" % out
+               %% of_list ldpostflags)
+    in
+    Log.info (fun m -> m "linking with %a" Bos.Cmd.pp linker);
+    Bos.OS.Cmd.run linker >>= fun () ->
+    Ok out
   | `Ukvm ->
     extra_c_artifacts "freestanding" libs >>= fun c_artifacts ->
     static_libs "mirage-solo5" >>= fun static_libs ->
@@ -2046,6 +2066,7 @@ let clean i =
   Bos.OS.File.delete Fpath.(v name + "xen") >>= fun () ->
   Bos.OS.File.delete Fpath.(v name + "elf") >>= fun () ->
   Bos.OS.File.delete Fpath.(v name + "virtio") >>= fun () ->
+  Bos.OS.File.delete Fpath.(v name + "muen") >>= fun () ->
   Bos.OS.File.delete Fpath.(v name + "ukvm") >>= fun () ->
   Bos.OS.File.delete Fpath.(v "Makefile.ukvm") >>= fun () ->
   Bos.OS.Dir.delete ~recurse:true Fpath.(v "_build-ukvm") >>= fun () ->
@@ -2090,6 +2111,8 @@ module Project = struct
         | `Virtio -> [ package ~min:"0.2.1" ~ocamlfind:[] "solo5-kernel-virtio" ;
                        package ~min:"0.2.0" "mirage-solo5" ] @ common
         | `Ukvm -> [ package ~min:"0.2.1" ~ocamlfind:[] "solo5-kernel-ukvm" ;
+                     package ~min:"0.2.0" "mirage-solo5" ] @ common
+        | `Muen -> [ package ~ocamlfind:[] "solo5-kernel-muen" ;
                      package ~min:"0.2.0" "mirage-solo5" ] @ common
         | `Unix | `MacOSX -> [ package ~min:"3.0.0" "mirage-unix" ] @ common
 

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -86,6 +86,7 @@ type mode = [
   | `Xen
   | `Virtio
   | `Ukvm
+  | `Muen
   | `MacOSX
   | `Qubes
 ]
@@ -97,6 +98,7 @@ let target_conv: mode Cmdliner.Arg.converter =
     "xen"   , `Xen;
     "virtio", `Virtio;
     "ukvm"  , `Ukvm;
+    "muen"  , `Muen;
     "qubes" , `Qubes
   ]
 
@@ -113,13 +115,14 @@ let default_unix = lazy (
 let target =
   let doc =
     "Target platform to compile the unikernel for. Valid values are: \
-     $(i,xen), $(i,qubes), $(i,unix), $(i,macosx), $(i,virtio), $(i,ukvm)."
+     $(i,xen), $(i,qubes), $(i,unix), $(i,macosx), $(i,virtio), $(i,ukvm), $(i,muen)."
   in
   let serialize ppf = function
     | `Unix   -> Fmt.pf ppf "`Unix"
     | `Xen    -> Fmt.pf ppf "`Xen"
     | `Virtio -> Fmt.pf ppf "`Virtio"
     | `Ukvm   -> Fmt.pf ppf "`Ukvm"
+    | `Muen   -> Fmt.pf ppf "`Muen"
     | `MacOSX -> Fmt.pf ppf "`MacOSX"
     | `Qubes  -> Fmt.pf ppf "`Qubes"
   in
@@ -134,7 +137,7 @@ let target =
 let is_unix =
   Key.match_ Key.(value target) @@ function
   | `Unix | `MacOSX -> true
-  | `Qubes | `Xen | `Virtio | `Ukvm -> false
+  | `Qubes | `Xen | `Virtio | `Ukvm | `Muen -> false
 
 let warn_error =
   let doc = "Enable -warn-error when compiling OCaml sources." in

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -30,13 +30,14 @@ end
 
 include Functoria.KEY with module Arg := Arg
 
-type mode = [ `Unix | `Xen | `Qubes | `MacOSX | `Virtio | `Ukvm ]
+type mode = [ `Unix | `Xen | `Qubes | `MacOSX | `Virtio | `Ukvm | `Muen ]
 
 (** {2 Mirage keys} *)
 
 val target: mode key
 (** [-t TARGET]: Key setting the configuration mode for the current project.
-    Is one of ["unix"], ["macosx"], ["xen"], ["qubes"], ["virtio"] or ["ukvm"].
+    Is one of ["unix"], ["macosx"], ["xen"], ["qubes"], ["virtio"], ["ukvm"]
+    or ["muen"].
 *)
 
 val pp_target: mode Fmt.t


### PR DESCRIPTION
Now that Solo5 0.3.0 has been released, and the Mirage/Solo5 packages are all published on opam.ocaml.org, this can be merged into mirage `master`.

User-visible changes:
- Add new Solo5-based platform `Muen (#887) 
- respect ld from pkg-config (#898) 

I've reviewed both of these again and there are no backward incompatibilities here, obviously #887 will only work with the Solo5 0.3.0 packages.