### PR TITLE
Renaming for Solo5 0.4.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ env:
    - TESTS=false #testing via travis-ci.sh
  matrix:
    - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.04 EXTRA_ENV="MODE=xen"
-   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.04 EXTRA_ENV="MODE=ukvm"
+   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.04 EXTRA_ENV="MODE=hvt"
    - PACKAGE=mirage DISTRO=debian-unstable OCAML_VERSION=4.04 EXTRA_ENV="MODE=unix"
    - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.05 EXTRA_ENV="MODE=xen"
-   - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.05 EXTRA_ENV="MODE=ukvm"
+   - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.05 EXTRA_ENV="MODE=hvt"
    - PACKAGE=mirage DISTRO=ubuntu-16.04 OCAML_VERSION=4.05 EXTRA_ENV="MODE=virtio"
    - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.06 EXTRA_ENV="MODE=unix"
-   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.06 EXTRA_ENV="MODE=ukvm"
+   - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.06 EXTRA_ENV="MODE=hvt"
    - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.06 EXTRA_ENV="MODE=muen"

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -44,7 +44,7 @@ let connect_err name number =
 (* Mirage implementation backing the target. *)
 let backend_predicate = function
   | `Xen | `Qubes           -> "mirage_xen"
-  | `Virtio | `Ukvm | `Muen -> "mirage_solo5"
+  | `Virtio | `Hvt | `Muen  -> "mirage_solo5"
   | `Unix | `MacOSX         -> "mirage_unix"
 
 (** {2 Devices} *)
@@ -232,7 +232,7 @@ let nocrypto = impl @@ object
       | `Xen | `Qubes ->
         [ package ~min:"0.5.4" ~sublibs:["mirage"] "nocrypto";
           package ~ocamlfind:[] "zarith-xen" ]
-      | `Virtio | `Ukvm | `Muen ->
+      | `Virtio | `Hvt | `Muen ->
         [ package ~min:"0.5.4" ~sublibs:["mirage"] "nocrypto";
           package ~ocamlfind:[] "zarith-freestanding" ]
       | `Unix | `MacOSX ->
@@ -241,7 +241,7 @@ let nocrypto = impl @@ object
     method! build _ = R.ok (enable_entropy ())
     method! connect i _ _ =
       match get_target i with
-      | `Xen | `Qubes | `Virtio | `Ukvm | `Muen -> "Nocrypto_entropy_mirage.initialize ()"
+      | `Xen | `Qubes | `Virtio | `Hvt | `Muen -> "Nocrypto_entropy_mirage.initialize ()"
       | `Unix | `MacOSX -> "Nocrypto_entropy_lwt.initialize ()"
   end
 
@@ -300,7 +300,7 @@ let custom_console str =
     `Xen, console_xen str;
     `Qubes, console_xen str;
     `Virtio, console_solo5 str;
-    `Ukvm, console_solo5 str;
+    `Hvt, console_solo5 str;
     `Muen, console_solo5 str
   ] ~default:(console_unix str)
 
@@ -350,7 +350,7 @@ let direct_kv_ro dirname =
     `Xen, crunch dirname;
     `Qubes, crunch dirname;
     `Virtio, crunch dirname;
-    `Ukvm, crunch dirname;
+    `Hvt, crunch dirname;
     `Muen, crunch dirname
   ] ~default:(direct_kv_ro_conf dirname)
 
@@ -417,7 +417,7 @@ class block_conf file =
     method! packages =
       Key.match_ Key.(value target) @@ function
       | `Xen | `Qubes -> xen_block_packages
-      | `Virtio | `Ukvm | `Muen -> [ package ~min:"0.3.0" "mirage-block-solo5" ]
+      | `Virtio | `Hvt | `Muen -> [ package ~min:"0.3.0" "mirage-block-solo5" ]
       | `Unix | `MacOSX -> [ package ~min:"2.5.0" "mirage-block-unix" ]
 
     method! configure _ =
@@ -426,7 +426,7 @@ class block_conf file =
 
     method private connect_name target root =
       match target with
-      | `Unix | `MacOSX | `Virtio | `Ukvm | `Muen ->
+      | `Unix | `MacOSX | `Virtio | `Hvt | `Muen ->
         Fpath.(to_string (root / file)) (* open the file directly *)
       | `Xen | `Qubes ->
         let b = make_block_t file in
