### PR TITLE
WIP: extract and test a Mirage_cli module

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1575,32 +1575,10 @@ let configure_main_xe ~root ~name =
 let clean_main_xe ~name = Bos.OS.File.delete Fpath.(v name + "xe")
 
 let configure_makefile ~opam_name =
-  let open Codegen in
   let file = Fpath.(v "Makefile") in
   with_output file (fun oc () ->
       let fmt = Format.formatter_of_out_channel oc in
-      append fmt "# %s" (generated_header ());
-      newline fmt;
-      append fmt "-include Makefile.user";
-      newline fmt;
-      append fmt "OPAM = opam\n\
-                  DEPEXT ?= opam depext --yes --update %s\n\
-                  \n\
-                  .PHONY: all depend depends clean build\n\
-                  all:: build\n\
-                  \n\
-                  depend depends::\n\
-                  \t$(OPAM) pin add -k path --no-action --yes %s .\n\
-                  \t$(DEPEXT)\n\
-                  \t$(OPAM) install --yes --deps-only %s\n\
-                  \t$(OPAM) pin remove --no-action %s\n\
-                  \n\
-                  build::\n\
-                  \tmirage build\n\
-                  \n\
-                  clean::\n\
-                  \tmirage clean\n"
-        opam_name opam_name opam_name opam_name;
+      Mirage_cli.output_makefile fmt ~opam_name;
       R.ok ())
     "Makefile"
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1672,61 +1672,14 @@ let configure_main_xl ?substitutions ext i =
 let clean_main_xl ~name ext = Bos.OS.File.delete Fpath.(v name + ext)
 
 let configure_main_xe ~root ~name =
-  let open Codegen in
   let file = Fpath.(v name + "xe") in
