### PR TITLE
Add conflict with mirage-solo5 >= 0.4.0

### DIFF
--- a/mirage.opam
+++ b/mirage.opam
@@ -29,5 +29,6 @@ conflicts: [
   "io-page"  {< "1.4.0"}
   "crunch"   {< "1.2.2"}
   "jbuilder" {= "1.0+beta18"}
+  "mirage-solo5" {>= "0.4.0"}
 ]
 available: [ocaml-version >= "4.04.2"]


### PR DESCRIPTION
This will avoid spurious CI failures until #924 is merged.

/cc #923