@@ -435,7 +435,7 @@ class block_conf file =
     method! connect i s _ =
       match get_target i with
       | `Muen -> failwith "Block devices not supported on Muen target."
-      | `Unix | `MacOSX | `Virtio | `Ukvm | `Xen | `Qubes ->
+      | `Unix | `MacOSX | `Virtio | `Hvt | `Xen | `Qubes ->
         Fmt.strf "%s.connect %S" s
           (self#connect_name (get_target i) @@ Info.build_dir i)
   end
@@ -605,7 +605,7 @@ let network_conf (intf : string Key.key) =
       | `MacOSX -> [ package ~min:"1.3.0" "mirage-net-macosx" ]
       | `Xen -> [ package ~min:"1.7.0" "mirage-net-xen"]
       | `Qubes -> [ package ~min:"1.7.0" "mirage-net-xen" ; package ~min:"0.4" "mirage-qubes" ]
-      | `Virtio | `Ukvm | `Muen -> [ package ~min:"0.3.0" "mirage-net-solo5" ]
+      | `Virtio | `Hvt | `Muen -> [ package ~min:"0.3.0" "mirage-net-solo5" ]
     method! connect _ modname _ =
       Fmt.strf "%s.connect %a" modname Key.serialize_call key
     method! configure i =
@@ -712,7 +712,7 @@ let right_tcpip_library ?min ?max ?ocamlfind ~sublibs pkg =
   Key.match_ Key.(value target) @@ function
   |`MacOSX | `Unix         -> [ package ?min ?max ?ocamlfind ~sublibs:("unix"::sublibs) pkg ]
   |`Qubes  | `Xen          -> [ package ?min ?max ?ocamlfind ~sublibs:("xen"::sublibs) pkg ]
-  |`Virtio | `Ukvm | `Muen -> [ package ?min ?max ?ocamlfind ~sublibs pkg ]
+  |`Virtio | `Hvt | `Muen  -> [ package ?min ?max ?ocamlfind ~sublibs pkg ]
 
 let ipv4_keyed_conf ?network ?gateway () = impl @@ object
     inherit base_configurable
@@ -1348,7 +1348,7 @@ let default_argv =
     `Xen, argv_xen;
     `Qubes, argv_xen;
     `Virtio, argv_solo5;
-    `Ukvm, argv_solo5;
+    `Hvt, argv_solo5;
     `Muen, argv_solo5
   ] ~default:argv_unix
 
@@ -1419,7 +1419,7 @@ let mprof_trace ~size () =
     method! packages =
       Key.match_ Key.(value target) @@ function
       | `Xen | `Qubes -> [ package "mirage-profile"; package "mirage-profile-xen" ]
-      | `Virtio | `Ukvm | `Muen -> []
+      | `Virtio | `Hvt | `Muen -> []
       | `Unix | `MacOSX -> [ package "mirage-profile"; package "mirage-profile-unix" ]
     method! build _ =
       match query_ocamlfind ["lwt.tracing"] with
@@ -1428,7 +1428,7 @@ let mprof_trace ~size () =
                      opam pin add lwt https://github.com/mirage/lwt.git#tracing"
       | Ok _ -> Ok ()
     method! connect i _ _ = match get_target i with
-      | `Virtio | `Ukvm | `Muen -> failwith  "tracing is not currently implemented for solo5 targets"
+      | `Virtio | `Hvt | `Muen -> failwith  "tracing is not currently implemented for solo5 targets"
       | `Unix | `MacOSX ->
         Fmt.strf
           "Lwt.return ())@.\
@@ -1828,7 +1828,7 @@ let configure i =
   Log.info (fun m -> m "Configuring for target: %a" Key.pp_target target);
   let opam_name = unikernel_name target name in
   let target_debug = Key.(get ctx target_debug) in
-  if target_debug && target <> `Ukvm then
+  if target_debug && target <> `Hvt then
     Log.warn (fun m -> m "-g not supported for target: %a" Key.pp_target target);
   configure_myocamlbuild () >>= fun () ->
   configure_opam ~name:opam_name i >>= fun () ->
@@ -1864,12 +1864,12 @@ let compile libs warn_error target =
     (if terminal () then ["color(always)"] else [])
   and result = match target with
     | `Unix | `MacOSX -> "main.native"
-    | `Xen | `Qubes | `Virtio | `Ukvm | `Muen -> "main.native.o"
+    | `Xen | `Qubes | `Virtio | `Hvt | `Muen -> "main.native.o"
   and cflags = [ "-g" ]
   and lflags =
     let dontlink =
       match target with
-      | `Xen | `Qubes | `Virtio | `Ukvm | `Muen -> ["unix"; "str"; "num"; "threads"]
+      | `Xen | `Qubes | `Virtio | `Hvt | `Muen -> ["unix"; "str"; "num"; "threads"]
       | `Unix | `MacOSX -> []
     in
     let dont = List.map (fun k -> [ "-dontlink" ; k ]) dontlink in
@@ -1883,6 +1883,9 @@ let compile libs warn_error target =
                      "-cflags" % concat cflags %
                      "-lflags" % concat lflags %
                      "-tag-line" % "<static*.*>: warn(-32-34)" %
