### PR TITLE
Use the exposed signature in functoria for Key modules.

### DIFF
--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -346,6 +346,4 @@ let logs =
   let arg = Key.Arg.(opt logs []) info in
   Key.create "logs" arg
 
-(* FIXME: this is a crazy *)
-include (Key: module type of struct include Functoria_key end
-         with module Arg := Arg and module Alias := Alias)
+include (Key: Functoria.KEY with module Arg := Arg and module Alias := Alias)


### PR DESCRIPTION
This changes nothing. In particular, this doesn't fix the failure in 4.07 since the current definition in functoria is exactly the same.
However, it delegates the definition to functoria which means we can fix everything there.