### PR TITLE
revise stdlibrandom.initialize signature

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -183,7 +183,7 @@ let stdlib_random_conf = object
   method name = "random"
   method module_name = "Stdlibrandom"
   method! packages = Key.pure [ package "mirage-random" ]
-  method! connect _ modname _ = Fmt.strf "Lwt.return (%s.initialize ())" modname
+  method! connect _ modname _ = Fmt.strf "%s.initialize ()" modname
 end
 
 let stdlib_random = impl stdlib_random_conf


### PR DESCRIPTION
which now lives inside of Lwt.t, see https://github.com/mirage/mirage-random/pull/7