+                     "-X" %  "_build-solo5-hvt" %
+                     (* The following deprecated name is kept to allow mirage
+                      * clean to continue to work after an upgrade *)
                      "-X" %  "_build-ukvm" %
                      result)
   in
@@ -1962,9 +1965,9 @@ let find_ld pkg =
     "ld"
 
 let solo5_pkg = function
-  | `Virtio -> "solo5-kernel-virtio", ".virtio"
-  | `Muen -> "solo5-kernel-muen", ".muen"
-  | `Ukvm -> "solo5-kernel-ukvm", ".ukvm"
+  | `Virtio -> "solo5-bindings-virtio", ".virtio"
+  | `Muen -> "solo5-bindings-muen", ".muen"
+  | `Hvt -> "solo5-bindings-hvt", ".hvt"
   | `Unix | `MacOSX | `Xen | `Qubes ->
     invalid_arg "solo5_kernel only defined for solo5 targets"
 
@@ -2002,7 +2005,7 @@ let link info name target target_debug =
       Bos.OS.Cmd.run link >>= fun () ->
       Ok out
     end
-  | `Virtio | `Muen | `Ukvm ->
+  | `Virtio | `Muen | `Hvt ->
     let pkg, post = solo5_pkg target in
     extra_c_artifacts "freestanding" libs >>= fun c_artifacts ->
     static_libs "mirage-solo5" >>= fun static_libs ->
@@ -2017,8 +2020,8 @@ let link info name target target_debug =
     in
     Log.info (fun m -> m "linking with %a" Bos.Cmd.pp linker);
     Bos.OS.Cmd.run linker >>= fun () ->