-  with_output ~mode:0o755 file (fun oc () ->
+  with_output
+    ~mode:0o755
+    file
+    (fun oc () ->
       let fmt = Format.formatter_of_out_channel oc in
-      append fmt "#!/bin/sh";
-      append fmt "# %s" (generated_header ());
-      newline fmt;
-      append fmt "set -e";
-      newline fmt;
-      append fmt "# Dependency: xe";
-      append fmt "command -v xe >/dev/null 2>&1 || { echo >&2 \"I require xe but \
-                  it's not installed.  Aborting.\"; exit 1; }";
-      append fmt "# Dependency: xe-unikernel-upload";
-      append fmt "command -v xe-unikernel-upload >/dev/null 2>&1 || { echo >&2 \"I \
-                  require xe-unikernel-upload but it's not installed.  Aborting.\"\
-                  ; exit 1; }";
-      append fmt "# Dependency: a $HOME/.xe";
-      append fmt "if [ ! -e $HOME/.xe ]; then";
-      append fmt "  echo Please create a config file for xe in $HOME/.xe which \
-                  contains:";
-      append fmt "  echo server='<IP or DNS name of the host running xapi>'";
-      append fmt "  echo username=root";
-      append fmt "  echo password=password";
-      append fmt "  exit 1";
-      append fmt "fi";
-      newline fmt;
-      append fmt "echo Uploading VDI containing unikernel";
-      append fmt "VDI=$(xe-unikernel-upload --path %s/%s.xen)" root name;
-      append fmt "echo VDI=$VDI";
-      append fmt "echo Creating VM metadata";
-      append fmt "VM=$(xe vm-create name-label=%s)" name;
-      append fmt "echo VM=$VM";
-      append fmt "xe vm-param-set uuid=$VM PV-bootloader=pygrub";
-      append fmt "echo Adding network interface connected to xenbr0";
-      append fmt "ETH0=$(xe network-list bridge=xenbr0 params=uuid --minimal)";
-      append fmt "VIF=$(xe vif-create vm-uuid=$VM network-uuid=$ETH0 device=0)";
-      append fmt "echo Atting block device and making it bootable";
-      append fmt "VBD=$(xe vbd-create vm-uuid=$VM vdi-uuid=$VDI device=0)";
-      append fmt "xe vbd-param-set uuid=$VBD bootable=true";
-      append fmt "xe vbd-param-set uuid=$VBD other-config:owner=true";
-      List.iter (fun b ->
-          append fmt "echo Uploading data VDI %s" b.filename;
-          append fmt "echo VDI=$VDI";
-          append fmt "SIZE=$(stat --format '%%s' %s/%s)" root b.filename;
-          append fmt "POOL=$(xe pool-list params=uuid --minimal)";
-          append fmt "SR=$(xe pool-list uuid=$POOL params=default-SR --minimal)";
-          append fmt "VDI=$(xe vdi-create type=user name-label='%s' \
-                      virtual-size=$SIZE sr-uuid=$SR)" b.filename;
-          append fmt "xe vdi-import uuid=$VDI filename=%s/%s" root b.filename;
-          append fmt "VBD=$(xe vbd-create vm-uuid=$VM vdi-uuid=$VDI device=%d)"
-            b.number;
-          append fmt "xe vbd-param-set uuid=$VBD other-config:owner=true")
-        (Hashtbl.fold (fun _ v acc -> v :: acc) all_blocks []);
-      append fmt "echo Starting VM";
-      append fmt "xe vm-start uuid=$VM";
+      let blocks = hashtbl_map_values (fun b -> (b.filename, b.number)) all_blocks in
+      Mirage_cli.output_main_xe fmt ~root ~name ~blocks;
       R.ok ())
     "xe file"
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -523,27 +523,7 @@ let fat_block ?(dir=".") ?(regexp="*") () =
       with_output ~mode:0o755 (Fpath.v file)
         (fun oc () ->
            let fmt = Format.formatter_of_out_channel oc in
-           Codegen.append fmt "#!/bin/sh";
-           Codegen.append fmt "";
-           Codegen.append fmt "echo This uses the 'fat' command-line tool to \
-                               build a simple FAT";
-           Codegen.append fmt "echo filesystem image.";
-           Codegen.append fmt "";
-           Codegen.append fmt "FAT=$(which fat)";
-           Codegen.append fmt "if [ ! -x \"${FAT}\" ]; then";
-           Codegen.append fmt "  echo I couldn\\'t find the 'fat' command-line \
-                               tool.";
-           Codegen.append fmt "  echo Try running 'opam install fat-filesystem'";
-           Codegen.append fmt "  exit 1";
-           Codegen.append fmt "fi";
-           Codegen.append fmt "";
-           Codegen.append fmt "IMG=$(pwd)/%s" block_file;
-           Codegen.append fmt "rm -f ${IMG}";
-           Codegen.append fmt "cd %a" Fpath.pp (Fpath.append root dir);
-           Codegen.append fmt "SIZE=$(du -s . | cut -f 1)";
-           Codegen.append fmt "${FAT} create ${IMG} ${SIZE}KiB";
-           Codegen.append fmt "${FAT} add ${IMG} %s" regexp;
-           Codegen.append fmt "echo Created '%s'" block_file;
+           Mirage_cli.output_fat fmt ~block_file ~root ~dir ~regexp;
            R.ok ())
         "fat shell script" >>= fun () ->
       Log.info (fun m -> m "Executing block generator script: ./%s" file);

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1647,17 +1647,10 @@ let clean_myocamlbuild () =
 let opam_file n = Fpath.(v n + "opam")
 
 let configure_opam ~name info =
-  let open Codegen in
   let file = opam_file name in
   with_output file (fun oc () ->
       let fmt = Format.formatter_of_out_channel oc in
-      append fmt "# %s" (generated_header ());
-      Info.opam ~name fmt info;
-      append fmt "maintainer: \"dummy\"";
-      append fmt "authors: \"dummy\"";
-      append fmt "homepage: \"dummy\"";
-      append fmt "bug-reports: \"dummy\"";
-      append fmt "build: [ \"mirage\" \"build\" ]";
+      Mirage_cli.output_opam fmt ~name ~info;
       R.ok ())
     "opam file"
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1472,56 +1472,11 @@ let configure_main_libvirt_xml ~root ~name =
     "libvirt.xml"
 
 let configure_virtio_libvirt_xml ~root ~name =
-  let open Codegen in
   let file = Fpath.(v (name ^  "_libvirt") + "xml") in
   with_output file
     (fun oc () ->
       let fmt = Format.formatter_of_out_channel oc in
-      append fmt "<!-- %s -->" (generated_header ());
-      append fmt "<domain type='kvm'>";
-      append fmt "    <name>%s</name>" name;
-      append fmt "    <memory unit='KiB'>262144</memory>";
-      append fmt "    <currentMemory unit='KiB'>262144</currentMemory>";
-      append fmt "    <vcpu placement='static'>1</vcpu>";
-      append fmt "    <os>";
-      append fmt "        <type arch='x86_64' machine='pc'>hvm</type>";
-      append fmt "        <kernel>%s/%s.virtio</kernel>" root name;
-      append fmt "        <!-- Command line arguments can be given if required:";
-      append fmt "        <cmdline>-l *:debug</cmdline>";
-      append fmt "        -->";
-      append fmt "    </os>";
-      append fmt "    <clock offset='utc' adjustment='reset'/>";
-      append fmt "    <devices>";
-      append fmt "        <emulator>/usr/bin/qemu-system-x86_64</emulator>";
-      append fmt "        <!--";
-      append fmt "        Disk/block configuration reference is here:";
-      append fmt "        https://libvirt.org/formatdomain.html#elementsDisks";
-      append fmt "        This example uses a raw file on the host as a block in the guest:";
-      append fmt "        <disk type='file' device='disk'>";
-      append fmt "            <driver name='qemu' type='raw'/>";
-      append fmt "            <source file='/var/lib/libvirt/images/%s.img'/>" name;
-      append fmt "            <target dev='vda' bus='virtio'/>";
-      append fmt "        </disk>";
-      append fmt "        -->";
-      append fmt "        <!-- ";
-      append fmt "        Network configuration reference is here:";
-      append fmt "        https://libvirt.org/formatdomain.html#elementsNICS";
-      append fmt "        This example adds a device in the 'default' libvirt bridge:";
-      append fmt "        <interface type='bridge'>";
-      append fmt "            <source bridge='virbr0'/>";
-      append fmt "            <model type='virtio'/>";
-      append fmt "            <alias name='0'/>";
-      append fmt "        </interface>";
-      append fmt "        -->";
-      append fmt "        <serial type='pty'>";
-      append fmt "            <target port='0'/>";
-      append fmt "        </serial>";
-      append fmt "        <console type='pty'>";
-      append fmt "            <target type='serial' port='0'/>";
-      append fmt "        </console>";
-      append fmt "        <memballoon model='none'/>";
-      append fmt "    </devices>";
-      append fmt "</domain>";
+      Mirage_cli.output_virtio_libvirt_xml fmt ~root ~name;
       R.ok ())
     "libvirt.xml"
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -1463,57 +1463,11 @@ let info = Functoria_app.info
 let app_info = Functoria_app.app_info ~type_modname:"Mirage_info" ()
 
 let configure_main_libvirt_xml ~root ~name =
-  let open Codegen in
   let file = Fpath.(v (name ^  "_libvirt") + "xml") in
   with_output file
     (fun oc () ->
        let fmt = Format.formatter_of_out_channel oc in
-       append fmt "<!-- %s -->" (generated_header ());
-       append fmt "<domain type='xen'>";
-       append fmt "    <name>%s</name>" name;
-       append fmt "    <memory unit='KiB'>262144</memory>";
-       append fmt "    <currentMemory unit='KiB'>262144</currentMemory>";
-       append fmt "    <vcpu placement='static'>1</vcpu>";
-       append fmt "    <os>";
-       append fmt "        <type arch='armv7l' machine='xenpv'>linux</type>";
-       append fmt "        <kernel>%s/%s.xen</kernel>" root name;
-       append fmt "        <cmdline> </cmdline>";
-       (* the libxl driver currently needs an empty cmdline to be able to
-           start the domain on arm - due to this?
-           http://lists.xen.org/archives/html/xen-devel/2014-02/msg02375.html *)
-       append fmt "    </os>";
-       append fmt "    <clock offset='utc' adjustment='reset'/>";
-       append fmt "    <on_crash>preserve</on_crash>";
-       append fmt "    <!-- ";
-       append fmt "    You must define network and block interfaces manually.";
-       append fmt "    See http://libvirt.org/drvxen.html for information about \
-                   converting .xl-files to libvirt xml automatically.";
-       append fmt "    -->";
-       append fmt "    <devices>";
-       append fmt "        <!--";
-       append fmt "        The disk configuration is defined here:";
-       append fmt "        http://libvirt.org/formatstorage.html.";
-       append fmt "        An example would look like:";
-       append fmt"         <disk type='block' device='disk'>";
-       append fmt "            <driver name='phy'/>";
-       append fmt "            <source dev='/dev/loop0'/>";
-       append fmt "            <target dev='' bus='xen'/>";
-       append fmt "        </disk>";
-       append fmt "        -->";
-       append fmt "        <!-- ";
-       append fmt "        The network configuration is defined here:";
-       append fmt "        http://libvirt.org/formatnetwork.html";
-       append fmt "        An example would look like:";
-       append fmt "        <interface type='bridge'>";
-       append fmt "            <mac address='c0:ff:ee:c0:ff:ee'/>";
-       append fmt "            <source bridge='br0'/>";
-       append fmt "        </interface>";
-       append fmt "        -->";
-       append fmt "        <console type='pty'>";
-       append fmt "            <target type='xen' port='0'/>";
-       append fmt "        </console>";
-       append fmt "    </devices>";
-       append fmt "</domain>";
+       Mirage_cli.output_main_libvirt_xml fmt ~root ~name;
        R.ok ())
     "libvirt.xml"
 

--- a/lib/mirage_cli.ml
+++ b/lib/mirage_cli.ml
@@ -194,3 +194,12 @@ let output_virtio_libvirt_xml fmt ~root ~name =
   append fmt "        <memballoon model='none'/>";
   append fmt "    </devices>";
   append fmt "</domain>"
+
+let output_opam fmt ~name ~info =
+  append fmt "# %s" (generated_header ());
+  Functoria.Info.opam ~name fmt info;
+  append fmt "maintainer: \"dummy\"";
+  append fmt "authors: \"dummy\"";
+  append fmt "homepage: \"dummy\"";
+  append fmt "bug-reports: \"dummy\"";
+  append fmt "build: [ \"mirage\" \"build\" ]"

--- a/lib/mirage_cli.ml
+++ b/lib/mirage_cli.ml
@@ -226,3 +226,27 @@ let output_fat fmt ~block_file ~root ~dir ~regexp =
   append fmt "${FAT} create ${IMG} ${SIZE}KiB";
   append fmt "${FAT} add ${IMG} %s" regexp;
   append fmt "echo Created '%s'" block_file
+
+let output_makefile fmt ~opam_name =
+  append fmt "# %s" (generated_header ());
+  newline fmt;
+  append fmt "-include Makefile.user";
+  newline fmt;
+  append fmt "OPAM = opam\n\
+              DEPEXT ?= opam depext --yes --update %s\n\
+              \n\
+              .PHONY: all depend depends clean build\n\
+              all:: build\n\
+              \n\
+              depend depends::\n\
+              \t$(OPAM) pin add -k path --no-action --yes %s .\n\
+              \t$(DEPEXT)\n\
+              \t$(OPAM) install --yes --deps-only %s\n\
+              \t$(OPAM) pin remove --no-action %s\n\
+              \n\
+              build::\n\
+              \tmirage build\n\
+              \n\
+              clean::\n\
+              \tmirage clean\n"
+    opam_name opam_name opam_name opam_name

--- a/lib/mirage_cli.ml
+++ b/lib/mirage_cli.ml
@@ -203,3 +203,26 @@ let output_opam fmt ~name ~info =
   append fmt "homepage: \"dummy\"";
   append fmt "bug-reports: \"dummy\"";
   append fmt "build: [ \"mirage\" \"build\" ]"
+
+let output_fat fmt ~block_file ~root ~dir ~regexp =
+  append fmt "#!/bin/sh";
+  append fmt "";
+  append fmt "echo This uses the 'fat' command-line tool to \
+              build a simple FAT";
+  append fmt "echo filesystem image.";
+  append fmt "";
+  append fmt "FAT=$(which fat)";
+  append fmt "if [ ! -x \"${FAT}\" ]; then";
+  append fmt "  echo I couldn\\'t find the 'fat' command-line \
+              tool.";
+  append fmt "  echo Try running 'opam install fat-filesystem'";
+  append fmt "  exit 1";
+  append fmt "fi";
+  append fmt "";
+  append fmt "IMG=$(pwd)/%s" block_file;
+  append fmt "rm -f ${IMG}";
+  append fmt "cd %a" Fpath.pp (Fpath.append root dir);
+  append fmt "SIZE=$(du -s . | cut -f 1)";
+  append fmt "${FAT} create ${IMG} ${SIZE}KiB";
+  append fmt "${FAT} add ${IMG} %s" regexp;
+  append fmt "echo Created '%s'" block_file

--- a/lib/mirage_cli.ml
+++ b/lib/mirage_cli.ml
@@ -98,3 +98,52 @@ let output_main_xe fmt ~root ~name ~blocks =
     blocks;
   append fmt "echo Starting VM";
   append fmt "xe vm-start uuid=$VM"
+
+let output_main_libvirt_xml fmt ~root ~name =
+  let open Functoria_app.Codegen in
+  append fmt "<!-- %s -->" (generated_header ());
+  append fmt "<domain type='xen'>";
+  append fmt "    <name>%s</name>" name;
+  append fmt "    <memory unit='KiB'>262144</memory>";
+  append fmt "    <currentMemory unit='KiB'>262144</currentMemory>";
+  append fmt "    <vcpu placement='static'>1</vcpu>";
+  append fmt "    <os>";
+  append fmt "        <type arch='armv7l' machine='xenpv'>linux</type>";
+  append fmt "        <kernel>%s/%s.xen</kernel>" root name;
+  append fmt "        <cmdline> </cmdline>";
+  (* the libxl driver currently needs an empty cmdline to be able to
+      start the domain on arm - due to this?
+      http://lists.xen.org/archives/html/xen-devel/2014-02/msg02375.html *)
+  append fmt "    </os>";
+  append fmt "    <clock offset='utc' adjustment='reset'/>";
+  append fmt "    <on_crash>preserve</on_crash>";
+  append fmt "    <!-- ";
+  append fmt "    You must define network and block interfaces manually.";
+  append fmt "    See http://libvirt.org/drvxen.html for information about \
+              converting .xl-files to libvirt xml automatically.";
+  append fmt "    -->";
+  append fmt "    <devices>";
+  append fmt "        <!--";
+  append fmt "        The disk configuration is defined here:";
+  append fmt "        http://libvirt.org/formatstorage.html.";
+  append fmt "        An example would look like:";
+  append fmt"         <disk type='block' device='disk'>";
+  append fmt "            <driver name='phy'/>";
+  append fmt "            <source dev='/dev/loop0'/>";
+  append fmt "            <target dev='' bus='xen'/>";
+  append fmt "        </disk>";
+  append fmt "        -->";
+  append fmt "        <!-- ";
+  append fmt "        The network configuration is defined here:";
+  append fmt "        http://libvirt.org/formatnetwork.html";
+  append fmt "        An example would look like:";
+  append fmt "        <interface type='bridge'>";
+  append fmt "            <mac address='c0:ff:ee:c0:ff:ee'/>";
+  append fmt "            <source bridge='br0'/>";
+  append fmt "        </interface>";
+  append fmt "        -->";
+  append fmt "        <console type='pty'>";
+  append fmt "            <target type='xen' port='0'/>";
+  append fmt "        </console>";
+  append fmt "    </devices>";
+  append fmt "</domain>"

--- a/lib/mirage_cli.ml
+++ b/lib/mirage_cli.ml
@@ -1,0 +1,47 @@
+open Astring
+open Functoria_app.Codegen
+
+let rec string_of_int26 x =
+  let high, low = x / 26 - 1, x mod 26 + 1 in
+  let high' = if high = -1 then "" else string_of_int26 high in
+  let low' =
+    String.v ~len:1
+      (fun _ -> char_of_int (low + (int_of_char 'a') - 1))
+  in
+  high' ^ low'
+
+(* We need the Linux version of the block number (this is a
+   strange historical artifact) Taken from
+   https://github.com/mirage/mirage-block-xen/blob/
+   a64d152586c7ebc1d23c5adaa4ddd440b45a3a83/lib/device_number.ml#L128 *)
+let vdev number =
+  Fmt.strf "xvd%s" (string_of_int26 number)
+
+let output_main_xl fmt ~name ~kernel ~memory ~blocks ~networks =
+  let block_strings =
+    List.map
+      (fun (number, path) ->
+        Fmt.strf "'format=raw, vdev=%s, access=rw, target=%s'" (vdev number) path)
+      blocks
+  in
+  let network_strings =
+    List.map
+    (fun n -> Fmt.strf "'bridge=%s'" n)
+    networks
+  in
+  append fmt "# %s" (generated_header ()) ;
+  newline fmt;
+  append fmt "name = '%s'" name;
+  append fmt "kernel = '%s'" kernel;
+  append fmt "builder = 'linux'";
+  append fmt "memory = %s" memory;
+  append fmt "on_crash = 'preserve'";
+  newline fmt;
+  append fmt "disk = [ %s ]" (String.concat ~sep:", " block_strings);
+  newline fmt;
+  append fmt "# if your system uses openvswitch then either edit \
+              /etc/xen/xl.conf and set";
+  append fmt "#     vif.default.script=\"vif-openvswitch\"";
+  append fmt "# or add \"script=vif-openvswitch,\" before the \"bridge=\" \
+              below:";
+  append fmt "vif = [ %s ]" (String.concat ~sep:", " network_strings);

--- a/lib/mirage_cli.ml
+++ b/lib/mirage_cli.ml
@@ -44,4 +44,57 @@ let output_main_xl fmt ~name ~kernel ~memory ~blocks ~networks =
   append fmt "#     vif.default.script=\"vif-openvswitch\"";
   append fmt "# or add \"script=vif-openvswitch,\" before the \"bridge=\" \
               below:";
-  append fmt "vif = [ %s ]" (String.concat ~sep:", " network_strings);
+  append fmt "vif = [ %s ]" (String.concat ~sep:", " network_strings)
+
+let output_main_xe fmt ~root ~name ~blocks =
+  append fmt "#!/bin/sh";
+  append fmt "# %s" (generated_header ());
+  newline fmt;
+  append fmt "set -e";
+  newline fmt;
+  append fmt "# Dependency: xe";
+  append fmt "command -v xe >/dev/null 2>&1 || { echo >&2 \"I require xe but \
+              it's not installed.  Aborting.\"; exit 1; }";
+  append fmt "# Dependency: xe-unikernel-upload";
+  append fmt "command -v xe-unikernel-upload >/dev/null 2>&1 || { echo >&2 \"I \
+              require xe-unikernel-upload but it's not installed.  Aborting.\"\
+              ; exit 1; }";
+  append fmt "# Dependency: a $HOME/.xe";
+  append fmt "if [ ! -e $HOME/.xe ]; then";
+  append fmt "  echo Please create a config file for xe in $HOME/.xe which \
+              contains:";
+  append fmt "  echo server='<IP or DNS name of the host running xapi>'";
+  append fmt "  echo username=root";
+  append fmt "  echo password=password";
+  append fmt "  exit 1";
+  append fmt "fi";
+  newline fmt;
+  append fmt "echo Uploading VDI containing unikernel";
+  append fmt "VDI=$(xe-unikernel-upload --path %s/%s.xen)" root name;
+  append fmt "echo VDI=$VDI";
+  append fmt "echo Creating VM metadata";
+  append fmt "VM=$(xe vm-create name-label=%s)" name;
+  append fmt "echo VM=$VM";
+  append fmt "xe vm-param-set uuid=$VM PV-bootloader=pygrub";
+  append fmt "echo Adding network interface connected to xenbr0";
+  append fmt "ETH0=$(xe network-list bridge=xenbr0 params=uuid --minimal)";
+  append fmt "VIF=$(xe vif-create vm-uuid=$VM network-uuid=$ETH0 device=0)";
+  append fmt "echo Atting block device and making it bootable";
+  append fmt "VBD=$(xe vbd-create vm-uuid=$VM vdi-uuid=$VDI device=0)";
+  append fmt "xe vbd-param-set uuid=$VBD bootable=true";
+  append fmt "xe vbd-param-set uuid=$VBD other-config:owner=true";
+  List.iter
+    (fun (filename, number) ->
+      append fmt "echo Uploading data VDI %s" filename;
+      append fmt "echo VDI=$VDI";
+      append fmt "SIZE=$(stat --format '%%s' %s/%s)" root filename;
+      append fmt "POOL=$(xe pool-list params=uuid --minimal)";
+      append fmt "SR=$(xe pool-list uuid=$POOL params=default-SR --minimal)";
+      append fmt "VDI=$(xe vdi-create type=user name-label='%s' \
+                  virtual-size=$SIZE sr-uuid=$SR)" filename;
+      append fmt "xe vdi-import uuid=$VDI filename=%s/%s" root filename;
+      append fmt "VBD=$(xe vbd-create vm-uuid=$VM vdi-uuid=$VDI device=%d)" number;
+      append fmt "xe vbd-param-set uuid=$VBD other-config:owner=true")
+    blocks;
+  append fmt "echo Starting VM";
+  append fmt "xe vm-start uuid=$VM"

--- a/lib/mirage_cli.ml
+++ b/lib/mirage_cli.ml
@@ -147,3 +147,50 @@ let output_main_libvirt_xml fmt ~root ~name =
   append fmt "        </console>";
   append fmt "    </devices>";
   append fmt "</domain>"
+
+let output_virtio_libvirt_xml fmt ~root ~name =
+  append fmt "<!-- %s -->" (generated_header ());
+  append fmt "<domain type='kvm'>";
+  append fmt "    <name>%s</name>" name;
+  append fmt "    <memory unit='KiB'>262144</memory>";
+  append fmt "    <currentMemory unit='KiB'>262144</currentMemory>";
+  append fmt "    <vcpu placement='static'>1</vcpu>";
+  append fmt "    <os>";
+  append fmt "        <type arch='x86_64' machine='pc'>hvm</type>";
+  append fmt "        <kernel>%s/%s.virtio</kernel>" root name;
+  append fmt "        <!-- Command line arguments can be given if required:";
+  append fmt "        <cmdline>-l *:debug</cmdline>";
+  append fmt "        -->";
+  append fmt "    </os>";
+  append fmt "    <clock offset='utc' adjustment='reset'/>";
+  append fmt "    <devices>";
+  append fmt "        <emulator>/usr/bin/qemu-system-x86_64</emulator>";
+  append fmt "        <!--";
+  append fmt "        Disk/block configuration reference is here:";
+  append fmt "        https://libvirt.org/formatdomain.html#elementsDisks";
+  append fmt "        This example uses a raw file on the host as a block in the guest:";
+  append fmt "        <disk type='file' device='disk'>";
+  append fmt "            <driver name='qemu' type='raw'/>";
+  append fmt "            <source file='/var/lib/libvirt/images/%s.img'/>" name;
+  append fmt "            <target dev='vda' bus='virtio'/>";
+  append fmt "        </disk>";
+  append fmt "        -->";
+  append fmt "        <!-- ";
+  append fmt "        Network configuration reference is here:";
+  append fmt "        https://libvirt.org/formatdomain.html#elementsNICS";
+  append fmt "        This example adds a device in the 'default' libvirt bridge:";
+  append fmt "        <interface type='bridge'>";
+  append fmt "            <source bridge='virbr0'/>";
+  append fmt "            <model type='virtio'/>";
+  append fmt "            <alias name='0'/>";
+  append fmt "        </interface>";
+  append fmt "        -->";
+  append fmt "        <serial type='pty'>";
+  append fmt "            <target port='0'/>";
+  append fmt "        </serial>";
+  append fmt "        <console type='pty'>";
+  append fmt "            <target type='serial' port='0'/>";
+  append fmt "        </console>";
+  append fmt "        <memballoon model='none'/>";
+  append fmt "    </devices>";
+  append fmt "</domain>"

--- a/lib/mirage_cli.mli
+++ b/lib/mirage_cli.mli
@@ -39,3 +39,8 @@ val output_fat :
   dir:Fpath.t ->
   regexp:string ->
   unit
+
+val output_makefile :
+  Format.formatter ->
+  opam_name:string ->
+  unit

--- a/lib/mirage_cli.mli
+++ b/lib/mirage_cli.mli
@@ -19,3 +19,9 @@ val output_main_libvirt_xml :
   root:string ->
   name:string ->
   unit
+
+val output_virtio_libvirt_xml :
+  Format.formatter ->
+  root:string ->
+  name:string ->
+  unit

--- a/lib/mirage_cli.mli
+++ b/lib/mirage_cli.mli
@@ -13,3 +13,9 @@ val output_main_xe :
   name:string ->
   blocks:(string * int) list ->
   unit
+
+val output_main_libvirt_xml :
+  Format.formatter ->
+  root:string ->
+  name:string ->
+  unit

--- a/lib/mirage_cli.mli
+++ b/lib/mirage_cli.mli
@@ -1,0 +1,8 @@
+val output_main_xl :
+  Format.formatter ->
+  name:string ->
+  kernel:string ->
+  memory:string ->
+  blocks:(int * string) list ->
+  networks:string list ->
+  unit

--- a/lib/mirage_cli.mli
+++ b/lib/mirage_cli.mli
@@ -25,3 +25,9 @@ val output_virtio_libvirt_xml :
   root:string ->
   name:string ->
   unit
+
+val output_opam :
+  Format.formatter ->
+  name:string ->
+  info:Functoria.Info.t ->
+  unit

--- a/lib/mirage_cli.mli
+++ b/lib/mirage_cli.mli
@@ -31,3 +31,11 @@ val output_opam :
   name:string ->
   info:Functoria.Info.t ->
   unit
+
+val output_fat :
+  Format.formatter ->
+  block_file:string ->
+  root:Fpath.t ->
+  dir:Fpath.t ->
+  regexp:string ->
+  unit

--- a/lib/mirage_cli.mli
+++ b/lib/mirage_cli.mli
@@ -6,3 +6,10 @@ val output_main_xl :
   blocks:(int * string) list ->
   networks:string list ->
   unit
+
+val output_main_xe :
+  Format.formatter ->
+  root:string ->
+  name:string ->
+  blocks:(string * int) list ->
+  unit

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,4 @@
+(test
+ (name test_cli)
+ (libraries mirage)
+)

--- a/test/test_cli.expected
+++ b/test/test_cli.expected
@@ -118,3 +118,52 @@ output_main_libvirt_xml
     </devices>
 </domain>
 
+output_virtio_libvirt_xml
+=========================
+
+# REDACTED
+<domain type='kvm'>
+    <name>NAME</name>
+    <memory unit='KiB'>262144</memory>
+    <currentMemory unit='KiB'>262144</currentMemory>
+    <vcpu placement='static'>1</vcpu>
+    <os>
+        <type arch='x86_64' machine='pc'>hvm</type>
+        <kernel>ROOT/NAME.virtio</kernel>
+        <!-- Command line arguments can be given if required:
+        <cmdline>-l *:debug</cmdline>
+        -->
+    </os>
+    <clock offset='utc' adjustment='reset'/>
+    <devices>
+        <emulator>/usr/bin/qemu-system-x86_64</emulator>
+        <!--
+        Disk/block configuration reference is here:
+        https://libvirt.org/formatdomain.html#elementsDisks
+        This example uses a raw file on the host as a block in the guest:
+        <disk type='file' device='disk'>
+            <driver name='qemu' type='raw'/>
+            <source file='/var/lib/libvirt/images/NAME.img'/>
+            <target dev='vda' bus='virtio'/>
+        </disk>
+        -->
+        <!-- 
+        Network configuration reference is here:
+        https://libvirt.org/formatdomain.html#elementsNICS
+        This example adds a device in the 'default' libvirt bridge:
+        <interface type='bridge'>
+            <source bridge='virbr0'/>
+            <model type='virtio'/>
+            <alias name='0'/>
+        </interface>
+        -->
+        <serial type='pty'>
+            <target port='0'/>
+        </serial>
+        <console type='pty'>
+            <target type='serial' port='0'/>
+        </console>
+        <memballoon model='none'/>
+    </devices>
+</domain>
+

--- a/test/test_cli.expected
+++ b/test/test_cli.expected
@@ -72,3 +72,49 @@ xe vbd-param-set uuid=$VBD other-config:owner=true
 echo Starting VM
 xe vm-start uuid=$VM
 
+output_main_libvirt_xml
+=======================
+
+# REDACTED
+<domain type='xen'>
+    <name>NAME</name>
+    <memory unit='KiB'>262144</memory>
+    <currentMemory unit='KiB'>262144</currentMemory>
+    <vcpu placement='static'>1</vcpu>
+    <os>
+        <type arch='armv7l' machine='xenpv'>linux</type>
+        <kernel>ROOT/NAME.xen</kernel>
+        <cmdline> </cmdline>
+    </os>
+    <clock offset='utc' adjustment='reset'/>
+    <on_crash>preserve</on_crash>
+    <!-- 
+    You must define network and block interfaces manually.
+    See http://libvirt.org/drvxen.html for information about converting .xl-files to libvirt xml automatically.
+    -->
+    <devices>
+        <!--
+        The disk configuration is defined here:
+        http://libvirt.org/formatstorage.html.
+        An example would look like:
+         <disk type='block' device='disk'>
+            <driver name='phy'/>
+            <source dev='/dev/loop0'/>
+            <target dev='' bus='xen'/>
+        </disk>
+        -->
+        <!-- 
+        The network configuration is defined here:
+        http://libvirt.org/formatnetwork.html
+        An example would look like:
+        <interface type='bridge'>
+            <mac address='c0:ff:ee:c0:ff:ee'/>
+            <source bridge='br0'/>
+        </interface>
+        -->
+        <console type='pty'>
+            <target type='xen' port='0'/>
+        </console>
+    </devices>
+</domain>
+

--- a/test/test_cli.expected
+++ b/test/test_cli.expected
@@ -167,3 +167,21 @@ output_virtio_libvirt_xml
     </devices>
 </domain>
 
+output_opam
+===========
+
+# REDACTED
+opam-version: "1.2"
+name: "NAME"
+depends: [ "pkg1" 
+           "pkg2" {build}
+           "pkg3" {>="3"}
+           "pkg4" {<"4"}
+           "pkg5" {>="5.0" & <"5.1"}
+]
+maintainer: "dummy"
+authors: "dummy"
+homepage: "dummy"
+bug-reports: "dummy"
+build: [ "mirage" "build" ]
+

--- a/test/test_cli.expected
+++ b/test/test_cli.expected
@@ -16,3 +16,59 @@ disk = [ 'format=raw, vdev=xvda, access=rw, target=BLOCK_PATH0', 'format=raw, vd
 # or add "script=vif-openvswitch," before the "bridge=" below:
 vif = [ 'bridge=NETWORK1', 'bridge=NETWORK2' ]
 
+output_main_xe
+==============
+
+#!/bin/sh
+# REDACTED
+
+set -e
+
+# Dependency: xe
+command -v xe >/dev/null 2>&1 || { echo >&2 "I require xe but it's not installed.  Aborting."; exit 1; }
+# Dependency: xe-unikernel-upload
+command -v xe-unikernel-upload >/dev/null 2>&1 || { echo >&2 "I require xe-unikernel-upload but it's not installed.  Aborting."; exit 1; }
+# Dependency: a $HOME/.xe
+if [ ! -e $HOME/.xe ]; then
+  echo Please create a config file for xe in $HOME/.xe which contains:
+  echo server='<IP or DNS name of the host running xapi>'
+  echo username=root
+  echo password=password
+  exit 1
+fi
+
+echo Uploading VDI containing unikernel
+VDI=$(xe-unikernel-upload --path ROOT/NAME.xen)
+echo VDI=$VDI
+echo Creating VM metadata
+VM=$(xe vm-create name-label=NAME)
+echo VM=$VM
+xe vm-param-set uuid=$VM PV-bootloader=pygrub
+echo Adding network interface connected to xenbr0
+ETH0=$(xe network-list bridge=xenbr0 params=uuid --minimal)
+VIF=$(xe vif-create vm-uuid=$VM network-uuid=$ETH0 device=0)
+echo Atting block device and making it bootable
+VBD=$(xe vbd-create vm-uuid=$VM vdi-uuid=$VDI device=0)
+xe vbd-param-set uuid=$VBD bootable=true
+xe vbd-param-set uuid=$VBD other-config:owner=true
+echo Uploading data VDI FILE1
+echo VDI=$VDI
+SIZE=$(stat --format '%s' ROOT/FILE1)
+POOL=$(xe pool-list params=uuid --minimal)
+SR=$(xe pool-list uuid=$POOL params=default-SR --minimal)
+VDI=$(xe vdi-create type=user name-label='FILE1' virtual-size=$SIZE sr-uuid=$SR)
+xe vdi-import uuid=$VDI filename=ROOT/FILE1
+VBD=$(xe vbd-create vm-uuid=$VM vdi-uuid=$VDI device=1)
+xe vbd-param-set uuid=$VBD other-config:owner=true
+echo Uploading data VDI FILE2
+echo VDI=$VDI
+SIZE=$(stat --format '%s' ROOT/FILE2)
+POOL=$(xe pool-list params=uuid --minimal)
+SR=$(xe pool-list uuid=$POOL params=default-SR --minimal)
+VDI=$(xe vdi-create type=user name-label='FILE2' virtual-size=$SIZE sr-uuid=$SR)
+xe vdi-import uuid=$VDI filename=ROOT/FILE2
+VBD=$(xe vbd-create vm-uuid=$VM vdi-uuid=$VDI device=2)
+xe vbd-param-set uuid=$VBD other-config:owner=true
+echo Starting VM
+xe vm-start uuid=$VM
+

--- a/test/test_cli.expected
+++ b/test/test_cli.expected
@@ -185,3 +185,26 @@ homepage: "dummy"
 bug-reports: "dummy"
 build: [ "mirage" "build" ]
 
+output_fat
+==========
+
+#!/bin/sh
+
+echo This uses the 'fat' command-line tool to build a simple FAT
+echo filesystem image.
+
+FAT=$(which fat)
+if [ ! -x "${FAT}" ]; then
+  echo I couldn\'t find the 'fat' command-line tool.
+  echo Try running 'opam install fat-filesystem'
+  exit 1
+fi
+
+IMG=$(pwd)/BLOCK_FILE
+rm -f ${IMG}
+cd ROOT/DIR
+SIZE=$(du -s . | cut -f 1)
+${FAT} create ${IMG} ${SIZE}KiB
+${FAT} add ${IMG} REGEXP
+echo Created 'BLOCK_FILE'
+

--- a/test/test_cli.expected
+++ b/test/test_cli.expected
@@ -208,3 +208,29 @@ ${FAT} create ${IMG} ${SIZE}KiB
 ${FAT} add ${IMG} REGEXP
 echo Created 'BLOCK_FILE'
 
+output_makefile
+===============
+
+# REDACTED
+
+-include Makefile.user
+
+OPAM = opam
+DEPEXT ?= opam depext --yes --update OPAM_NAME
+
+.PHONY: all depend depends clean build
+all:: build
+
+depend depends::
+	$(OPAM) pin add -k path --no-action --yes OPAM_NAME .
+	$(DEPEXT)
+	$(OPAM) install --yes --deps-only OPAM_NAME
+	$(OPAM) pin remove --no-action OPAM_NAME
+
+build::
+	mirage build
+
+clean::
+	mirage clean
+
+

--- a/test/test_cli.expected
+++ b/test/test_cli.expected
@@ -1,0 +1,18 @@
+output_main_xl
+==============
+
+# REDACTED
+
+name = 'NAME'
+kernel = 'KERNEL'
+builder = 'linux'
+memory = MEMORY
+on_crash = 'preserve'
+
+disk = [ 'format=raw, vdev=xvda, access=rw, target=BLOCK_PATH0', 'format=raw, vdev=xvdb, access=rw, target=BLOCK_PATH1', 'format=raw, vdev=xvdbi, access=rw, target=BLOCK_PATH60' ]
+
+# if your system uses openvswitch then either edit /etc/xen/xl.conf and set
+#     vif.default.script="vif-openvswitch"
+# or add "script=vif-openvswitch," before the "bridge=" below:
+vif = [ 'bridge=NETWORK1', 'bridge=NETWORK2' ]
+

--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -101,10 +101,22 @@ let test_output_opam () =
       )
     )
 
+let test_output_fat () =
+  print_banner "output_fat";
+  print_endline @@
+  with_fmt_str
+    (Mirage_cli.output_fat
+      ~block_file:"BLOCK_FILE"
+      ~root:(Fpath.v "ROOT")
+      ~dir:(Fpath.v "DIR")
+      ~regexp:"REGEXP"
+    )
+
 let () =
   test_output_main_xl ();
   test_output_main_xe ();
   test_output_main_libvirt_xml ();
   test_output_virtio_libvirt_xml ();
   test_output_opam ();
+  test_output_fat ();
   ()

--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -78,9 +78,33 @@ let test_output_virtio_libvirt_xml () =
        ~name:"NAME"
     )
 
+let test_output_opam () =
+  print_banner "output_opam";
+  print_endline @@
+  redact_line 1 @@
+  with_fmt_str
+    (Mirage_cli.output_opam
+      ~name:"NAME"
+      ~info:(
+        Functoria.Info.create
+          ~packages:
+            [ Functoria.package "pkg1"
+            ; Functoria.package "pkg2" ~build:true
+            ; Functoria.package "pkg3" ~min:"3"
+            ; Functoria.package "pkg4" ~max:"4"
+            ; Functoria.package "pkg5" ~min:"5.0" ~max:"5.1"
+            ]
+          ~keys:[]
+          ~context:Functoria_key.empty_context
+          ~name:"INFO_NAME"
+          ~build_dir:(Fpath.v "BUILD_DIR")
+      )
+    )
+
 let () =
   test_output_main_xl ();
   test_output_main_xe ();
   test_output_main_libvirt_xml ();
   test_output_virtio_libvirt_xml ();
+  test_output_opam ();
   ()

--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -68,8 +68,19 @@ let test_output_main_libvirt_xml () =
        ~name:"NAME"
     )
 
+let test_output_virtio_libvirt_xml () =
+  print_banner "output_virtio_libvirt_xml";
+  print_endline @@
+  redact_line 1 @@
+  with_fmt_str
+    (Mirage_cli.output_virtio_libvirt_xml
+       ~root:"ROOT"
+       ~name:"NAME"
+    )
+
 let () =
   test_output_main_xl ();
   test_output_main_xe ();
   test_output_main_libvirt_xml ();
+  test_output_virtio_libvirt_xml ();
   ()

--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -112,6 +112,15 @@ let test_output_fat () =
       ~regexp:"REGEXP"
     )
 