-    if target = `Ukvm then
-      let ukvm_mods =
+    if target = `Hvt then
+      let tender_mods =
         List.fold_left (fun acc -> function
             | "mirage-net-solo5" -> "net" :: acc
             | "mirage-block-solo5" -> "blk" :: acc
@@ -2027,8 +2030,8 @@ let link info name target target_debug =
       in
       pkg_config pkg ["--variable=libdir"] >>= function
       | [ libdir ] ->
-        Bos.OS.Cmd.run Bos.Cmd.(v "ukvm-configure" % (libdir ^ "/src/ukvm") %% of_list ukvm_mods) >>= fun () ->
-        Bos.OS.Cmd.run Bos.Cmd.(v "make" % "-f" % "Makefile.ukvm" % "ukvm-bin") >>= fun () ->
+        Bos.OS.Cmd.run Bos.Cmd.(v "solo5-hvt-configure" % (libdir ^ "/src") %% of_list tender_mods) >>= fun () ->
+        Bos.OS.Cmd.run Bos.Cmd.(v "make" % "-f" % "Makefile.solo5-hvt" % "solo5-hvt") >>= fun () ->
         Ok out
       | _ -> R.error_msg ("pkg-config " ^ pkg ^ " --variable=libdir failed")
     else
@@ -2064,7 +2067,12 @@ let clean i =
   Bos.OS.File.delete Fpath.(v name + "elf") >>= fun () ->
   Bos.OS.File.delete Fpath.(v name + "virtio") >>= fun () ->
   Bos.OS.File.delete Fpath.(v name + "muen") >>= fun () ->
-  Bos.OS.File.delete Fpath.(v name + "ukvm") >>= fun () ->
+  Bos.OS.File.delete Fpath.(v name + "hvt") >>= fun () ->
+  Bos.OS.File.delete Fpath.(v "Makefile.solo5-hvt") >>= fun () ->
+  Bos.OS.Dir.delete ~recurse:true Fpath.(v "_build-solo5-hvt") >>= fun () ->
+  Bos.OS.File.delete Fpath.(v "solo5-hvt") >>= fun () ->
+  (* The following deprecated names are kept here to allow "mirage clean" to
+   * continue to work after an upgrade. *)
   Bos.OS.File.delete Fpath.(v "Makefile.ukvm") >>= fun () ->
   Bos.OS.Dir.delete ~recurse:true Fpath.(v "_build-ukvm") >>= fun () ->
   Bos.OS.File.delete Fpath.(v "ukvm-bin")
@@ -2081,7 +2089,7 @@ module Project = struct
   let packages = [package "mirage"]
 
   (* The directories to ignore when compiling config.ml *)
-  let ignore_dirs = ["_build-ukvm"]
+  let ignore_dirs = ["_build-solo5-hvt"; "_build-ukvm"]
 
   let create jobs = impl @@ object
       inherit base_configurable
@@ -2106,10 +2114,10 @@ module Project = struct
         Key.match_ Key.(value target) @@ function
         | `Unix | `MacOSX -> [ package ~min:"3.0.0" "mirage-unix" ] @ common
         | `Xen | `Qubes -> [ package ~min:"3.0.4" "mirage-xen" ] @ common
-        | `Virtio | `Ukvm | `Muen as tgt ->
+        | `Virtio | `Hvt | `Muen as tgt ->
           let pkg, _ = solo5_pkg tgt in
-          [ package ~min:"0.3.0" ~ocamlfind:[] pkg ;
-            package ~min:"0.3.0" "mirage-solo5" ] @ common
+          [ package ~min:"0.4.0" ~ocamlfind:[] pkg ;
+            package ~min:"0.4.0" "mirage-solo5" ] @ common
 
       method! build = build
       method! configure = configure

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -85,7 +85,7 @@ type mode = [
   | `Unix
   | `Xen
   | `Virtio
-  | `Ukvm
+  | `Hvt
   | `Muen
   | `MacOSX
   | `Qubes
@@ -97,7 +97,7 @@ let target_conv: mode Cmdliner.Arg.converter =
     "macosx", `MacOSX;
     "xen"   , `Xen;
     "virtio", `Virtio;
-    "ukvm"  , `Ukvm;
+    "hvt"    ,`Hvt;
     "muen"  , `Muen;
     "qubes" , `Qubes
   ]
@@ -115,13 +115,13 @@ let default_unix = lazy (
 let target =
   let doc =
     "Target platform to compile the unikernel for. Valid values are: \
-     $(i,xen), $(i,qubes), $(i,unix), $(i,macosx), $(i,virtio), $(i,ukvm), $(i,muen)."
+     $(i,xen), $(i,qubes), $(i,unix), $(i,macosx), $(i,virtio), $(i,hvt), $(i,muen)."
   in
   let serialize ppf = function
     | `Unix   -> Fmt.pf ppf "`Unix"
     | `Xen    -> Fmt.pf ppf "`Xen"
     | `Virtio -> Fmt.pf ppf "`Virtio"
-    | `Ukvm   -> Fmt.pf ppf "`Ukvm"
+    | `Hvt    -> Fmt.pf ppf "`Hvt"
     | `Muen   -> Fmt.pf ppf "`Muen"
     | `MacOSX -> Fmt.pf ppf "`MacOSX"
     | `Qubes  -> Fmt.pf ppf "`Qubes"
@@ -137,7 +137,7 @@ let target =
 let is_unix =
   Key.match_ Key.(value target) @@ function
   | `Unix | `MacOSX -> true
-  | `Qubes | `Xen | `Virtio | `Ukvm | `Muen -> false
+  | `Qubes | `Xen | `Virtio | `Hvt | `Muen -> false
 
 let warn_error =
   let doc = "Enable -warn-error when compiling OCaml sources." in
@@ -147,7 +147,7 @@ let warn_error =
 
 let target_debug =
   let doc = "Enables target-specific support for debugging. Supported \
-             targets: ukvm (compiles ukvm-bin with GDB server support)." in
+             targets: hvt (compiles solo5-hvt with GDB server support)." in
   let doc = Arg.info ~docs:mirage_section ~docv:"DEBUG" ~doc ["g"] in
   let key = Arg.flag ~stage:`Configure doc in
   Key.create "target_debug" key

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -30,13 +30,13 @@ end
 
 include Functoria.KEY with module Arg := Arg
 
-type mode = [ `Unix | `Xen | `Qubes | `MacOSX | `Virtio | `Ukvm | `Muen ]
+type mode = [ `Unix | `Xen | `Qubes | `MacOSX | `Virtio | `Hvt | `Muen ]
 
 (** {2 Mirage keys} *)
 
 val target: mode key
 (** [-t TARGET]: Key setting the configuration mode for the current project.
-    Is one of ["unix"], ["macosx"], ["xen"], ["qubes"], ["virtio"], ["ukvm"]
+    Is one of ["unix"], ["macosx"], ["xen"], ["qubes"], ["virtio"], ["hvt"]
     or ["muen"].
 *)
 

--- a/mirage.opam
+++ b/mirage.opam
@@ -29,6 +29,6 @@ conflicts: [
   "io-page"  {< "1.4.0"}
   "crunch"   {< "1.2.2"}
   "jbuilder" {= "1.0+beta18"}
-  "mirage-solo5" {>= "0.4.0"}
+  "mirage-solo5" {< "0.4.0"}
 ]
 available: [ocaml-version >= "4.04.2"]


### PR DESCRIPTION
Solo5 0.4.0 will rename the "ukvm" target to "hvt", and the Solo5 OPAM packages to "solo5-bindings-TARGET". Adapt the mirage front-end tool to match the new names.

Note that some references to "ukvm" build artifacts are kept to allow a "mirage clean" to succeed after reconfiguring a dirty "ukvm" unikernel source tree with the "hvt" target.

CI is not expected to pass on this PR until the intermediate steps in #923 have been completed. Posting now for early review.