+let test_output_makefile () =
+  print_banner "output_makefile";
+  print_endline @@
+  redact_line 1 @@
+  with_fmt_str
+    (Mirage_cli.output_makefile
+      ~opam_name:"OPAM_NAME"
+    )
+
 let () =
   test_output_main_xl ();
   test_output_main_xe ();
@@ -119,4 +128,5 @@ let () =
   test_output_virtio_libvirt_xml ();
   test_output_opam ();
   test_output_fat ();
+  test_output_makefile ();
   ()

--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -5,7 +5,7 @@ let with_fmt_str k =
   Format.pp_print_flush fmt ();
   Buffer.contents buf
 
-let redact_first_line s =
+let redact_line n s =
   (* At the moment it is not possible to inject argv & time so we remove the
    * generated line.
    * See https://github.com/mirage/functoria/pull/159 *)
@@ -13,7 +13,7 @@ let redact_first_line s =
   let redacted_lines =
     List.mapi
       (fun i line ->
-        if i = 0 then
+        if i + 1 = n then
           "# REDACTED"
         else
           line
@@ -30,7 +30,7 @@ let print_banner s =
 let test_output_main_xl () =
   print_banner "output_main_xl";
   print_endline @@
-  redact_first_line @@
+  redact_line 1 @@
   with_fmt_str
     (Mirage_cli.output_main_xl
        ~name:"NAME"
@@ -44,5 +44,21 @@ let test_output_main_xl () =
        ~networks:["NETWORK1"; "NETWORK2"]
     )
 
+let test_output_main_xe () =
+  print_banner "output_main_xe";
+  print_endline @@
+  redact_line 2 @@
+  with_fmt_str
+    (Mirage_cli.output_main_xe
+       ~root:"ROOT"
+       ~name:"NAME"
+       ~blocks:
+         [ ("FILE1", 1)
+         ; ("FILE2", 2)
+         ]
+    )
+
 let () =
-  test_output_main_xl ()
+  test_output_main_xl ();
+  test_output_main_xe ();
+  ()

--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -1,0 +1,48 @@
+let with_fmt_str k =
+  let buf = Buffer.create 0 in
+  let fmt = Format.formatter_of_buffer buf in
+  k fmt;
+  Format.pp_print_flush fmt ();
+  Buffer.contents buf
+
+let redact_first_line s =
+  (* At the moment it is not possible to inject argv & time so we remove the
+   * generated line.
+   * See https://github.com/mirage/functoria/pull/159 *)
+  let lines = String.split_on_char '\n' s in
+  let redacted_lines =
+    List.mapi
+      (fun i line ->
+        if i = 0 then
+          "# REDACTED"
+        else
+          line
+      )
+      lines
+  in
+  String.concat "\n" redacted_lines
+
+let print_banner s =
+  print_endline s;
+  print_endline @@ String.make (String.length s) '=';
+  print_newline ()
+
+let test_output_main_xl () =
+  print_banner "output_main_xl";
+  print_endline @@
+  redact_first_line @@
+  with_fmt_str
+    (Mirage_cli.output_main_xl
+       ~name:"NAME"
+       ~kernel:"KERNEL"
+       ~memory:"MEMORY"
+       ~blocks:
+         [ (0, "BLOCK_PATH0")
+         ; (1, "BLOCK_PATH1")
+         ; (60, "BLOCK_PATH60")
+         ]
+       ~networks:["NETWORK1"; "NETWORK2"]
+    )
+
+let () =
+  test_output_main_xl ()

--- a/test/test_cli.ml
+++ b/test/test_cli.ml
@@ -58,7 +58,18 @@ let test_output_main_xe () =
          ]
     )
 
+let test_output_main_libvirt_xml () =
+  print_banner "output_main_libvirt_xml";
+  print_endline @@
+  redact_line 1 @@
+  with_fmt_str
+    (Mirage_cli.output_main_libvirt_xml
+       ~root:"ROOT"
+       ~name:"NAME"
+    )
+
 let () =
   test_output_main_xl ();
   test_output_main_xe ();
+  test_output_main_libvirt_xml ();
   ()


### PR DESCRIPTION
Hello!

While trying to understand how this package works, I noticed that the `Mirage` module does a lot of things. I'd like to make it a bit more modular, in particular to test some internals.

This PR adds some characterization tests - just a way to dump the existing behavior so that we know about how these work and we can touch them without fear of breaking things. When/if this becomes possible, they can be replaced by lower level tests.

I have some questions:
- Is a global `Mirage_cli` module OK, or should it be a bit more hidden (like `Mirage.Private_cli` or under `Mirage.Codegen`?)
- At the moment it only deals with generating files, so maybe `Mirage_codegen` is more appropriate?

Thanks!