### PR TITLE
Split mirage.ml into private impl modules

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -23,21 +23,10 @@ module Key = Mirage_key
 module Name = Functoria_app.Name
 module Codegen = Functoria_app.Codegen
 
-let src = Logs.Src.create "mirage" ~doc:"mirage cli tool"
-module Log = (val Logs.src_log src : Logs.LOG)
+module Log = Mirage_impl_misc.Log
+open Mirage_impl_misc
 
 include Functoria
-
-let get_target i = Key.(get (Info.context i) target)
-
-let with_output ?mode f k err =
-  match Bos.OS.File.with_oc ?mode f k () with
-  | Ok b -> b
-  | Error _ -> R.error_msg ("couldn't open output channel for " ^ err)
-
-let connect_err name number =
-  Fmt.strf "The %s connect expects exactly %d argument%s"
-    name number (if number = 1 then "" else "s")
 
 (** {2 OCamlfind predicates} *)
 
@@ -48,1412 +37,158 @@ let backend_predicate = function
   | `Unix | `MacOSX         -> "mirage_unix"
 
 (** {2 Devices} *)
-let qrexec = job
 
-let qrexec_qubes = impl @@ object
-  inherit base_configurable
-  method ty = qrexec
-  val name = Name.ocamlify @@ "qrexec_"
-  method name = name
-  method module_name = "Qubes.RExec"
-  method! packages = Key.pure [ package ~min:"0.4" "mirage-qubes" ]
-  method! configure i =
-    match get_target i with
-    | `Qubes -> R.ok ()
-    | _ -> R.error_msg "Qubes remote-exec invoked for non-Qubes target."
-  method! connect _ modname _args =
-    Fmt.strf
-      "@[<v 2>\
-       %s.connect ~domid:0 () >>= fun qrexec ->@ \
-       Lwt.async (fun () ->@ \
-       OS.Lifecycle.await_shutdown_request () >>= fun _ ->@ \
-       %s.disconnect qrexec);@ \
-       Lwt.return (`Ok qrexec)@]"
-      modname modname
-end
-
-let gui = job
-
-let gui_qubes = impl @@ object
-  inherit base_configurable
-  method ty = gui
-  val name = Name.ocamlify @@ "gui"
-  method name = name
-  method module_name = "Qubes.GUI"
-  method! packages = Key.pure [ package ~min:"0.4" "mirage-qubes" ]
-  method! configure i =
-    match get_target i with
-    | `Qubes -> R.ok ()
-    | _ -> R.error_msg "Qubes GUI invoked for non-Qubes target."
-  method! connect _ modname _args =
-    Fmt.strf
-      "@[<v 2>\
-       %s.connect ~domid:0 () >>= fun gui ->@ \
-       Lwt.async (fun () -> %s.listen gui);@ \
-       Lwt.return (`Ok gui)@]"
-      modname modname
-end
-
-type qubesdb = QUBES_DB
-let qubesdb = Type QUBES_DB
-
-let qubesdb_conf = object
-  inherit base_configurable
-  method ty = qubesdb
-  method name = "qubesdb"
-  method module_name = "Qubes.DB"
-  method! packages = Key.pure [ package ~min:"0.4" "mirage-qubes" ]
-  method! configure i =
-    match get_target i with
-    | `Qubes | `Xen -> R.ok ()
-    | _ -> R.error_msg "Qubes DB invoked for an unsupported target; qubes and xen are supported"
-  method! connect _ modname _args = Fmt.strf "%s.connect ~domid:0 ()" modname
-end
-
-let default_qubesdb = impl qubesdb_conf
-
-type io_page = IO_PAGE
-let io_page = Type IO_PAGE
-
-let io_page_conf = object
-  inherit base_configurable
-  method ty = io_page
-  method name = "io_page"
-  method module_name = "Io_page"
-  method! packages =
-    Key.(if_ is_unix)
-      [ package ~sublibs:["unix"] "io-page" ]
-      [ package "io-page" ]
-end
-
-let default_io_page = impl io_page_conf
-
-type time = TIME
-let time = Type TIME
-
-let time_conf = object
-  inherit base_configurable
-  method ty = time
-  method name = "time"
-  method module_name = "OS.Time"
-end
-
-let default_time = impl time_conf
-
-type pclock = PCLOCK
-let pclock = Type PCLOCK
-
-let posix_clock_conf = object
-  inherit base_configurable
-  method ty = pclock
-  method name = "pclock"
-  method module_name = "Pclock"
-  method! packages =
-    Key.(if_ is_unix)
-      [ package ~min:"1.2.0" "mirage-clock-unix" ]
-      [ package ~min:"1.2.0" "mirage-clock-freestanding" ]
-  method! connect _ modname _args = Fmt.strf "%s.connect ()" modname
-end
-
-let default_posix_clock = impl posix_clock_conf
-
-type mclock = MCLOCK
-let mclock = Type MCLOCK
-
-let monotonic_clock_conf = object
-  inherit base_configurable
-  method ty = mclock
-  method name = "mclock"
-  method module_name = "Mclock"
-  method! packages =
-    Key.(if_ is_unix)
-      [ package ~min:"1.2.0" "mirage-clock-unix" ]
-      [ package ~min:"1.2.0" "mirage-clock-freestanding" ]
-  method! connect _ modname _args = Fmt.strf "%s.connect ()" modname
-end
-
-let default_monotonic_clock = impl monotonic_clock_conf
-
-type random = RANDOM
-let random = Type RANDOM
-
-let stdlib_random_conf = object
-  inherit base_configurable
-  method ty = random
-  method name = "random"
-  method module_name = "Stdlibrandom"
-  method! packages = Key.pure [ package "mirage-random" ]
-  method! connect _ modname _ = Fmt.strf "Lwt.return (%s.initialize ())" modname
-end
-
-let stdlib_random = impl stdlib_random_conf
-
-
-let query_ocamlfind ?(recursive = false) ?(format="%p") ?predicates libs =
-  let open Bos in
-  let flag = if recursive then (Cmd.v "-recursive") else Cmd.empty
-  and format = Cmd.of_list [ "-format" ; format ]
-  and predicate = match predicates with
-    | None -> []
-    | Some x -> [ "-predicates" ; x ]
-  and q = "query"
-  in
-  let cmd =
-    Cmd.(v "ocamlfind" % q %% flag %% format %% of_list predicate %% of_list libs)
-  in
-  OS.Cmd.run_out cmd |> OS.Cmd.out_lines >>| fst
-
-(* This is to check that entropy is a dependency if "tls" is in
-   the package array. *)
-let enable_entropy, is_entropy_enabled =
-  let r = ref false in
-  let f () = r := true in
-  let g () = !r in
-  (f, g)
-
-let check_entropy libs =
-  query_ocamlfind ~recursive:true libs >>= fun ps ->
-  if List.mem "nocrypto" ps && not (is_entropy_enabled ()) then
-    R.error_msg
-      {___|The \"nocrypto\" library is loaded but entropy is not enabled!@ \
-       Please enable the entropy by adding a dependency to the nocrypto \
-       device. You can do so by adding ~deps:[abstract nocrypto] \
-       to the arguments of Mirage.foreign.|___}
-  else
-    R.ok ()
-
-let nocrypto = impl @@ object
-    inherit base_configurable
-    method ty = job
-    method name = "nocrypto"
-    method module_name = "Nocrypto_entropy"
-    method! packages =
-      Key.match_ Key.(value target) @@ function
-      | `Xen | `Qubes ->
-        [ package ~min:"0.5.4" ~sublibs:["mirage"] "nocrypto";
-          package ~ocamlfind:[] "zarith-xen" ]
-      | `Virtio | `Hvt | `Muen ->
-        [ package ~min:"0.5.4" ~sublibs:["mirage"] "nocrypto";
-          package ~ocamlfind:[] "zarith-freestanding" ]
-      | `Unix | `MacOSX ->
-        [ package ~min:"0.5.4" ~sublibs:["lwt"] "nocrypto" ]
-
-    method! build _ = R.ok (enable_entropy ())
-    method! connect i _ _ =
-      match get_target i with
-      | `Xen | `Qubes | `Virtio | `Hvt | `Muen -> "Nocrypto_entropy_mirage.initialize ()"
-      | `Unix | `MacOSX -> "Nocrypto_entropy_lwt.initialize ()"
-  end
-
-let nocrypto_random_conf = object
-  inherit base_configurable
-  method ty = random
-  method name = "random"
-  method module_name = "Nocrypto.Rng"
-  method! packages = Key.pure [ package ~min:"0.5.4" "nocrypto" ]
-  method! deps = [abstract nocrypto]
-end
-
-let nocrypto_random = impl nocrypto_random_conf
-
-let default_random =
-  match_impl (Key.value @@ Key.prng ()) [
-    `Stdlib  , stdlib_random;
-    `Nocrypto, nocrypto_random;
-  ] ~default:stdlib_random
-
-type console = CONSOLE
-let console = Type CONSOLE
-
-let console_unix str = impl @@ object
-    inherit base_configurable
-    method ty = console
-    val name = Name.ocamlify @@ "console_unix_" ^ str
-    method name = name
-    method module_name = "Console_unix"
-    method! packages = Key.pure [ package ~min:"2.2.0" "mirage-console-unix" ]
-    method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
-  end
-
-let console_xen str = impl @@ object
-    inherit base_configurable
-    method ty = console
-    val name = Name.ocamlify @@ "console_xen_" ^ str
-    method name = name
-    method module_name = "Console_xen"
-    method! packages = Key.pure [ package ~min:"2.2.0" "mirage-console-xen" ]
-    method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
-  end
-
-let console_solo5 str = impl @@ object
-    inherit base_configurable
-    method ty = console
-    val name = Name.ocamlify @@ "console_solo5_" ^ str
-    method name = name
-    method module_name = "Console_solo5"
-    method! packages = Key.pure [ package ~min:"0.3.0" "mirage-console-solo5" ]
-    method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
-  end
-
-let custom_console str =
-  match_impl Key.(value target) [
-    `Xen, console_xen str;
-    `Qubes, console_xen str;
-    `Virtio, console_solo5 str;
-    `Hvt, console_solo5 str;
-    `Muen, console_solo5 str
-  ] ~default:(console_unix str)
-
-let default_console = custom_console "0"
-
-type kv_ro = KV_RO
-let kv_ro = Type KV_RO
-
-let crunch dirname = impl @@ object
-    inherit base_configurable
-    method ty = kv_ro
-    val name = Name.create ("static" ^ dirname) ~prefix:"static"
-    method name = name
-    method module_name = String.Ascii.capitalize name
-    method! packages =
-      Key.pure [ package "io-page"; package ~min:"2.0.0" ~build:true "crunch" ]
-    method! deps = [ abstract default_io_page ]
-    method! connect _ modname _ = Fmt.strf "%s.connect ()" modname
-    method! build _i =
-      let dir = Fpath.(v dirname) in
-      let file = Fpath.(v name + "ml") in
-      Bos.OS.Path.exists dir >>= function
-      | true ->
-        Log.info (fun m -> m "Generating: %a" Fpath.pp file);
-        Bos.OS.Cmd.run Bos.Cmd.(v "ocaml-crunch" % "-o" % p file % p dir)
-      | false ->
-        R.error_msg (Fmt.strf "The directory %s does not exist." dirname)
-    method! clean _i =
-      Bos.OS.File.delete Fpath.(v name + "ml") >>= fun () ->
-      Bos.OS.File.delete Fpath.(v name + "mli")
-  end
-
-let direct_kv_ro_conf dirname = impl @@ object
-    inherit base_configurable
-    method ty = kv_ro
-    val name = Name.create ("direct" ^ dirname) ~prefix:"direct"
-    method name = name
-    method module_name = "Kvro_fs_unix"
-    method! packages = Key.pure [ package ~min:"1.3.0" "mirage-fs-unix" ]
-    method! connect i _modname _names =
-      let path = Fpath.(Info.build_dir i / dirname) in
-      Fmt.strf "Kvro_fs_unix.connect \"%a\"" Fpath.pp path
-  end
-
-let direct_kv_ro dirname =
-  match_impl Key.(value target) [
-    `Xen, crunch dirname;
-    `Qubes, crunch dirname;
-    `Virtio, crunch dirname;
-    `Hvt, crunch dirname;
-    `Muen, crunch dirname
-  ] ~default:(direct_kv_ro_conf dirname)
-
-type block = BLOCK
-let block = Type BLOCK
-type block_t = { filename: string; number: int }
-let all_blocks = Hashtbl.create 7
-
-let make_block_t =
-  (* NB: reserve number 0 for the boot disk *)
-  let next_number = ref 1 in
-  fun filename ->
-    let b =
-      if Hashtbl.mem all_blocks filename then
-        Hashtbl.find all_blocks filename
-      else begin
-        let number = !next_number in
-        incr next_number;
-        let b = { filename; number } in
-        Hashtbl.add all_blocks filename b;
-        b
-      end in
-    b
-
-let xen_block_packages =
-  [ package ~min:"1.5.0" ~sublibs:["front"] "mirage-block-xen" ]
-
-(* this class takes a string rather than an int as `id` to allow the user to
-   pass stuff like "/dev/xvdi1", which mirage-block-xen also understands *)
-class xenstore_conf id =
-  let name = Name.create id ~prefix:"block" in
-  object
-    inherit base_configurable
-    method ty = block
-    method name = name
-    method module_name = "Block"
-    method! packages = Key.pure xen_block_packages
-    method! configure i =
-      match get_target i with
-      | `Qubes | `Xen -> R.ok ()
-      | _ -> R.error_msg "XenStore IDs are only valid ways of specifying block \
-                          devices when the target is Xen or Qubes."
-    method! connect _ s _ =
-      Fmt.strf "%s.connect %S" s id
-  end
-
-let block_of_xenstore_id id = impl (new xenstore_conf id)
-
-(* calculate the XenStore ID for the nth available block device.
-   Taken from https://github.com/mirage/mirage-block-xen/blob/
-   a64d152586c7ebc1d23c5adaa4ddd440b45a3a83/lib/device_number.ml#L64 . *)
-let xenstore_id_of_index number =
-        (if number < 16
-         then (202 lsl 8) lor (number lsl 4)
-         else (1 lsl 28)  lor (number lsl 8))
-
-class block_conf file =
-  let name = Name.create file ~prefix:"block" in
-  object (self)
-    inherit base_configurable
-    method ty = block
-    method name = name
-    method module_name = "Block"
-    method! packages =
-      Key.match_ Key.(value target) @@ function
-      | `Xen | `Qubes -> xen_block_packages
-      | `Virtio | `Hvt | `Muen -> [ package ~min:"0.3.0" "mirage-block-solo5" ]
-      | `Unix | `MacOSX -> [ package ~min:"2.5.0" "mirage-block-unix" ]
-
-    method! configure _ =
-      let _block = make_block_t file in
-      R.ok ()
-
-    method private connect_name target root =
-      match target with
-      | `Unix | `MacOSX | `Virtio | `Hvt | `Muen ->
-        Fpath.(to_string (root / file)) (* open the file directly *)
-      | `Xen | `Qubes ->
-        let b = make_block_t file in
-        xenstore_id_of_index b.number |> string_of_int
-
-    method! connect i s _ =
-      match get_target i with
-      | `Muen -> failwith "Block devices not supported on Muen target."
-      | `Unix | `MacOSX | `Virtio | `Hvt | `Xen | `Qubes ->
-        Fmt.strf "%s.connect %S" s
-          (self#connect_name (get_target i) @@ Info.build_dir i)
-  end
-
-let block_of_file file = impl (new block_conf file)
-
-class ramdisk_conf rname =
-  object
-    inherit base_configurable
-    method ty = block
-    method name = "ramdisk"
-    method module_name = "Ramdisk"
-    method! packages =
-      Key.pure [ package "mirage-block-ramdisk" ]
-
-    method! connect _i modname _names =
-      Fmt.strf "%s.connect ~name:%S" modname rname
-  end
-
-
-let ramdisk rname = impl (new ramdisk_conf rname)
-
-let generic_block ?group ?(key = Key.value @@ Key.block ?group ()) name =
-  match_impl key [
-    `XenstoreId, block_of_xenstore_id name;
-    `BlockFile, block_of_file name;
-    `Ramdisk, ramdisk name;
-  ] ~default:(ramdisk name)
-
-let tar_block dir =
-  let name = Name.create ("tar_block" ^ dir) ~prefix:"tar_block" in
-  let block_file = name ^ ".img" in
-  impl @@ object
-    inherit block_conf block_file as super
-    method! build i =
-      Bos.OS.Cmd.run Bos.Cmd.(v "tar" % "-cvf" % block_file % dir) >>= fun () ->
-      super#build i
-  end
-
-let archive_conf = impl @@ object
-    inherit base_configurable
-    method ty = block @-> kv_ro
-    method name = "archive"
-    method module_name = "Tar_mirage.Make_KV_RO"
-    method! packages =
-      Key.pure [ package ~min:"0.8.0" "tar-mirage" ]
-    method! connect _ modname = function
-      | [ block ] -> Fmt.strf "%s.connect %s" modname block
-      | _ -> failwith (connect_err "archive" 1)
-  end
-
-let archive block = archive_conf $ block
-let archive_of_files ?(dir=".") () = archive @@ tar_block dir
-
-type fs = FS
-let fs = Type FS
-
-let fat_conf = impl @@ object
-    inherit base_configurable
-    method ty = (block @-> fs)
-    method! packages = Key.pure [ package ~min:"0.12.0" "fat-filesystem" ]
-    method name = "fat"
-    method module_name = "Fat.FS"
-    method! connect _ modname l = match l with
-      | [ block_name ] -> Fmt.strf "%s.connect %s" modname block_name
-      | _ -> failwith (connect_err "fat" 1)
-  end
-
-let fat block = fat_conf $ block
-
-let fat_block ?(dir=".") ?(regexp="*") () =
-  let name =
-    Name.(ocamlify @@ create (Fmt.strf "fat%s:%s" dir regexp) ~prefix:"fat_block")
-  in
-  let block_file = name ^ ".img" in
-  impl @@ object
-    inherit block_conf block_file as super
-    method! packages =
-      Key.map (List.cons (package ~min:"0.12.0" ~build:true "fat-filesystem")) super#packages
-    method! build i =
-      let root = Info.build_dir i in
-      let file = Fmt.strf "make-%s-image.sh" name in
-      let dir = Fpath.of_string dir |> R.error_msg_to_invalid_arg in
-      Log.info (fun m -> m "Generating block generator script: %s" file);
-      with_output ~mode:0o755 (Fpath.v file)
-        (fun oc () ->
-           let fmt = Format.formatter_of_out_channel oc in
-           Codegen.append fmt "#!/bin/sh";
-           Codegen.append fmt "";
-           Codegen.append fmt "echo This uses the 'fat' command-line tool to \
-                               build a simple FAT";
-           Codegen.append fmt "echo filesystem image.";
-           Codegen.append fmt "";
-           Codegen.append fmt "FAT=$(which fat)";
-           Codegen.append fmt "if [ ! -x \"${FAT}\" ]; then";
-           Codegen.append fmt "  echo I couldn\\'t find the 'fat' command-line \
-                               tool.";
-           Codegen.append fmt "  echo Try running 'opam install fat-filesystem'";
-           Codegen.append fmt "  exit 1";
-           Codegen.append fmt "fi";
-           Codegen.append fmt "";
-           Codegen.append fmt "IMG=$(pwd)/%s" block_file;
-           Codegen.append fmt "rm -f ${IMG}";
-           Codegen.append fmt "cd %a" Fpath.pp (Fpath.append root dir);
-           Codegen.append fmt "SIZE=$(du -s . | cut -f 1)";
-           Codegen.append fmt "${FAT} create ${IMG} ${SIZE}KiB";
-           Codegen.append fmt "${FAT} add ${IMG} %s" regexp;
-           Codegen.append fmt "echo Created '%s'" block_file;
-           R.ok ())
-        "fat shell script" >>= fun () ->
-      Log.info (fun m -> m "Executing block generator script: ./%s" file);
-      Bos.OS.Cmd.run (Bos.Cmd.v ("./" ^ file)) >>= fun () ->
-      super#build i
-
-    method! clean i =
-      let file = Fmt.strf "make-%s-image.sh" name in
-      Bos.OS.File.delete (Fpath.v file) >>= fun () ->
-      Bos.OS.File.delete (Fpath.v block_file) >>= fun () ->
-      super#clean i
-  end
-
-let fat_of_files ?dir ?regexp () = fat @@ fat_block ?dir ?regexp ()
-
-
-let kv_ro_of_fs_conf = impl @@ object
-    inherit base_configurable
-    method ty = fs @-> kv_ro
-    method name = "kv_ro_of_fs"
-    method module_name = "Mirage_fs_lwt.To_KV_RO"
-    method! packages = Key.pure [ package "mirage-fs-lwt" ]
-    method! connect _ modname = function
-      | [ fs ] -> Fmt.strf "%s.connect %s" modname fs
-      | _ -> failwith (connect_err "kv_ro_of_fs" 1)
-  end
-
-let kv_ro_of_fs x = kv_ro_of_fs_conf $ x
-
-(** generic kv_ro. *)
-
-let generic_kv_ro ?group ?(key = Key.value @@ Key.kv_ro ?group ()) dir =
-  match_impl key [
-    `Fat    , kv_ro_of_fs @@ fat_of_files ~dir () ;
-    `Archive, archive_of_files ~dir () ;
-    `Crunch , crunch dir ;
-    `Direct , direct_kv_ro dir ;
-  ] ~default:(direct_kv_ro dir)
-
-(** network devices *)
-
-type network = NETWORK
-let network = Type NETWORK
-
-let all_networks = ref []
-
-let network_conf (intf : string Key.key) =
-  let key = Key.abstract intf in
-  object
-    inherit base_configurable
-    method ty = network
-    val name = Functoria_app.Name.create "net" ~prefix:"net"
-    method name = name
-    method module_name = "Netif"
-    method! keys = [ key ]
-    method! packages =
-      Key.match_ Key.(value target) @@ function
-      | `Unix -> [ package ~min:"2.3.0" "mirage-net-unix" ]
-      | `MacOSX -> [ package ~min:"1.3.0" "mirage-net-macosx" ]
-      | `Xen -> [ package ~min:"1.7.0" "mirage-net-xen"]
-      | `Qubes -> [ package ~min:"1.7.0" "mirage-net-xen" ; package ~min:"0.4" "mirage-qubes" ]
-      | `Virtio | `Hvt | `Muen -> [ package ~min:"0.3.0" "mirage-net-solo5" ]
-    method! connect _ modname _ =
-      Fmt.strf "%s.connect %a" modname Key.serialize_call key
-    method! configure i =
-      all_networks := Key.get (Info.context i) intf :: !all_networks;
-      R.ok ()
-  end
-
-let netif ?group dev = impl (network_conf @@ Key.interface ?group dev)
-let default_network =
-  match_impl Key.(value target) [
-    `Unix   , netif "tap0";
-    `MacOSX , netif "tap0";
-  ] ~default:(netif "0")
-
-type dhcp = Dhcp_client
-let dhcp = Type Dhcp_client
-
-type ethernet = ETHERNET
-let ethernet = Type ETHERNET
-
-let ethernet_conf = object
-  inherit base_configurable
-  method ty = network @-> ethernet
-  method name = "ethif"
-  method module_name = "Ethif.Make"
-  method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["ethif"] "tcpip" ]
-  method! connect _ modname = function
-    | [ eth ] -> Fmt.strf "%s.connect %s" modname eth
-    | _ -> failwith (connect_err "ethernet" 1)
-end
-
-let etif_func = impl ethernet_conf
-let etif network = etif_func $ network
-
-type arpv4 = Arpv4
-let arpv4 = Type Arpv4
-
-let arpv4_conf = object
-  inherit base_configurable
-  method ty = ethernet @-> mclock @-> time @-> arpv4
-  method name = "arpv4"
-  method module_name = "Arpv4.Make"
-  method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["arpv4"] "tcpip" ]
-  method! connect _ modname = function
-    | [ eth ; clock ; _time ] -> Fmt.strf "%s.connect %s %s" modname eth clock
-    | _ -> failwith (connect_err "arpv4" 3)
-end
-
-let arp_func = impl arpv4_conf
-let arp
-    ?(clock = default_monotonic_clock)
-    ?(time = default_time)
-    (eth : ethernet impl) =
-  arp_func $ eth $ clock $ time
-
-
-let farp_conf = object
-  inherit base_configurable
-  method ty = ethernet @-> mclock @-> time @-> arpv4
-  method name = "arp"
-  method module_name = "Arp.Make"
-  method! packages = Key.pure [ package ~min:"0.2.0" ~sublibs:["mirage"] "arp" ]
-  method! connect _ modname = function
-    | [ eth ; clock ; _time ] -> Fmt.strf "%s.connect %s %s" modname eth clock
-    | _ -> failwith (connect_err "arp" 3)
-end
-
-let farp_func = impl farp_conf
-let farp
-    ?(clock = default_monotonic_clock)
-    ?(time = default_time)
-    (eth : ethernet impl) =
-  farp_func $ eth $ clock $ time
-
-
-type v4
-type v6
-type 'a ip = IP
-type ipv4 = v4 ip
-type ipv6 = v6 ip
-
-let ip = Type IP
-let ipv4: ipv4 typ = ip
-let ipv6: ipv6 typ = ip
-
-let meta_ipv4 ppf s =
-  Fmt.pf ppf "(Ipaddr.V4.of_string_exn %S)" (Ipaddr.V4.to_string s)
-
-type ipv4_config = {
+type qubesdb = Mirage_impl_qubesdb.qubesdb
+let qubesdb = Mirage_impl_qubesdb.qubesdb
+let default_qubesdb = Mirage_impl_qubesdb.default_qubesdb
+
+type io_page = Mirage_impl_io_page.io_page
+let io_page = Mirage_impl_io_page.io_page
+let default_io_page = Mirage_impl_io_page.default_io_page
+
+type time = Mirage_impl_time.time
+let time = Mirage_impl_time.time
+let default_time = Mirage_impl_time.default_time
+
+type pclock = Mirage_impl_pclock.pclock
+let pclock = Mirage_impl_pclock.pclock
+let default_posix_clock = Mirage_impl_pclock.default_posix_clock
+
+type mclock = Mirage_impl_mclock.mclock
+let mclock = Mirage_impl_mclock.mclock
+let default_monotonic_clock = Mirage_impl_mclock.default_monotonic_clock
+
+type random = Mirage_impl_random.random
+let random = Mirage_impl_random.random
+let stdlib_random = Mirage_impl_random.stdlib_random
+let default_random = Mirage_impl_random.default_random
+let nocrypto = Mirage_impl_random.nocrypto
+let nocrypto_random = Mirage_impl_random.nocrypto_random
+
+type console = Mirage_impl_console.console
+let console = Mirage_impl_console.console
+let default_console = Mirage_impl_console.default_console
+let custom_console = Mirage_impl_console.custom_console
+
+type kv_ro = Mirage_impl_kv_ro.kv_ro
+let kv_ro = Mirage_impl_kv_ro.kv_ro
+let direct_kv_ro = Mirage_impl_kv_ro.direct_kv_ro
+let crunch = Mirage_impl_kv_ro.crunch
+
+type block = Mirage_impl_block.block
+let block = Mirage_impl_block.block
+let archive_of_files = Mirage_impl_block.archive_of_files
+let archive = Mirage_impl_block.archive
+let generic_block = Mirage_impl_block.generic_block
+let ramdisk = Mirage_impl_block.ramdisk
+let block_of_xenstore_id = Mirage_impl_block.block_of_xenstore_id
+let block_of_file = Mirage_impl_block.block_of_file
+
+type fs = Mirage_impl_fs.fs
+let fs = Mirage_impl_fs.fs
+let fat = Mirage_impl_fs.fat
+let fat_of_files = Mirage_impl_fs.fat_of_files
+let generic_kv_ro = Mirage_impl_fs.generic_kv_ro
+let kv_ro_of_fs = Mirage_impl_fs.kv_ro_of_fs
+
+type network = Mirage_impl_network.network
+let network = Mirage_impl_network.network
+let netif = Mirage_impl_network.netif
+let default_network = Mirage_impl_network.default_network
+
+type ethernet = Mirage_impl_ethernet.ethernet
+let ethernet = Mirage_impl_ethernet.ethernet
+let etif = Mirage_impl_ethernet.etif
+
+type arpv4 = Mirage_impl_arpv4.arpv4
+let arpv4 = Mirage_impl_arpv4.arpv4
+let arp = Mirage_impl_arpv4.arp
+let farp = Mirage_impl_arpv4.farp
+
+type v4 = Mirage_impl_ip.v4
+type v6 = Mirage_impl_ip.v6
+type 'a ip = 'a Mirage_impl_ip.ip
+type ipv4 = Mirage_impl_ip.ipv4
+type ipv6 = Mirage_impl_ip.ipv6
+let ipv4 = Mirage_impl_ip.ipv4
+let ipv6 = Mirage_impl_ip.ipv6
+let ipv4_qubes = Mirage_impl_ip.ipv4_qubes
+let create_ipv4 = Mirage_impl_ip.create_ipv4
+let create_ipv6 = Mirage_impl_ip.create_ipv6
+type ipv4_config = Mirage_impl_ip.ipv4_config = {
   network : Ipaddr.V4.Prefix.t * Ipaddr.V4.t;
   gateway : Ipaddr.V4.t option;
 }
-(** Types for IPv4 manual configuration. *)
-
-
-let pp_key fmt k = Key.serialize_call fmt (Key.abstract k)
-let opt_key s = Fmt.(option @@ prefix (unit ("~"^^s^^":")) pp_key)
-let opt_map f = function Some x -> Some (f x) | None -> None
-let (@?) x l = match x with Some s -> s :: l | None -> l
-let (@??) x y = opt_map Key.abstract x @? y
-
-(* convenience function for linking tcpip.unix or .xen for checksums *)
-let right_tcpip_library ?min ?max ?ocamlfind ~sublibs pkg =
-  Key.match_ Key.(value target) @@ function
-  |`MacOSX | `Unix         -> [ package ?min ?max ?ocamlfind ~sublibs:("unix"::sublibs) pkg ]
-  |`Qubes  | `Xen          -> [ package ?min ?max ?ocamlfind ~sublibs:("xen"::sublibs) pkg ]
-  |`Virtio | `Hvt | `Muen  -> [ package ?min ?max ?ocamlfind ~sublibs pkg ]
-
-let ipv4_keyed_conf ?network ?gateway () = impl @@ object
-    inherit base_configurable
-    method ty = random @-> mclock @-> ethernet @-> arpv4 @-> ipv4
-    method name = Name.create "ipv4" ~prefix:"ipv4"
-    method module_name = "Static_ipv4.Make"
-    method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["ipv4"] "tcpip"
-    method! keys = network @?? gateway @?? []
-    method! connect _ modname = function
-    | [ _random ; mclock ; etif ; arp ] ->
-      Fmt.strf
-        "let (network, ip) = %a in @ \
-         %s.connect@[@ ~ip ~network %a@ %s@ %s@ %s@]"
-        (Fmt.option pp_key) network
-        modname
-        (opt_key "gateway") gateway
-        mclock etif arp
-      | _ -> failwith (connect_err "ipv4 keyed" 4)
-  end
-
-let dhcp_conf = impl @@ object
-    inherit base_configurable
-    method ty = time @-> network @-> dhcp
-    method name = "dhcp_client"
-    method module_name = "Dhcp_client_mirage.Make"
-    method! packages = Key.pure [ package ~min:"0.10" "charrua-client-mirage" ]
-    method! connect _ modname = function
-      | [ _time; network ] -> Fmt.strf "%s.connect %s " modname network
-      | _ -> failwith (connect_err "dhcp" 2)
-  end
-
-let ipv4_dhcp_conf = impl @@ object
-    inherit base_configurable
-    method ty = dhcp @-> random @-> mclock @-> ethernet @-> arpv4 @-> ipv4
-    method name = Name.create "dhcp_ipv4" ~prefix:"dhcp_ipv4"
-    method module_name = "Dhcp_ipv4.Make"
-    method! packages = Key.pure [ package "charrua-client-mirage" ]
-    method! connect _ modname = function
-      | [ dhcp ; _random ; mclock ; ethernet ; arp ] ->
-        Fmt.strf "%s.connect@[@ %s@ %s@ %s@ %s@]"
-          modname dhcp mclock ethernet arp
-      | _ -> failwith (connect_err "ipv4 dhcp" 5)
-  end
-
-
-let dhcp time net = dhcp_conf $ time $ net
-let ipv4_of_dhcp
-    ?(random = default_random)
-    ?(clock = default_monotonic_clock) dhcp ethif arp =
-  ipv4_dhcp_conf $ dhcp $ random $ clock $ ethif $ arp
-
-let create_ipv4 ?group ?config
-    ?(random = default_random) ?(clock = default_monotonic_clock) etif arp =
-  let config = match config with
-  | None ->
-    let network = Ipaddr.V4.Prefix.of_address_string_exn "10.0.0.2/24"
-    and gateway = Some (Ipaddr.V4.of_string_exn "10.0.0.1")
-    in
-    { network; gateway }
-  | Some config -> config
-  in
-  let network = Key.V4.network ?group config.network
-  and gateway = Key.V4.gateway ?group config.gateway
-  in
-  ipv4_keyed_conf ~network ~gateway () $ random $ clock $ etif $ arp
-
-type ipv6_config = {
-  addresses: Ipaddr.V6.t list;
-  netmasks: Ipaddr.V6.Prefix.t list;
-  gateways: Ipaddr.V6.t list;
-}
-(** Types for IP manual configuration. *)
-
-let ipv4_qubes_conf = impl @@ object
-    inherit base_configurable
-    method ty = qubesdb @-> random @-> mclock @-> ethernet @-> arpv4 @-> ipv4
-    method name = Name.create "qubes_ipv4" ~prefix:"qubes_ipv4"
-    method module_name = "Qubesdb_ipv4.Make"
-    method! packages = Key.pure [ package ~min:"0.6" "mirage-qubes-ipv4" ]
-    method! connect _ modname = function
-      | [  db ; _random ; mclock ;etif; arp ] ->
-        Fmt.strf "%s.connect@[@ %s@ %s@ %s@ %s@]" modname db mclock etif arp
-      | _ -> failwith (connect_err "qubes ipv4" 5)
-  end
-
-let ipv4_qubes
-    ?(random = default_random)
-    ?(clock = default_monotonic_clock) db ethernet arp =
-  ipv4_qubes_conf $ db $ random $ clock $ ethernet $ arp
-
-let ipv6_conf ?addresses ?netmasks ?gateways () = impl @@ object
-    inherit base_configurable
-    method ty = ethernet @-> random @-> time @-> mclock @-> ipv6
-    method name = Name.create "ipv6" ~prefix:"ipv6"
-    method module_name = "Ipv6.Make"
-    method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["ipv6"] "tcpip"
-    method! keys = addresses @?? netmasks @?? gateways @?? []
-    method! connect _ modname = function
-      | [ etif ; _random ; _time ; clock ] ->
-        Fmt.strf "%s.connect@[@ %a@ %a@ %a@ %s@ %s@]"
-          modname
-          (opt_key "ip") addresses
-          (opt_key "netmask") netmasks
-          (opt_key "gateways") gateways
-          etif clock
-      | _ -> failwith (connect_err "ipv6" 3)
-  end
-
-let create_ipv6
-    ?(random = default_random)
-    ?(time = default_time)
-    ?(clock = default_monotonic_clock)
-    ?group etif { addresses ; netmasks ; gateways } =
-  let addresses = Key.V6.ips ?group addresses in
-  let netmasks = Key.V6.netmasks ?group netmasks in
-  let gateways = Key.V6.gateways ?group gateways in
-  ipv6_conf ~addresses ~netmasks ~gateways () $ etif $ random $ time $ clock
-
-type 'a icmp = ICMP
-type icmpv4 = v4 icmp
-
-let icmp = Type ICMP
-let icmpv4: icmpv4 typ = icmp
-
-let icmpv4_direct_conf () = object
-  inherit base_configurable
-  method ty : ('a ip -> 'a icmp) typ = ip @-> icmp
-  method name = "icmpv4"
-  method module_name = "Icmpv4.Make"
-  method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["icmpv4"] "tcpip"
-  method! connect _ modname = function
-    | [ ip ] -> Fmt.strf "%s.connect %s" modname ip
-    | _  -> failwith (connect_err "icmpv4" 1)
-end
-
-let icmpv4_direct_func () = impl (icmpv4_direct_conf ())
-let direct_icmpv4 ip = icmpv4_direct_func () $ ip
-
-type 'a udp = UDP
-type udpv4 = v4 udp
-type udpv6 = v6 udp
-
-let udp = Type UDP
-let udpv4: udpv4 typ = udp
-let udpv6: udpv6 typ = udp
-
-(* Value restriction ... *)
-let udp_direct_conf () = object
-  inherit base_configurable
-  method ty = (ip: 'a ip typ) @-> random @-> (udp: 'a udp typ)
-  method name = "udp"
-  method module_name = "Udp.Make"
-  method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["udp"] "tcpip"
-  method! connect _ modname = function
-    | [ ip; _random ] -> Fmt.strf "%s.connect %s" modname ip
-    | _  -> failwith (connect_err "udp" 2)
-end
-
-(* Value restriction ... *)
-let udp_direct_func () = impl (udp_direct_conf ())
-let direct_udp ?(random=default_random) ip = udp_direct_func () $ ip $ random
-
-let udpv4_socket_conf ipv4_key = object
-  inherit base_configurable
-  method ty = udpv4
-  val name = Name.create "udpv4_socket" ~prefix:"udpv4_socket"
-  method name = name
-  method module_name = "Udpv4_socket"
-  method! keys = [ Key.abstract ipv4_key ]
-  method! packages =
-    Key.(if_ is_unix)
-      [ package ~min:"3.5.0" ~sublibs:["udpv4-socket"; "unix"] "tcpip" ]
-      []
-  method! configure i =
-    match get_target i with
-    | `Unix | `MacOSX -> R.ok ()
-    | _ -> R.error_msg "UDPv4 socket not supported on non-UNIX targets."
-  method! connect _ modname _ = Fmt.strf "%s.connect %a" modname pp_key ipv4_key
-end
-
-let socket_udpv4 ?group ip = impl (udpv4_socket_conf @@ Key.V4.socket ?group ip)
-
-type 'a tcp = TCP
-type tcpv4 = v4 tcp
-type tcpv6 = v6 tcp
-
-let tcp = Type TCP
-let tcpv4 : tcpv4 typ = tcp
-let tcpv6 : tcpv6 typ = tcp
-
-(* Value restriction ... *)
-let tcp_direct_conf () = object
-  inherit base_configurable
-  method ty = (ip: 'a ip typ) @-> time @-> mclock @-> random @-> (tcp: 'a tcp typ)
-  method name = "tcp"
-  method module_name = "Tcp.Flow.Make"
-  method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["tcp"] "tcpip"
-  method! connect _ modname = function
-    | [ip; _time; clock; _random] -> Fmt.strf "%s.connect %s %s" modname ip clock
-    | _ -> failwith (connect_err "direct tcp" 4)
-end
-
-(* Value restriction ... *)
-let tcp_direct_func () = impl (tcp_direct_conf ())
-
-let direct_tcp
-    ?(clock=default_monotonic_clock)
-    ?(random=default_random)
-    ?(time=default_time) ip =
-  tcp_direct_func () $ ip $ time $ clock $ random
-
-let tcpv4_socket_conf ipv4_key = object
-  inherit base_configurable
-  method ty = tcpv4
-  val name = Name.create "tcpv4_socket" ~prefix:"tcpv4_socket"
-  method name = name
-  method module_name = "Tcpv4_socket"
-  method! keys = [ Key.abstract ipv4_key ]
-  method! packages =
-    Key.(if_ is_unix) [ package ~min:"3.5.0" ~sublibs:["tcpv4-socket"; "unix"] "tcpip" ] []
-  method! configure i =
-    match get_target i with
-    | `Unix | `MacOSX -> R.ok ()
-    | _  -> R.error_msg "TCPv4 socket not supported on non-UNIX targets."
-  method! connect _ modname _ = Fmt.strf "%s.connect %a" modname pp_key ipv4_key
-end
-
-let socket_tcpv4 ?group ip = impl (tcpv4_socket_conf @@ Key.V4.socket ?group ip)
-
-type stackv4 = STACKV4
-let stackv4 = Type STACKV4
-
-let add_suffix s ~suffix = if suffix = "" then s else s^"_"^suffix
-
-let stackv4_direct_conf ?(group="") () = impl @@ object
-    inherit base_configurable
-    method ty =
-      time @-> random @-> network @->
-      ethernet @-> arpv4 @-> ipv4 @-> icmpv4 @-> udpv4 @-> tcpv4 @->
-      stackv4
-    val name = add_suffix "stackv4_" ~suffix:group
-    method name = name
-    method module_name = "Tcpip_stack_direct.Make"
-    method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["stack-direct"] "tcpip" ]
-    method! connect _i modname = function
-      | [ _t; _r; interface; ethif; arp; ip; icmp; udp; tcp ] ->
-        Fmt.strf
-          "%s.connect %s %s %s %s %s %s %s"
-          modname interface ethif arp ip icmp udp tcp
-      | _ -> failwith (connect_err "direct stackv4" 9)
-  end
-
-let direct_stackv4
-    ?(clock=default_monotonic_clock)
-    ?(random=default_random)
-    ?(time=default_time)
-    ?group
-    network eth arp ip =
-  stackv4_direct_conf ?group ()
-  $ time $ random $ network
-  $ eth $ arp $ ip
-  $ direct_icmpv4 ip
-  $ direct_udp ~random ip
-  $ direct_tcp ~clock ~random ~time ip
-
-let dhcp_ipv4_stack ?group ?(time = default_time) ?(arp = arp ?clock:None ?time:None) tap =
-  let config = dhcp time tap in
-  let e = etif tap in
-  let a = arp e in
-  let i = ipv4_of_dhcp config e a in
-  direct_stackv4 ?group tap e a i
-
-let static_ipv4_stack ?group ?config ?(arp = arp ?clock:None ?time:None) tap =
-  let e = etif tap in
-  let a = arp e in
-  let i = create_ipv4 ?group ?config e a in
-  direct_stackv4 ?group tap e a i
-
-let qubes_ipv4_stack ?group ?(qubesdb = default_qubesdb) ?(arp = arp ?clock:None ?time:None) tap =
-  let e = etif tap in
-  let a = arp e in
-  let i = ipv4_qubes qubesdb e a in
-  direct_stackv4 ?group tap e a i
-
-let stackv4_socket_conf ?(group="") ips = impl @@ object
-    inherit base_configurable
-    method ty = stackv4
-    val name = add_suffix "stackv4_socket" ~suffix:group
-    method name = name
-    method module_name = "Tcpip_stack_socket"
-    method! keys = [ Key.abstract ips ]
-    method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["stack-socket"; "unix"] "tcpip" ]
-    method! deps = [abstract (socket_udpv4 None); abstract (socket_tcpv4 None)]
-    method! connect _i modname = function
-      | [ udpv4 ; tcpv4 ] ->
-        Fmt.strf
-          "%s.connect %a %s %s"
-          modname pp_key ips udpv4 tcpv4
-      | _ -> failwith (connect_err "socket stack" 2)
-  end
-
-let socket_stackv4 ?group ipv4s =
-  stackv4_socket_conf ?group (Key.V4.ips ?group ipv4s)
-
-(** Generic stack *)
-
-let generic_stackv4
-    ?group ?config
-    ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
-    ?(net_key = Key.value @@ Key.net ?group ())
-    (tap : network impl) : stackv4 impl =
-  let eq a b = Key.(pure ((=) a) $ b) in
-  let choose qubes socket dhcp =
-    if qubes then `Qubes
-    else if socket then `Socket
-    else if dhcp then `Dhcp
-    else `Static
-  in
-  let p = Functoria_key.((pure choose)
-          $ eq `Qubes Key.(value target)
-          $ eq `Socket net_key
-          $ eq true dhcp_key) in
-  match_impl p [
-    `Dhcp, dhcp_ipv4_stack ?group tap;
-    `Socket, socket_stackv4 ?group [Ipaddr.V4.any];
-    `Qubes, qubes_ipv4_stack ?group tap;
-  ] ~default:(static_ipv4_stack ?config ?group tap)
-
-type conduit_connector = Conduit_connector
-let conduit_connector = Type Conduit_connector
-
-let tcp_conduit_connector = impl @@ object
-    inherit base_configurable
-    method ty = stackv4 @-> conduit_connector
-    method name = "tcp_conduit_connector"
-    method module_name = "Conduit_mirage.With_tcp"
-    method! packages =
-      Key.pure [
-        package ~min:"3.0.1" "mirage-conduit";
-      ]
-    method! connect _ modname = function
-      | [ stack ] -> Fmt.strf "Lwt.return (%s.connect %s)@;" modname stack
-      | _ -> failwith (connect_err "tcp conduit" 1)
-  end
-
-let tls_conduit_connector = impl @@ object
-    inherit base_configurable
-    method ty = conduit_connector
-    method name = "tls_conduit_connector"
-    method module_name = "Conduit_mirage"
-    method! packages =
-      Key.pure [
-        package ~min:"0.8.0" ~sublibs:["mirage"] "tls" ;
-        package "mirage-flow-lwt";
-        package "mirage-kv-lwt";
-        package "mirage-clock";
-        package ~min:"3.0.1" "mirage-conduit" ;
-      ]
-    method! deps = [ abstract nocrypto ]
-    method! connect _ _ _ = "Lwt.return Conduit_mirage.with_tls"
-  end
-
-type conduit = Conduit
-let conduit = Type Conduit
-
-let conduit_with_connectors connectors = impl @@ object
-    inherit base_configurable
-    method ty = conduit
-    method name = Name.create "conduit" ~prefix:"conduit"
-    method module_name = "Conduit_mirage"
-    method! packages =
-      Key.pure [
-        package ~min:"3.0.1" "mirage-conduit";
-      ]
-    method! deps = abstract nocrypto :: List.map abstract connectors
-
-    method! connect _i _ = function
-      (* There is always at least the nocrypto device *)
-      | _nocrypto :: connectors ->
-        let pp_connector = Fmt.fmt "%s >>=@ " in
-        let pp_connectors = Fmt.list ~sep:Fmt.nop pp_connector in
-        Fmt.strf
-          "Lwt.return Conduit_mirage.empty >>=@ \
-           %a\
-           fun t -> Lwt.return t"
-          pp_connectors connectors
-      | [] -> failwith "The conduit with connectors expects at least one argument"
-  end
-
-let conduit_direct ?(tls=false) s =
-  (* TCP must be before tls in the list. *)
-  let connectors = [tcp_conduit_connector $ s] in
-  let connectors =
-    if tls then
-      connectors @ [tls_conduit_connector]
-    else
-      connectors
-  in
-  conduit_with_connectors connectors
-
-type resolver = Resolver
-let resolver = Type Resolver
-
-let resolver_unix_system = impl @@ object
-    inherit base_configurable
-    method ty = resolver
-    method name = "resolver_unix"
-    method module_name = "Resolver_lwt"
-    method! packages =
-      Key.(if_ is_unix)
-        [ package ~min:"3.1.0" ~ocamlfind:[] "mirage-conduit" ;
-          package ~min:"1.0.0" "conduit-lwt-unix"; ]
-        []
-    method! configure i =
-      match get_target i with
-      | `Unix | `MacOSX -> R.ok ()
-      | _ -> R.error_msg "Unix resolver not supported on non-UNIX targets."
-    method! connect _ _modname _ = "Lwt.return Resolver_lwt_unix.system"
-  end
-
-let resolver_dns_conf ~ns ~ns_port = impl @@ object
-    inherit base_configurable
-    method ty = time @-> stackv4 @-> resolver
-    method name = "resolver"
-    method module_name = "Resolver_mirage.Make_with_stack"
-    method! packages =
-      Key.pure [
-        package ~min:"3.0.1" "mirage-conduit" ;
-      ]
-    method! connect _ modname = function
-      | [ _t ; stack ] ->
-        let meta_ns = Fmt.Dump.option meta_ipv4 in
-        let meta_port = Fmt.(Dump.option int) in
-        Fmt.strf
-          "let ns = %a in@;\
-           let ns_port = %a in@;\
-           let res = %s.R.init ?ns ?ns_port ~stack:%s () in@;\
-           Lwt.return res@;"
-          meta_ns ns meta_port ns_port modname stack
-      | _ -> failwith (connect_err "resolver" 2)
-  end
-
-let resolver_dns ?ns ?ns_port ?(time = default_time) stack =
-  resolver_dns_conf ~ns ~ns_port $ time $ stack
-
-
-type syslog_config = {
-  hostname : string;
-  server   : Ipaddr.V4.t option;
-  port     : int option;
-  truncate : int option;
+type ipv6_config = Mirage_impl_ip.ipv6_config = {
+  addresses : Ipaddr.V6.t list;
+  netmasks  : Ipaddr.V6.Prefix.t list;
+  gateways  : Ipaddr.V6.t list;
 }
 
-let syslog_config ?port ?truncate ?server hostname = {
-  hostname ; server ; port ; truncate
-}
+type 'a udp = 'a Mirage_impl_udp.udp
+let udp = Mirage_impl_udp.udp
+type udpv4 = Mirage_impl_udp.udpv4
+type udpv6 = Mirage_impl_udp.udpv6
+let udpv4 = Mirage_impl_udp.udpv4
+let udpv6 = Mirage_impl_udp.udpv6
+let direct_udp = Mirage_impl_udp.direct_udp
+let socket_udpv4 = Mirage_impl_udp.socket_udpv4
 
-let default_syslog_config =
-  let hostname = "no_name"
-  and server = None
-  and port = None
-  and truncate = None
-  in
-  { hostname ; server ; port ; truncate }
+type 'a tcp = 'a Mirage_impl_tcp.tcp
+let tcp = Mirage_impl_tcp.tcp
+type tcpv4 = Mirage_impl_tcp.tcpv4
+type tcpv6 = Mirage_impl_tcp.tcpv6
+let tcpv4 = Mirage_impl_tcp.tcpv4
+let tcpv6 = Mirage_impl_tcp.tcpv6
+let direct_tcp = Mirage_impl_tcp.direct_tcp
+let socket_tcpv4 = Mirage_impl_tcp.socket_tcpv4
 
-type syslog = SYSLOG
-let syslog = Type SYSLOG
+type stackv4 = Mirage_impl_stackv4.stackv4
+let stackv4 = Mirage_impl_stackv4.stackv4
+let generic_stackv4 = Mirage_impl_stackv4.generic_stackv4
+let static_ipv4_stack = Mirage_impl_stackv4.static_ipv4_stack
+let dhcp_ipv4_stack = Mirage_impl_stackv4.dhcp_ipv4_stack
+let qubes_ipv4_stack = Mirage_impl_stackv4.qubes_ipv4_stack
+let direct_stackv4 = Mirage_impl_stackv4.direct_stackv4
+let socket_stackv4 = Mirage_impl_stackv4.socket_stackv4
 
-let opt p s = Fmt.(option @@ prefix (unit ("~"^^s^^":")) p)
-let opt_int = opt Fmt.int
-let opt_string = opt (fun pp v -> Format.fprintf pp "%S" v)
+type conduit = Mirage_impl_conduit.conduit
+let conduit = Mirage_impl_conduit.conduit
+let conduit_direct = Mirage_impl_conduit.conduit_direct
 
-let syslog_udp_conf config =
-  let endpoint = Key.syslog config.server
-  and port = Key.syslog_port config.port
-  and hostname = Key.syslog_hostname config.hostname
-  in
-  impl @@ object
-    inherit base_configurable
-    method ty = console @-> pclock @-> stackv4 @-> syslog
-    method name = "udp_syslog"
-    method module_name = "Logs_syslog_mirage.Udp"
-    method! packages = Key.pure [ package ~min:"0.1.0" ~sublibs:["mirage"] "logs-syslog" ]
-    method! keys = [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
-    method! connect _i modname = function
-      | [ console ; pclock ; stack ] ->
-        Fmt.strf
-          "@[<v 2>\
-           match %a with@ \
-           | None -> Lwt.return_unit@ \
-           | Some server ->@ \
-             let port = %a in@ \
-             let reporter =@ \
-               %s.create %s %s %s ~hostname:%a ?port server %a ()@ \
-             in@ \
-             Logs.set_reporter reporter;@ \
-             Lwt.return_unit@]"
-          pp_key endpoint
-          pp_key port
-          modname console pclock stack
-          pp_key hostname
-          (opt_int "truncate") config.truncate
-      | _ -> failwith (connect_err "syslog udp" 3)
-  end
+type resolver = Mirage_impl_resolver.resolver
+let resolver = Mirage_impl_resolver.resolver
+let resolver_unix_system = Mirage_impl_resolver.resolver_unix_system
+let resolver_dns = Mirage_impl_resolver.resolver_dns
 
-let syslog_udp ?(config = default_syslog_config) ?(console = default_console) ?(clock = default_posix_clock) stack =
-  syslog_udp_conf config $ console $ clock $ stack
+type syslog = Mirage_impl_syslog.syslog
+let syslog = Mirage_impl_syslog.syslog
+let syslog_tls = Mirage_impl_syslog.syslog_tls
+let syslog_tcp = Mirage_impl_syslog.syslog_tcp
+let syslog_udp = Mirage_impl_syslog.syslog_udp
+type syslog_config = Mirage_impl_syslog.syslog_config =
+  { hostname : string;
+    server   : Ipaddr.V4.t option;
+    port     : int option;
+    truncate : int option;
+  }
+let syslog_config = Mirage_impl_syslog.syslog_config
 
-let syslog_tcp_conf config =
-  let endpoint = Key.syslog config.server
-  and port = Key.syslog_port config.port
-  and hostname = Key.syslog_hostname config.hostname
-  in
-  impl @@ object
-    inherit base_configurable
-    method ty = console @-> pclock @-> stackv4 @-> syslog
-    method name = "tcp_syslog"
-    method module_name = "Logs_syslog_mirage.Tcp"
-    method! packages = Key.pure [ package ~min:"0.1.0" ~sublibs:["mirage"] "logs-syslog" ]
-    method! keys = [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
-    method! connect _i modname = function
-      | [ console ; pclock ; stack ] ->
-        Fmt.strf
-          "@[<v 2>\
-           match %a with@ \
-           | None -> Lwt.return_unit@ \
-           | Some server ->@ \
-             let port = %a in@ \
-             %s.create %s %s %s ~hostname:%a ?port server %a () >>= function@ \
-             | Ok reporter -> Logs.set_reporter reporter; Lwt.return_unit@ \
-             | Error e -> invalid_arg e@]"
-          pp_key endpoint
-          pp_key port
-          modname console pclock stack
-          pp_key hostname
-          (opt_int "truncate") config.truncate
-      | _ -> failwith (connect_err "syslog tcp" 3)
-  end
+type http = Mirage_impl_http.http
+let http = Mirage_impl_http.http
+let http_server = Mirage_impl_http.http_server
 
-let syslog_tcp ?(config = default_syslog_config) ?(console = default_console) ?(clock = default_posix_clock) stack =
-  syslog_tcp_conf config $ console $ clock $ stack
+let default_argv = Mirage_impl_argv.default_argv
+let no_argv = Mirage_impl_argv.no_argv
 
-let syslog_tls_conf ?keyname config =
-  let endpoint = Key.syslog config.server
-  and port = Key.syslog_port config.port
-  and hostname = Key.syslog_hostname config.hostname
-  in
-  impl @@ object
-    inherit base_configurable
-    method ty = console @-> pclock @-> stackv4 @-> kv_ro @-> syslog
-    method name = "tls_syslog"
-    method module_name = "Logs_syslog_mirage_tls.Tls"
-    method! packages = Key.pure [ package ~min:"0.1.0" ~sublibs:["mirage" ; "mirage.tls"] "logs-syslog" ]
-    method! keys = [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
-    method! connect _i modname = function
-      | [ console ; pclock ; stack ; kv ] ->
-        Fmt.strf
-          "@[<v 2>\
-           match %a with@ \
-           | None -> Lwt.return_unit@ \
-           | Some server ->@ \
-             let port = %a in@ \
-             %s.create %s %s %s %s ~hostname:%a ?port server %a %a () >>= function@ \
-             | Ok reporter -> Logs.set_reporter reporter; Lwt.return_unit@ \
-             | Error e -> invalid_arg e@]"
-          pp_key endpoint
-          pp_key port
-          modname console pclock stack kv
-          pp_key hostname
-          (opt_int "truncate") config.truncate
-          (opt_string "keyname") keyname
-      | _ -> failwith (connect_err "syslog tls" 4)
-  end
+type reporter = Mirage_impl_reporter.reporter
+let reporter = Mirage_impl_reporter.reporter
+let default_reporter = Mirage_impl_reporter.default_reporter
+let no_reporter = Mirage_impl_reporter.no_reporter
 
-let syslog_tls ?(config = default_syslog_config) ?keyname ?(console = default_console) ?(clock = default_posix_clock) stack kv =
-  syslog_tls_conf ?keyname config $ console $ clock $ stack $ kv
-
-
-type http = HTTP
-let http = Type HTTP
-
-let http_server conduit = impl @@ object
-    inherit base_configurable
-    method ty = http
-    method name = "http"
-    method module_name = "Cohttp_mirage.Server_with_conduit"
-    method! packages = Key.pure [ package ~min:"1.0.0" "cohttp-mirage" ]
-    method! deps = [ abstract conduit ]
-    method! connect _i modname = function
-      | [ conduit ] -> Fmt.strf "%s.connect %s" modname conduit
-      | _ -> failwith (connect_err "http" 1)
-  end
-
-(** Argv *)
-
-let argv_unix = impl @@ object
-    inherit base_configurable
-    method ty = Functoria_app.argv
-    method name = "argv_unix"
-    method module_name = "OS.Env"
-    method! connect _ _ _ = "OS.Env.argv ()"
-  end
-
-let argv_solo5 = impl @@ object
-    inherit base_configurable
-    method ty = Functoria_app.argv
-    method name = "argv_solo5"
-    method module_name = "Bootvar"
-    method! packages = Key.pure [ package ~min:"0.3.0" "mirage-bootvar-solo5" ]
-    method! connect _ _ _ = "Bootvar.argv ()"
-  end
-
-let no_argv = impl @@ object
-    inherit base_configurable
-    method ty = Functoria_app.argv
-    method name = "argv_empty"
-    method module_name = "Mirage_runtime"
-    method! connect _ _ _ = "Lwt.return [|\"\"|]"
-  end
-
-let argv_xen = impl @@ object
-    inherit base_configurable
-    method ty = Functoria_app.argv
-    method name = "argv_xen"
-    method module_name = "Bootvar"
-    method! packages = Key.pure [ package ~min:"0.4.0" "mirage-bootvar-xen" ]
-    method! connect _ _ _ = Fmt.strf
-      (* Some hypervisor configurations try to pass some extra arguments.
-       * They means well, but we can't do much with them,
-       * and they cause Functoria to abort. *)
-      "let filter (key, _) = List.mem key (List.map snd Key_gen.runtime_keys) in@ \
-       Bootvar.argv ~filter ()"
-  end
-
-let default_argv =
-  match_impl Key.(value target) [
-    `Xen, argv_xen;
-    `Qubes, argv_xen;
-    `Virtio, argv_solo5;
-    `Hvt, argv_solo5;
-    `Muen, argv_solo5
-  ] ~default:argv_unix
-
-(** Log reporting *)
-
-type reporter = job
-let reporter = job
-
-let pp_level ppf = function
-  | Logs.Error    -> Fmt.string ppf "Logs.Error"
-  | Logs.Warning  -> Fmt.string ppf "Logs.Warning"
-  | Logs.Info     -> Fmt.string ppf "Logs.Info"
-  | Logs.Debug    -> Fmt.string ppf "Logs.Debug"
-  | Logs.App      -> Fmt.string ppf "Logs.App"
-
-let mirage_log ?ring_size ~default =
-  let logs = Key.logs in
-  impl @@ object
-    inherit base_configurable
-    method ty = pclock @-> reporter
-    method name = "mirage_logs"
-    method module_name = "Mirage_logs.Make"
-    method! packages = Key.pure [ package ~min:"0.3.0" "mirage-logs"]
-    method! keys = [ Key.abstract logs ]
-    method! connect _ modname = function
-      | [ pclock ] ->
-        Fmt.strf
-          "@[<v 2>\
-           let ring_size = %a in@ \
-           let reporter = %s.create ?ring_size %s in@ \
-           Mirage_runtime.set_level ~default:%a %a;@ \
-           %s.set_reporter reporter;@ \
-           Lwt.return reporter"
-          Fmt.(Dump.option int) ring_size
-          modname pclock
-          pp_level default
-          pp_key logs
-          modname
-    | _ -> failwith (connect_err "log" 1)
-  end
-
-let default_reporter
-    ?(clock=default_posix_clock) ?ring_size ?(level=Logs.Info) () =
-  mirage_log ?ring_size ~default:level $ clock
-
-let no_reporter = impl @@ object
-    inherit base_configurable
-    method ty = reporter
-    method name = "no_reporter"
-    method module_name = "Mirage_runtime"
-    method! connect _ _ _ = "assert false"
-  end
-
-(** Tracing *)
-
-type tracing = job
-let tracing = job
-
-let mprof_trace ~size () =
-  let unix_trace_file = "trace.ctf" in
-  let key = Key.tracing_size size in
-  impl @@ object
-    inherit base_configurable
-    method ty = job
-    method name = "mprof_trace"
-    method module_name = "MProf"
-    method! keys = [ Key.abstract key ]
-    method! packages =
-      Key.match_ Key.(value target) @@ function
-      | `Xen | `Qubes -> [ package "mirage-profile"; package "mirage-profile-xen" ]
-      | `Virtio | `Hvt | `Muen -> []
-      | `Unix | `MacOSX -> [ package "mirage-profile"; package "mirage-profile-unix" ]
-    method! build _ =
-      match query_ocamlfind ["lwt.tracing"] with
-      | Error _ | Ok [] ->
-        R.error_msg "lwt.tracing module not found. Hint:\
-                     opam pin add lwt https://github.com/mirage/lwt.git#tracing"
-      | Ok _ -> Ok ()
-    method! connect i _ _ = match get_target i with
-      | `Virtio | `Hvt | `Muen -> failwith  "tracing is not currently implemented for solo5 targets"
-      | `Unix | `MacOSX ->
-        Fmt.strf
-          "Lwt.return ())@.\
-           let () = (@ \
-           @[<v 2> let buffer = MProf_unix.mmap_buffer ~size:%a %S in@ \
-           let trace_config = MProf.Trace.Control.make buffer MProf_unix.timestamper in@ \
-           MProf.Trace.Control.start trace_config@]"
-          Key.serialize_call (Key.abstract key)
-          unix_trace_file;
-      | `Xen | `Qubes ->
-        Fmt.strf
-          "Lwt.return ())@.\
-           let () = (@ \
-           @[<v 2> let trace_pages = MProf_xen.make_shared_buffer ~size:%a in@ \
-           let buffer = trace_pages |> Io_page.to_cstruct |> Cstruct.to_bigarray in@ \
-           let trace_config = MProf.Trace.Control.make buffer MProf_xen.timestamper in@ \
-           MProf.Trace.Control.start trace_config;@ \
-           MProf_xen.share_with (module Gnt.Gntshr) (module OS.Xs) ~domid:0 trace_pages@ \
-           |> OS.Main.run@]"
-          Key.serialize_call (Key.abstract key)
-  end
+type tracing = Mirage_impl_tracing.tracing
+let tracing = Mirage_impl_tracing.tracing
+let mprof_trace = Mirage_impl_tracing.mprof_trace
 
 (** Functoria devices *)
 
@@ -1606,7 +341,7 @@ module Substitutions = struct
     | Name
     | Kernel
     | Memory
-    | Block of block_t
+    | Block of Mirage_impl_block.block_t
     | Network of string
 
   let string_of_v = function
@@ -1625,10 +360,10 @@ module Substitutions = struct
   let defaults i =
     let blocks =
       List.map (fun b -> Block b, Fpath.(to_string ((Info.build_dir i) / b.filename)))
-        (Hashtbl.fold (fun _ v acc -> v :: acc) all_blocks [])
+        (Hashtbl.fold (fun _ v acc -> v :: acc) Mirage_impl_block.all_blocks [])
     and networks =
       List.mapi (fun i n -> Network n, Fmt.strf "%s%d" detected_bridge_name i)
-        !all_networks
+        !Mirage_impl_network.all_networks
     in [
       Name, (Info.name i);
       Kernel, Fpath.(to_string ((Info.build_dir i) / (Info.name i) + "xen"));
@@ -1644,6 +379,7 @@ let configure_main_xl ?substitutions ext i =
   let file = Fpath.(v (Info.name i) + ext) in
   let open Codegen in
   with_output file (fun oc () ->
+      let open Mirage_impl_block in
       let fmt = Format.formatter_of_out_channel oc in
       append fmt "# %s" (generated_header ()) ;
       newline fmt;
@@ -1676,7 +412,7 @@ let configure_main_xl ?substitutions ext i =
       newline fmt;
       let networks = List.map (fun n ->
           Fmt.strf "'bridge=%s'" (lookup substitutions (Network n)))
-          !all_networks
+          !Mirage_impl_network.all_networks
       in
       append fmt "# if your system uses openvswitch then either edit \
                   /etc/xen/xl.conf and set";
@@ -1694,6 +430,7 @@ let configure_main_xe ~root ~name =
   let file = Fpath.(v name + "xe") in
   with_output ~mode:0o755 file (fun oc () ->
       let fmt = Format.formatter_of_out_channel oc in
+      let open Mirage_impl_block in
       append fmt "#!/bin/sh";
       append fmt "# %s" (generated_header ());
       newline fmt;
@@ -2041,6 +778,17 @@ let link info name target target_debug =
     else
       Ok out
 
+let check_entropy libs =
+  query_ocamlfind ~recursive:true libs >>= fun ps ->
+  if List.mem "nocrypto" ps && not (Mirage_impl_random.is_entropy_enabled ()) then
+    R.error_msg
+      {___|The \"nocrypto\" library is loaded but entropy is not enabled!@ \
+       Please enable the entropy by adding a dependency to the nocrypto \
+       device. You can do so by adding ~deps:[abstract nocrypto] \
+       to the arguments of Mirage.foreign.|___}
+  else
+    R.ok ()
+
 let build i =
   let name = Info.name i in
   let ctx = Info.context i in
@@ -2149,11 +897,11 @@ let (++) acc x = match acc, x with
 
 (* TODO: ideally we'd combine these *)
 let qrexec_init = match_impl Key.(value target) [
-  `Qubes, qrexec_qubes;
+  `Qubes, Mirage_impl_qrexec.qrexec_qubes;
 ] ~default:Functoria_app.noop
 
 let gui_init = match_impl Key.(value target) [
-  `Qubes, gui_qubes;
+  `Qubes, Mirage_impl_gui.gui_qubes;
 ] ~default:Functoria_app.noop
 
 let register

--- a/lib/mirage_impl_argv.ml
+++ b/lib/mirage_impl_argv.ml
@@ -1,0 +1,50 @@
+open Functoria
+module Key = Mirage_key
+
+let argv_unix = impl @@ object
+    inherit base_configurable
+    method ty = Functoria_app.argv
+    method name = "argv_unix"
+    method module_name = "OS.Env"
+    method! connect _ _ _ = "OS.Env.argv ()"
+  end
+
+let argv_solo5 = impl @@ object
+    inherit base_configurable
+    method ty = Functoria_app.argv
+    method name = "argv_solo5"
+    method module_name = "Bootvar"
+    method! packages = Key.pure [ package ~min:"0.3.0" "mirage-bootvar-solo5" ]
+    method! connect _ _ _ = "Bootvar.argv ()"
+  end
+
+let no_argv = impl @@ object
+    inherit base_configurable
+    method ty = Functoria_app.argv
+    method name = "argv_empty"
+    method module_name = "Mirage_runtime"
+    method! connect _ _ _ = "Lwt.return [|\"\"|]"
+  end
+
+let argv_xen = impl @@ object
+    inherit base_configurable
+    method ty = Functoria_app.argv
+    method name = "argv_xen"
+    method module_name = "Bootvar"
+    method! packages = Key.pure [ package ~min:"0.4.0" "mirage-bootvar-xen" ]
+    method! connect _ _ _ = Fmt.strf
+      (* Some hypervisor configurations try to pass some extra arguments.
+       * They means well, but we can't do much with them,
+       * and they cause Functoria to abort. *)
+      "let filter (key, _) = List.mem key (List.map snd Key_gen.runtime_keys) in@ \
+       Bootvar.argv ~filter ()"
+  end
+
+let default_argv =
+  match_impl Key.(value target) [
+    `Xen, argv_xen;
+    `Qubes, argv_xen;
+    `Virtio, argv_solo5;
+    `Hvt, argv_solo5;
+    `Muen, argv_solo5
+  ] ~default:argv_unix

--- a/lib/mirage_impl_argv.mli
+++ b/lib/mirage_impl_argv.mli
@@ -1,0 +1,3 @@
+val default_argv : Functoria_app.argv Functoria.impl
+
+val no_argv : Functoria_app.argv Functoria.impl

--- a/lib/mirage_impl_arpv4.ml
+++ b/lib/mirage_impl_arpv4.ml
@@ -1,0 +1,46 @@
+module Key = Mirage_key
+open Functoria
+open Mirage_impl_ethernet
+open Mirage_impl_mclock
+open Mirage_impl_time
+open Mirage_impl_misc
+
+type arpv4 = Arpv4
+let arpv4 = Type Arpv4
+
+let arpv4_conf = object
+  inherit base_configurable
+  method ty = ethernet @-> mclock @-> time @-> arpv4
+  method name = "arpv4"
+  method module_name = "Arpv4.Make"
+  method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["arpv4"] "tcpip" ]
+  method! connect _ modname = function
+    | [ eth ; clock ; _time ] -> Fmt.strf "%s.connect %s %s" modname eth clock
+    | _ -> failwith (connect_err "arpv4" 3)
+end
+
+let arp_func = impl arpv4_conf
+let arp
+    ?(clock = default_monotonic_clock)
+    ?(time = default_time)
+    (eth : ethernet impl) =
+  arp_func $ eth $ clock $ time
+
+
+let farp_conf = object
+  inherit base_configurable
+  method ty = ethernet @-> mclock @-> time @-> arpv4
+  method name = "arp"
+  method module_name = "Arp.Make"
+  method! packages = Key.pure [ package ~min:"0.2.0" ~sublibs:["mirage"] "arp" ]
+  method! connect _ modname = function
+    | [ eth ; clock ; _time ] -> Fmt.strf "%s.connect %s %s" modname eth clock
+    | _ -> failwith (connect_err "arp" 3)
+end
+
+let farp_func = impl farp_conf
+let farp
+    ?(clock = default_monotonic_clock)
+    ?(time = default_time)
+    (eth : ethernet impl) =
+  farp_func $ eth $ clock $ time

--- a/lib/mirage_impl_arpv4.mli
+++ b/lib/mirage_impl_arpv4.mli
@@ -1,0 +1,15 @@
+type arpv4
+
+val arpv4 : arpv4 Functoria.typ
+
+val arp :
+     ?clock:Mirage_impl_mclock.mclock Functoria.impl
+  -> ?time:Mirage_impl_time.time Functoria.impl
+  -> Mirage_impl_ethernet.ethernet Functoria.impl
+  -> arpv4 Functoria.impl
+
+val farp :
+     ?clock:Mirage_impl_mclock.mclock Functoria.impl
+  -> ?time:Mirage_impl_time.time Functoria.impl
+  -> Mirage_impl_ethernet.ethernet Functoria.impl
+  -> arpv4 Functoria.impl

--- a/lib/mirage_impl_block.ml
+++ b/lib/mirage_impl_block.ml
@@ -1,0 +1,142 @@
+open Functoria
+module Name = Functoria_app.Name
+module Key = Mirage_key
+open Mirage_impl_misc
+open Rresult
+open Mirage_impl_kv_ro
+
+type block = BLOCK
+let block = Type BLOCK
+type block_t = { filename: string; number: int }
+let all_blocks = Hashtbl.create 7
+
+let make_block_t =
+  (* NB: reserve number 0 for the boot disk *)
+  let next_number = ref 1 in
+  fun filename ->
+    let b =
+      if Hashtbl.mem all_blocks filename then
+        Hashtbl.find all_blocks filename
+      else begin
+        let number = !next_number in
+        incr next_number;
+        let b = { filename; number } in
+        Hashtbl.add all_blocks filename b;
+        b
+      end in
+    b
+
+let xen_block_packages =
+  [ package ~min:"1.5.0" ~sublibs:["front"] "mirage-block-xen" ]
+
+(* this class takes a string rather than an int as `id` to allow the user to
+   pass stuff like "/dev/xvdi1", which mirage-block-xen also understands *)
+class xenstore_conf id =
+  let name = Name.create id ~prefix:"block" in
+  object
+    inherit base_configurable
+    method ty = block
+    method name = name
+    method module_name = "Block"
+    method! packages = Key.pure xen_block_packages
+    method! configure i =
+      match get_target i with
+      | `Qubes | `Xen -> R.ok ()
+      | _ -> R.error_msg "XenStore IDs are only valid ways of specifying block \
+                          devices when the target is Xen or Qubes."
+    method! connect _ s _ =
+      Fmt.strf "%s.connect %S" s id
+  end
+
+let block_of_xenstore_id id = impl (new xenstore_conf id)
+
+(* calculate the XenStore ID for the nth available block device.
+   Taken from https://github.com/mirage/mirage-block-xen/blob/
+   a64d152586c7ebc1d23c5adaa4ddd440b45a3a83/lib/device_number.ml#L64 . *)
+let xenstore_id_of_index number =
+        (if number < 16
+         then (202 lsl 8) lor (number lsl 4)
+         else (1 lsl 28)  lor (number lsl 8))
+
+class block_conf file =
+  let name = Name.create file ~prefix:"block" in
+  object (self)
+    inherit base_configurable
+    method ty = block
+    method name = name
+    method module_name = "Block"
+    method! packages =
+      Key.match_ Key.(value target) @@ function
+      | `Xen | `Qubes -> xen_block_packages
+      | `Virtio | `Hvt | `Muen -> [ package ~min:"0.3.0" "mirage-block-solo5" ]
+      | `Unix | `MacOSX -> [ package ~min:"2.5.0" "mirage-block-unix" ]
+
+    method! configure _ =
+      let _block = make_block_t file in
+      R.ok ()
+
+    method private connect_name target root =
+      match target with
+      | `Unix | `MacOSX | `Virtio | `Hvt | `Muen ->
+        Fpath.(to_string (root / file)) (* open the file directly *)
+      | `Xen | `Qubes ->
+        let b = make_block_t file in
+        xenstore_id_of_index b.number |> string_of_int
+
+    method! connect i s _ =
+      match get_target i with
+      | `Muen -> failwith "Block devices not supported on Muen target."
+      | `Unix | `MacOSX | `Virtio | `Hvt | `Xen | `Qubes ->
+        Fmt.strf "%s.connect %S" s
+          (self#connect_name (get_target i) @@ Info.build_dir i)
+  end
+
+let block_of_file file = impl (new block_conf file)
+
+class ramdisk_conf rname =
+  object
+    inherit base_configurable
+    method ty = block
+    method name = "ramdisk"
+    method module_name = "Ramdisk"
+    method! packages =
+      Key.pure [ package "mirage-block-ramdisk" ]
+
+    method! connect _i modname _names =
+      Fmt.strf "%s.connect ~name:%S" modname rname
+  end
+
+
+let ramdisk rname = impl (new ramdisk_conf rname)
+
+let generic_block ?group ?(key = Key.value @@ Key.block ?group ()) name =
+  match_impl key [
+    `XenstoreId, block_of_xenstore_id name;
+    `BlockFile, block_of_file name;
+    `Ramdisk, ramdisk name;
+  ] ~default:(ramdisk name)
+
+let tar_block dir =
+  let name = Name.create ("tar_block" ^ dir) ~prefix:"tar_block" in
+  let block_file = name ^ ".img" in
+  impl @@ object
+    inherit block_conf block_file as super
+    method! build i =
+      Bos.OS.Cmd.run Bos.Cmd.(v "tar" % "-cvf" % block_file % dir) >>= fun () ->
+      super#build i
+  end
+
+let archive_conf = impl @@ object
+    inherit base_configurable
+    method ty = block @-> kv_ro
+    method name = "archive"
+    method module_name = "Tar_mirage.Make_KV_RO"
+    method! packages =
+      Key.pure [ package ~min:"0.8.0" "tar-mirage" ]
+    method! connect _ modname = function
+      | [ block ] -> Fmt.strf "%s.connect %s" modname block
+      | _ -> failwith (connect_err "archive" 1)
+  end
+
+let archive block = archive_conf $ block
+let archive_of_files ?(dir=".") () = archive @@ tar_block dir

--- a/lib/mirage_impl_block.mli
+++ b/lib/mirage_impl_block.mli
@@ -1,0 +1,36 @@
+type block
+
+val block : block Functoria.typ
+
+val generic_block :
+     ?group:string
+  -> ?key:[`BlockFile | `Ramdisk | `XenstoreId] Functoria.value
+  -> string
+  -> block Functoria.impl
+
+val archive_of_files :
+  ?dir:string -> unit -> Mirage_impl_kv_ro.kv_ro Functoria.impl
+
+val archive : block Functoria.impl -> Mirage_impl_kv_ro.kv_ro Functoria.impl
+
+val ramdisk : string -> block Functoria.impl
+
+val block_of_xenstore_id : string -> block Functoria.impl
+
+val block_of_file : string -> block Functoria.impl
+
+class block_conf :
+  string
+  -> object
+       inherit Functoria.base_configurable
+
+       method module_name : string
+
+       method name : string
+
+       method ty : block Functoria.typ
+     end
+
+type block_t = {filename: string; number: int}
+
+val all_blocks : (string, block_t) Hashtbl.t

--- a/lib/mirage_impl_conduit.ml
+++ b/lib/mirage_impl_conduit.ml
@@ -1,0 +1,41 @@
+open Functoria
+open Mirage_impl_conduit_connector
+open Mirage_impl_random
+
+type conduit = Conduit
+let conduit = Type Conduit
+
+let conduit_with_connectors connectors = impl @@ object
+    inherit base_configurable
+    method ty = conduit
+    method name = Functoria_app.Name.create "conduit" ~prefix:"conduit"
+    method module_name = "Conduit_mirage"
+    method! packages =
+      Mirage_key.pure [
+        package ~min:"3.0.1" "mirage-conduit";
+      ]
+    method! deps = abstract nocrypto :: List.map abstract connectors
+
+    method! connect _i _ = function
+      (* There is always at least the nocrypto device *)
+      | _nocrypto :: connectors ->
+        let pp_connector = Fmt.fmt "%s >>=@ " in
+        let pp_connectors = Fmt.list ~sep:Fmt.nop pp_connector in
+        Fmt.strf
+          "Lwt.return Conduit_mirage.empty >>=@ \
+           %a\
+           fun t -> Lwt.return t"
+          pp_connectors connectors
+      | [] -> failwith "The conduit with connectors expects at least one argument"
+  end
+
+let conduit_direct ?(tls=false) s =
+  (* TCP must be before tls in the list. *)
+  let connectors = [tcp_conduit_connector $ s] in
+  let connectors =
+    if tls then
+      connectors @ [tls_conduit_connector]
+    else
+      connectors
+  in
+  conduit_with_connectors connectors

--- a/lib/mirage_impl_conduit.mli
+++ b/lib/mirage_impl_conduit.mli
@@ -1,0 +1,8 @@
+type conduit
+
+val conduit : conduit Functoria.typ
+
+val conduit_direct :
+     ?tls:bool
+  -> Mirage_impl_stackv4.stackv4 Functoria.impl
+  -> conduit Functoria.impl

--- a/lib/mirage_impl_conduit_connector.ml
+++ b/lib/mirage_impl_conduit_connector.ml
@@ -1,0 +1,38 @@
+open Functoria
+open Mirage_impl_misc
+open Mirage_impl_random
+open Mirage_impl_stackv4
+
+type conduit_connector = Conduit_connector
+let conduit_connector = Type Conduit_connector
+
+let tcp_conduit_connector = impl @@ object
+    inherit base_configurable
+    method ty = stackv4 @-> conduit_connector
+    method name = "tcp_conduit_connector"
+    method module_name = "Conduit_mirage.With_tcp"
+    method! packages =
+      Mirage_key.pure [
+        package ~min:"3.0.1" "mirage-conduit";
+      ]
+    method! connect _ modname = function
+      | [ stack ] -> Fmt.strf "Lwt.return (%s.connect %s)@;" modname stack
+      | _ -> failwith (connect_err "tcp conduit" 1)
+  end
+
+let tls_conduit_connector = impl @@ object
+    inherit base_configurable
+    method ty = conduit_connector
+    method name = "tls_conduit_connector"
+    method module_name = "Conduit_mirage"
+    method! packages =
+      Mirage_key.pure [
+        package ~min:"0.8.0" ~sublibs:["mirage"] "tls" ;
+        package "mirage-flow-lwt";
+        package "mirage-kv-lwt";
+        package "mirage-clock";
+        package ~min:"3.0.1" "mirage-conduit" ;
+      ]
+    method! deps = [ abstract nocrypto ]
+    method! connect _ _ _ = "Lwt.return Conduit_mirage.with_tls"
+  end

--- a/lib/mirage_impl_conduit_connector.mli
+++ b/lib/mirage_impl_conduit_connector.mli
@@ -1,0 +1,6 @@
+type conduit_connector
+
+val tcp_conduit_connector :
+  (Mirage_impl_stackv4.stackv4 -> conduit_connector) Functoria.impl
+
+val tls_conduit_connector : conduit_connector Functoria.impl

--- a/lib/mirage_impl_console.ml
+++ b/lib/mirage_impl_console.ml
@@ -1,0 +1,47 @@
+open Functoria
+module Name = Functoria_app.Name
+module Key = Mirage_key
+
+type console = CONSOLE
+let console = Type CONSOLE
+
+let console_unix str = impl @@ object
+    inherit base_configurable
+    method ty = console
+    val name = Name.ocamlify @@ "console_unix_" ^ str
+    method name = name
+    method module_name = "Console_unix"
+    method! packages = Key.pure [ package ~min:"2.2.0" "mirage-console-unix" ]
+    method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
+  end
+
+let console_xen str = impl @@ object
+    inherit base_configurable
+    method ty = console
+    val name = Name.ocamlify @@ "console_xen_" ^ str
+    method name = name
+    method module_name = "Console_xen"
+    method! packages = Key.pure [ package ~min:"2.2.0" "mirage-console-xen" ]
+    method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
+  end
+
+let console_solo5 str = impl @@ object
+    inherit base_configurable
+    method ty = console
+    val name = Name.ocamlify @@ "console_solo5_" ^ str
+    method name = name
+    method module_name = "Console_solo5"
+    method! packages = Key.pure [ package ~min:"0.3.0" "mirage-console-solo5" ]
+    method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
+  end
+
+let custom_console str =
+  match_impl Key.(value target) [
+    `Xen, console_xen str;
+    `Qubes, console_xen str;
+    `Virtio, console_solo5 str;
+    `Hvt, console_solo5 str;
+    `Muen, console_solo5 str
+  ] ~default:(console_unix str)
+
+let default_console = custom_console "0"

--- a/lib/mirage_impl_console.mli
+++ b/lib/mirage_impl_console.mli
@@ -1,0 +1,7 @@
+type console
+
+val console : console Functoria.typ
+
+val default_console : console Functoria.impl
+
+val custom_console : string -> console Functoria.impl

--- a/lib/mirage_impl_dhcp.ml
+++ b/lib/mirage_impl_dhcp.ml
@@ -1,0 +1,4 @@
+open Functoria
+
+type dhcp = Dhcp_client
+let dhcp = Type Dhcp_client

--- a/lib/mirage_impl_dhcp.mli
+++ b/lib/mirage_impl_dhcp.mli
@@ -1,0 +1,3 @@
+type dhcp
+
+val dhcp : dhcp Functoria.typ

--- a/lib/mirage_impl_ethernet.ml
+++ b/lib/mirage_impl_ethernet.ml
@@ -1,0 +1,21 @@
+module Key = Mirage_key
+open Functoria
+open Mirage_impl_misc
+open Mirage_impl_network
+
+type ethernet = ETHERNET
+let ethernet = Type ETHERNET
+
+let ethernet_conf = object
+  inherit base_configurable
+  method ty = network @-> ethernet
+  method name = "ethif"
+  method module_name = "Ethif.Make"
+  method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["ethif"] "tcpip" ]
+  method! connect _ modname = function
+    | [ eth ] -> Fmt.strf "%s.connect %s" modname eth
+    | _ -> failwith (connect_err "ethernet" 1)
+end
+
+let etif_func = impl ethernet_conf
+let etif network = etif_func $ network

--- a/lib/mirage_impl_ethernet.mli
+++ b/lib/mirage_impl_ethernet.mli
@@ -1,0 +1,5 @@
+type ethernet
+
+val ethernet : ethernet Functoria.typ
+
+val etif : Mirage_impl_network.network Functoria.impl -> ethernet Functoria.impl

--- a/lib/mirage_impl_fs.ml
+++ b/lib/mirage_impl_fs.ml
@@ -1,0 +1,101 @@
+module Codegen = Functoria_app.Codegen
+module Key = Mirage_key
+module Name = Functoria_app.Name
+open Functoria
+open Mirage_impl_block
+open Mirage_impl_kv_ro
+open Mirage_impl_misc
+open Rresult
+
+type fs = FS
+let fs = Type FS
+
+let fat_conf = impl @@ object
+    inherit base_configurable
+    method ty = (block @-> fs)
+    method! packages = Key.pure [ package ~min:"0.12.0" "fat-filesystem" ]
+    method name = "fat"
+    method module_name = "Fat.FS"
+    method! connect _ modname l = match l with
+      | [ block_name ] -> Fmt.strf "%s.connect %s" modname block_name
+      | _ -> failwith (connect_err "fat" 1)
+  end
+
+let fat block = fat_conf $ block
+
+let fat_block ?(dir=".") ?(regexp="*") () =
+  let name =
+    Name.(ocamlify @@ create (Fmt.strf "fat%s:%s" dir regexp) ~prefix:"fat_block")
+  in
+  let block_file = name ^ ".img" in
+  impl @@ object
+    inherit Mirage_impl_block.block_conf block_file as super
+    method! packages =
+      Key.map (List.cons (package ~min:"0.12.0" ~build:true "fat-filesystem")) super#packages
+    method! build i =
+      let root = Info.build_dir i in
+      let file = Fmt.strf "make-%s-image.sh" name in
+      let dir = Fpath.of_string dir |> R.error_msg_to_invalid_arg in
+      Log.info (fun m -> m "Generating block generator script: %s" file);
+      with_output ~mode:0o755 (Fpath.v file)
+        (fun oc () ->
+           let fmt = Format.formatter_of_out_channel oc in
+           Codegen.append fmt "#!/bin/sh";
+           Codegen.append fmt "";
+           Codegen.append fmt "echo This uses the 'fat' command-line tool to \
+                               build a simple FAT";
+           Codegen.append fmt "echo filesystem image.";
+           Codegen.append fmt "";
+           Codegen.append fmt "FAT=$(which fat)";
+           Codegen.append fmt "if [ ! -x \"${FAT}\" ]; then";
+           Codegen.append fmt "  echo I couldn\\'t find the 'fat' command-line \
+                               tool.";
+           Codegen.append fmt "  echo Try running 'opam install fat-filesystem'";
+           Codegen.append fmt "  exit 1";
+           Codegen.append fmt "fi";
+           Codegen.append fmt "";
+           Codegen.append fmt "IMG=$(pwd)/%s" block_file;
+           Codegen.append fmt "rm -f ${IMG}";
+           Codegen.append fmt "cd %a" Fpath.pp (Fpath.append root dir);
+           Codegen.append fmt "SIZE=$(du -s . | cut -f 1)";
+           Codegen.append fmt "${FAT} create ${IMG} ${SIZE}KiB";
+           Codegen.append fmt "${FAT} add ${IMG} %s" regexp;
+           Codegen.append fmt "echo Created '%s'" block_file;
+           R.ok ())
+        "fat shell script" >>= fun () ->
+      Log.info (fun m -> m "Executing block generator script: ./%s" file);
+      Bos.OS.Cmd.run (Bos.Cmd.v ("./" ^ file)) >>= fun () ->
+      super#build i
+
+    method! clean i =
+      let file = Fmt.strf "make-%s-image.sh" name in
+      Bos.OS.File.delete (Fpath.v file) >>= fun () ->
+      Bos.OS.File.delete (Fpath.v block_file) >>= fun () ->
+      super#clean i
+  end
+
+let fat_of_files ?dir ?regexp () = fat @@ fat_block ?dir ?regexp ()
+
+
+let kv_ro_of_fs_conf = impl @@ object
+    inherit base_configurable
+    method ty = fs @-> kv_ro
+    method name = "kv_ro_of_fs"
+    method module_name = "Mirage_fs_lwt.To_KV_RO"
+    method! packages = Key.pure [ package "mirage-fs-lwt" ]
+    method! connect _ modname = function
+      | [ fs ] -> Fmt.strf "%s.connect %s" modname fs
+      | _ -> failwith (connect_err "kv_ro_of_fs" 1)
+  end
+
+let kv_ro_of_fs x = kv_ro_of_fs_conf $ x
+
+(** generic kv_ro. *)
+
+let generic_kv_ro ?group ?(key = Key.value @@ Key.kv_ro ?group ()) dir =
+  match_impl key [
+    `Fat    , kv_ro_of_fs @@ fat_of_files ~dir () ;
+    `Archive, archive_of_files ~dir () ;
+    `Crunch , crunch dir ;
+    `Direct , direct_kv_ro dir ;
+  ] ~default:(direct_kv_ro dir)

--- a/lib/mirage_impl_fs.mli
+++ b/lib/mirage_impl_fs.mli
@@ -1,0 +1,15 @@
+type fs
+
+val fs : fs Functoria.typ
+
+val fat : Mirage_impl_block.block Functoria.impl -> fs Functoria.impl
+
+val fat_of_files : ?dir:string -> ?regexp:string -> unit -> fs Functoria.impl
+
+val kv_ro_of_fs : fs Functoria.impl -> Mirage_impl_kv_ro.kv_ro Functoria.impl
+
+val generic_kv_ro :
+     ?group:string
+  -> ?key:[`Archive | `Crunch | `Direct | `Fat] Functoria.value
+  -> string
+  -> Mirage_impl_kv_ro.kv_ro Functoria.impl

--- a/lib/mirage_impl_gui.ml
+++ b/lib/mirage_impl_gui.ml
@@ -1,0 +1,27 @@
+open Functoria
+module Name = Functoria_app.Name
+open Mirage_impl_misc
+module Key = Mirage_key
+open Rresult
+
+let gui = job
+
+let gui_qubes = impl @@ object
+  inherit base_configurable
+  method ty = gui
+  val name = Name.ocamlify @@ "gui"
+  method name = name
+  method module_name = "Qubes.GUI"
+  method! packages = Key.pure [ package ~min:"0.4" "mirage-qubes" ]
+  method! configure i =
+    match get_target i with
+    | `Qubes -> R.ok ()
+    | _ -> R.error_msg "Qubes GUI invoked for non-Qubes target."
+  method! connect _ modname _args =
+    Fmt.strf
+      "@[<v 2>\
+       %s.connect ~domid:0 () >>= fun gui ->@ \
+       Lwt.async (fun () -> %s.listen gui);@ \
+       Lwt.return (`Ok gui)@]"
+      modname modname
+end

--- a/lib/mirage_impl_gui.mli
+++ b/lib/mirage_impl_gui.mli
@@ -1,0 +1,1 @@
+val gui_qubes : Functoria.job Functoria.impl

--- a/lib/mirage_impl_http.ml
+++ b/lib/mirage_impl_http.ml
@@ -1,0 +1,17 @@
+open Functoria
+open Mirage_impl_misc
+
+type http = HTTP
+let http = Type HTTP
+
+let http_server conduit = impl @@ object
+    inherit base_configurable
+    method ty = http
+    method name = "http"
+    method module_name = "Cohttp_mirage.Server_with_conduit"
+    method! packages = Mirage_key.pure [ package ~min:"1.0.0" "cohttp-mirage" ]
+    method! deps = [ abstract conduit ]
+    method! connect _i modname = function
+      | [ conduit ] -> Fmt.strf "%s.connect %s" modname conduit
+      | _ -> failwith (connect_err "http" 1)
+  end

--- a/lib/mirage_impl_http.mli
+++ b/lib/mirage_impl_http.mli
@@ -1,0 +1,6 @@
+type http
+
+val http : http Functoria.typ
+
+val http_server :
+  Mirage_impl_conduit.conduit Functoria.impl -> http Functoria.impl

--- a/lib/mirage_impl_icmp.ml
+++ b/lib/mirage_impl_icmp.ml
@@ -1,0 +1,23 @@
+open Functoria
+open Mirage_impl_ip
+open Mirage_impl_misc
+
+type 'a icmp = ICMP
+type icmpv4 = v4 icmp
+
+let icmp = Type ICMP
+let icmpv4: icmpv4 typ = icmp
+
+let icmpv4_direct_conf () = object
+  inherit base_configurable
+  method ty : ('a ip -> 'a icmp) typ = ip @-> icmp
+  method name = "icmpv4"
+  method module_name = "Icmpv4.Make"
+  method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["icmpv4"] "tcpip"
+  method! connect _ modname = function
+    | [ ip ] -> Fmt.strf "%s.connect %s" modname ip
+    | _  -> failwith (connect_err "icmpv4" 1)
+end
+
+let icmpv4_direct_func () = impl (icmpv4_direct_conf ())
+let direct_icmpv4 ip = icmpv4_direct_func () $ ip

--- a/lib/mirage_impl_icmp.mli
+++ b/lib/mirage_impl_icmp.mli
@@ -1,0 +1,5 @@
+type icmpv4
+
+val icmpv4 : icmpv4 Functoria.typ
+
+val direct_icmpv4 : Mirage_impl_ip.ipv4 Functoria.impl -> icmpv4 Functoria.impl

--- a/lib/mirage_impl_io_page.ml
+++ b/lib/mirage_impl_io_page.ml
@@ -1,0 +1,18 @@
+open Functoria
+module Key = Mirage_key
+
+type io_page = IO_PAGE
+let io_page = Type IO_PAGE
+
+let io_page_conf = object
+  inherit base_configurable
+  method ty = io_page
+  method name = "io_page"
+  method module_name = "Io_page"
+  method! packages =
+    Key.(if_ is_unix)
+      [ package ~sublibs:["unix"] "io-page" ]
+      [ package "io-page" ]
+end
+
+let default_io_page = impl io_page_conf

--- a/lib/mirage_impl_io_page.mli
+++ b/lib/mirage_impl_io_page.mli
@@ -1,0 +1,5 @@
+type io_page
+
+val io_page : io_page Functoria.typ
+
+val default_io_page : io_page Functoria.impl

--- a/lib/mirage_impl_ip.ml
+++ b/lib/mirage_impl_ip.ml
@@ -1,0 +1,156 @@
+module Key = Mirage_key
+module Name = Functoria_app.Name
+open Functoria
+open Mirage_impl_arpv4
+open Mirage_impl_ethernet
+open Mirage_impl_mclock
+open Mirage_impl_misc
+open Mirage_impl_network
+open Mirage_impl_qubesdb
+open Mirage_impl_random
+open Mirage_impl_time
+
+type v4
+type v6
+type 'a ip = IP
+type ipv4 = v4 ip
+type ipv6 = v6 ip
+
+let ip = Type IP
+let ipv4: ipv4 typ = ip
+let ipv6: ipv6 typ = ip
+
+type ipv4_config = {
+  network : Ipaddr.V4.Prefix.t * Ipaddr.V4.t;
+  gateway : Ipaddr.V4.t option;
+}
+(** Types for IPv4 manual configuration. *)
+
+let opt_key s = Fmt.(option @@ prefix (unit ("~"^^s^^":")) pp_key)
+let opt_map f = function Some x -> Some (f x) | None -> None
+let (@?) x l = match x with Some s -> s :: l | None -> l
+let (@??) x y = opt_map Key.abstract x @? y
+
+(* convenience function for linking tcpip.unix or .xen for checksums *)
+let right_tcpip_library ?min ?max ?ocamlfind ~sublibs pkg =
+  Key.match_ Key.(value target) @@ function
+  |`MacOSX | `Unix         -> [ package ?min ?max ?ocamlfind ~sublibs:("unix"::sublibs) pkg ]
+  |`Qubes  | `Xen          -> [ package ?min ?max ?ocamlfind ~sublibs:("xen"::sublibs) pkg ]
+  |`Virtio | `Hvt | `Muen  -> [ package ?min ?max ?ocamlfind ~sublibs pkg ]
+
+let ipv4_keyed_conf ?network ?gateway () = impl @@ object
+    inherit base_configurable
+    method ty = random @-> mclock @-> ethernet @-> arpv4 @-> ipv4
+    method name = Name.create "ipv4" ~prefix:"ipv4"
+    method module_name = "Static_ipv4.Make"
+    method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["ipv4"] "tcpip"
+    method! keys = network @?? gateway @?? []
+    method! connect _ modname = function
+    | [ _random ; mclock ; etif ; arp ] ->
+      Fmt.strf
+        "let (network, ip) = %a in @ \
+         %s.connect@[@ ~ip ~network %a@ %s@ %s@ %s@]"
+        (Fmt.option pp_key) network
+        modname
+        (opt_key "gateway") gateway
+        mclock etif arp
+      | _ -> failwith (connect_err "ipv4 keyed" 4)
+  end
+
+let dhcp_conf = impl @@ object
+    inherit base_configurable
+    method ty = time @-> network @-> Mirage_impl_dhcp.dhcp
+    method name = "dhcp_client"
+    method module_name = "Dhcp_client_mirage.Make"
+    method! packages = Key.pure [ package ~min:"0.10" "charrua-client-mirage" ]
+    method! connect _ modname = function
+      | [ _time; network ] -> Fmt.strf "%s.connect %s " modname network
+      | _ -> failwith (connect_err "dhcp" 2)
+  end
+
+let ipv4_dhcp_conf = impl @@ object
+    inherit base_configurable
+    method ty = Mirage_impl_dhcp.dhcp @-> random @-> mclock @-> ethernet @-> arpv4 @-> ipv4
+    method name = Name.create "dhcp_ipv4" ~prefix:"dhcp_ipv4"
+    method module_name = "Dhcp_ipv4.Make"
+    method! packages = Key.pure [ package "charrua-client-mirage" ]
+    method! connect _ modname = function
+      | [ dhcp ; _random ; mclock ; ethernet ; arp ] ->
+        Fmt.strf "%s.connect@[@ %s@ %s@ %s@ %s@]"
+          modname dhcp mclock ethernet arp
+      | _ -> failwith (connect_err "ipv4 dhcp" 5)
+  end
+
+
+let dhcp time net = dhcp_conf $ time $ net
+let ipv4_of_dhcp
+    ?(random = default_random)
+    ?(clock = default_monotonic_clock) dhcp ethif arp =
+  ipv4_dhcp_conf $ dhcp $ random $ clock $ ethif $ arp
+
+let create_ipv4 ?group ?config
+    ?(random = default_random) ?(clock = default_monotonic_clock) etif arp =
+  let config = match config with
+  | None ->
+    let network = Ipaddr.V4.Prefix.of_address_string_exn "10.0.0.2/24"
+    and gateway = Some (Ipaddr.V4.of_string_exn "10.0.0.1")
+    in
+    { network; gateway }
+  | Some config -> config
+  in
+  let network = Key.V4.network ?group config.network
+  and gateway = Key.V4.gateway ?group config.gateway
+  in
+  ipv4_keyed_conf ~network ~gateway () $ random $ clock $ etif $ arp
+
+type ipv6_config = {
+  addresses: Ipaddr.V6.t list;
+  netmasks: Ipaddr.V6.Prefix.t list;
+  gateways: Ipaddr.V6.t list;
+}
+(** Types for IP manual configuration. *)
+
+let ipv4_qubes_conf = impl @@ object
+    inherit base_configurable
+    method ty = qubesdb @-> random @-> mclock @-> ethernet @-> arpv4 @-> ipv4
+    method name = Name.create "qubes_ipv4" ~prefix:"qubes_ipv4"
+    method module_name = "Qubesdb_ipv4.Make"
+    method! packages = Key.pure [ package ~min:"0.6" "mirage-qubes-ipv4" ]
+    method! connect _ modname = function
+      | [  db ; _random ; mclock ;etif; arp ] ->
+        Fmt.strf "%s.connect@[@ %s@ %s@ %s@ %s@]" modname db mclock etif arp
+      | _ -> failwith (connect_err "qubes ipv4" 5)
+  end
+
+let ipv4_qubes
+    ?(random = default_random)
+    ?(clock = default_monotonic_clock) db ethernet arp =
+  ipv4_qubes_conf $ db $ random $ clock $ ethernet $ arp
+
+let ipv6_conf ?addresses ?netmasks ?gateways () = impl @@ object
+    inherit base_configurable
+    method ty = ethernet @-> random @-> time @-> mclock @-> ipv6
+    method name = Name.create "ipv6" ~prefix:"ipv6"
+    method module_name = "Ipv6.Make"
+    method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["ipv6"] "tcpip"
+    method! keys = addresses @?? netmasks @?? gateways @?? []
+    method! connect _ modname = function
+      | [ etif ; _random ; _time ; clock ] ->
+        Fmt.strf "%s.connect@[@ %a@ %a@ %a@ %s@ %s@]"
+          modname
+          (opt_key "ip") addresses
+          (opt_key "netmask") netmasks
+          (opt_key "gateways") gateways
+          etif clock
+      | _ -> failwith (connect_err "ipv6" 3)
+  end
+
+let create_ipv6
+    ?(random = default_random)
+    ?(time = default_time)
+    ?(clock = default_monotonic_clock)
+    ?group etif { addresses ; netmasks ; gateways } =
+  let addresses = Key.V6.ips ?group addresses in
+  let netmasks = Key.V6.netmasks ?group netmasks in
+  let gateways = Key.V6.gateways ?group gateways in
+  ipv6_conf ~addresses ~netmasks ~gateways () $ etif $ random $ time $ clock

--- a/lib/mirage_impl_ip.mli
+++ b/lib/mirage_impl_ip.mli
@@ -1,0 +1,76 @@
+open Functoria
+open Mirage_impl_arpv4
+open Mirage_impl_ethernet
+open Mirage_impl_mclock
+open Mirage_impl_network
+open Mirage_impl_qubesdb
+open Mirage_impl_random
+
+type v4
+
+type v6
+
+type 'a ip
+
+type ipv4 = v4 ip
+
+type ipv6 = v6 ip
+
+val ip : 'a ip Functoria.typ
+
+val ipv4 : ipv4 Functoria.typ
+
+val ipv6 : ipv6 Functoria.typ
+
+type ipv4_config =
+  {network: Ipaddr.V4.Prefix.t * Ipaddr.V4.t; gateway: Ipaddr.V4.t option}
+
+type ipv6_config =
+  { addresses: Ipaddr.V6.t list
+  ; netmasks: Ipaddr.V6.Prefix.t list
+  ; gateways: Ipaddr.V6.t list }
+
+val create_ipv4 :
+     ?group:string
+  -> ?config:ipv4_config
+  -> ?random:random impl
+  -> ?clock:mclock impl
+  -> ethernet impl
+  -> arpv4 impl
+  -> ipv4 impl
+
+val create_ipv6 :
+     ?random:random impl
+  -> ?time:Mirage_impl_time.time impl
+  -> ?clock:mclock impl
+  -> ?group:string
+  -> ethernet impl
+  -> ipv6_config
+  -> ipv6 impl
+
+val dhcp :
+  Mirage_impl_time.time impl -> network impl -> Mirage_impl_dhcp.dhcp impl
+
+val ipv4_of_dhcp :
+     ?random:random impl
+  -> ?clock:mclock impl
+  -> Mirage_impl_dhcp.dhcp impl
+  -> ethernet impl
+  -> arpv4 impl
+  -> ipv4 impl
+
+val ipv4_qubes :
+     ?random:random impl
+  -> ?clock:mclock impl
+  -> qubesdb impl
+  -> ethernet impl
+  -> arpv4 impl
+  -> ipv4 impl
+
+val right_tcpip_library :
+     ?min:string
+  -> ?max:string
+  -> ?ocamlfind:string list
+  -> sublibs:string list
+  -> string
+  -> package list value

--- a/lib/mirage_impl_kv_ro.ml
+++ b/lib/mirage_impl_kv_ro.ml
@@ -1,0 +1,53 @@
+open Functoria
+module Name = Functoria_app.Name
+module Key = Mirage_key
+open Rresult
+open Astring
+
+type kv_ro = KV_RO
+let kv_ro = Type KV_RO
+
+let crunch dirname = impl @@ object
+    inherit base_configurable
+    method ty = kv_ro
+    val name = Name.create ("static" ^ dirname) ~prefix:"static"
+    method name = name
+    method module_name = String.Ascii.capitalize name
+    method! packages =
+      Key.pure [ package "io-page"; package ~min:"2.0.0" ~build:true "crunch" ]
+    method! deps = [ abstract Mirage_impl_io_page.default_io_page ]
+    method! connect _ modname _ = Fmt.strf "%s.connect ()" modname
+    method! build _i =
+      let dir = Fpath.(v dirname) in
+      let file = Fpath.(v name + "ml") in
+      Bos.OS.Path.exists dir >>= function
+      | true ->
+        Mirage_impl_misc.Log.info (fun m -> m "Generating: %a" Fpath.pp file);
+        Bos.OS.Cmd.run Bos.Cmd.(v "ocaml-crunch" % "-o" % p file % p dir)
+      | false ->
+        R.error_msg (Fmt.strf "The directory %s does not exist." dirname)
+    method! clean _i =
+      Bos.OS.File.delete Fpath.(v name + "ml") >>= fun () ->
+      Bos.OS.File.delete Fpath.(v name + "mli")
+  end
+
+let direct_kv_ro_conf dirname = impl @@ object
+    inherit base_configurable
+    method ty = kv_ro
+    val name = Name.create ("direct" ^ dirname) ~prefix:"direct"
+    method name = name
+    method module_name = "Kvro_fs_unix"
+    method! packages = Key.pure [ package ~min:"1.3.0" "mirage-fs-unix" ]
+    method! connect i _modname _names =
+      let path = Fpath.(Info.build_dir i / dirname) in
+      Fmt.strf "Kvro_fs_unix.connect \"%a\"" Fpath.pp path
+  end
+
+let direct_kv_ro dirname =
+  match_impl Key.(value target) [
+    `Xen, crunch dirname;
+    `Qubes, crunch dirname;
+    `Virtio, crunch dirname;
+    `Hvt, crunch dirname;
+    `Muen, crunch dirname
+  ] ~default:(direct_kv_ro_conf dirname)

--- a/lib/mirage_impl_kv_ro.mli
+++ b/lib/mirage_impl_kv_ro.mli
@@ -1,0 +1,7 @@
+type kv_ro
+
+val kv_ro : kv_ro Functoria.typ
+
+val direct_kv_ro : string -> kv_ro Functoria.impl
+
+val crunch : string -> kv_ro Functoria.impl

--- a/lib/mirage_impl_mclock.ml
+++ b/lib/mirage_impl_mclock.ml
@@ -1,0 +1,18 @@
+open Functoria
+
+type mclock = MCLOCK
+let mclock = Type MCLOCK
+
+let monotonic_clock_conf = object
+  inherit base_configurable
+  method ty = mclock
+  method name = "mclock"
+  method module_name = "Mclock"
+  method! packages =
+    Mirage_key.(if_ is_unix)
+      [ package ~min:"1.2.0" "mirage-clock-unix" ]
+      [ package ~min:"1.2.0" "mirage-clock-freestanding" ]
+  method! connect _ modname _args = Fmt.strf "%s.connect ()" modname
+end
+
+let default_monotonic_clock = impl monotonic_clock_conf

--- a/lib/mirage_impl_mclock.mli
+++ b/lib/mirage_impl_mclock.mli
@@ -1,0 +1,5 @@
+type mclock
+
+val mclock : mclock Functoria.typ
+
+val default_monotonic_clock : mclock Functoria.impl

--- a/lib/mirage_impl_misc.ml
+++ b/lib/mirage_impl_misc.ml
@@ -1,0 +1,30 @@
+let src = Logs.Src.create "mirage" ~doc:"mirage cli tool"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let get_target i = Mirage_key.(get (Functoria.Info.context i) target)
+
+let connect_err name number =
+  Fmt.strf "The %s connect expects exactly %d argument%s"
+    name number (if number = 1 then "" else "s")
+
+let with_output ?mode f k err =
+  match Bos.OS.File.with_oc ?mode f k () with
+  | Ok b -> b
+  | Error _ -> Rresult.R.error_msg ("couldn't open output channel for " ^ err)
+
+let pp_key fmt k = Mirage_key.serialize_call fmt (Mirage_key.abstract k)
+
+let query_ocamlfind ?(recursive = false) ?(format="%p") ?predicates libs =
+  let open Bos in
+  let flag = if recursive then (Cmd.v "-recursive") else Cmd.empty
+  and format = Cmd.of_list [ "-format" ; format ]
+  and predicate = match predicates with
+    | None -> []
+    | Some x -> [ "-predicates" ; x ]
+  and q = "query"
+  in
+  let cmd =
+    Cmd.(v "ocamlfind" % q %% flag %% format %% of_list predicate %% of_list libs)
+  in
+  let open Rresult in
+  OS.Cmd.run_out cmd |> OS.Cmd.out_lines >>| fst

--- a/lib/mirage_impl_misc.mli
+++ b/lib/mirage_impl_misc.mli
@@ -1,0 +1,21 @@
+module Log : Logs.LOG
+
+val get_target : Functoria.Info.t -> Mirage_key.mode
+
+val connect_err : string -> int -> string
+
+val with_output :
+     ?mode:int
+  -> Fpath.t
+  -> (out_channel -> unit -> ('a, ([> Rresult.R.msg] as 'b)) result)
+  -> string
+  -> ('a, 'b) result
+
+val pp_key : Format.formatter -> 'a Functoria_key.key -> unit
+
+val query_ocamlfind :
+     ?recursive:bool
+  -> ?format:string
+  -> ?predicates:string
+  -> string list
+  -> (string list, [> Rresult.R.msg]) result

--- a/lib/mirage_impl_network.ml
+++ b/lib/mirage_impl_network.ml
@@ -1,0 +1,37 @@
+open Functoria
+module Key = Mirage_key
+
+type network = NETWORK
+let network = Type NETWORK
+
+let all_networks = ref []
+
+let network_conf (intf : string Key.key) =
+  let key = Key.abstract intf in
+  object
+    inherit base_configurable
+    method ty = network
+    val name = Functoria_app.Name.create "net" ~prefix:"net"
+    method name = name
+    method module_name = "Netif"
+    method! keys = [ key ]
+    method! packages =
+      Key.match_ Key.(value target) @@ function
+      | `Unix -> [ package ~min:"2.3.0" "mirage-net-unix" ]
+      | `MacOSX -> [ package ~min:"1.3.0" "mirage-net-macosx" ]
+      | `Xen -> [ package ~min:"1.7.0" "mirage-net-xen"]
+      | `Qubes -> [ package ~min:"1.7.0" "mirage-net-xen" ; package ~min:"0.4" "mirage-qubes" ]
+      | `Virtio | `Hvt | `Muen -> [ package ~min:"0.3.0" "mirage-net-solo5" ]
+    method! connect _ modname _ =
+      Fmt.strf "%s.connect %a" modname Key.serialize_call key
+    method! configure i =
+      all_networks := Key.get (Info.context i) intf :: !all_networks;
+      Rresult.R.ok ()
+  end
+
+let netif ?group dev = impl (network_conf @@ Key.interface ?group dev)
+let default_network =
+  match_impl Key.(value target) [
+    `Unix   , netif "tap0";
+    `MacOSX , netif "tap0";
+  ] ~default:(netif "0")

--- a/lib/mirage_impl_network.mli
+++ b/lib/mirage_impl_network.mli
@@ -1,0 +1,9 @@
+type network
+
+val network : network Functoria.typ
+
+val netif : ?group:string -> string -> network Functoria.impl
+
+val default_network : network Functoria.impl
+
+val all_networks : string list ref

--- a/lib/mirage_impl_pclock.ml
+++ b/lib/mirage_impl_pclock.ml
@@ -1,0 +1,18 @@
+open Functoria
+
+type pclock = PCLOCK
+let pclock = Type PCLOCK
+
+let posix_clock_conf = object
+  inherit base_configurable
+  method ty = pclock
+  method name = "pclock"
+  method module_name = "Pclock"
+  method! packages =
+    Mirage_key.(if_ is_unix)
+      [ package ~min:"1.2.0" "mirage-clock-unix" ]
+      [ package ~min:"1.2.0" "mirage-clock-freestanding" ]
+  method! connect _ modname _args = Fmt.strf "%s.connect ()" modname
+end
+
+let default_posix_clock = impl posix_clock_conf

--- a/lib/mirage_impl_pclock.mli
+++ b/lib/mirage_impl_pclock.mli
@@ -1,0 +1,5 @@
+type pclock
+
+val pclock : pclock Functoria.typ
+
+val default_posix_clock : pclock Functoria.impl

--- a/lib/mirage_impl_qrexec.ml
+++ b/lib/mirage_impl_qrexec.ml
@@ -1,0 +1,28 @@
+open Functoria
+module Name = Functoria_app.Name
+module Key = Mirage_key
+open Rresult
+
+let qrexec = job
+
+let qrexec_qubes = impl @@ object
+  inherit base_configurable
+  method ty = qrexec
+  val name = Name.ocamlify @@ "qrexec_"
+  method name = name
+  method module_name = "Qubes.RExec"
+  method! packages = Key.pure [ package ~min:"0.4" "mirage-qubes" ]
+  method! configure i =
+    match Mirage_impl_misc.get_target i with
+    | `Qubes -> R.ok ()
+    | _ -> R.error_msg "Qubes remote-exec invoked for non-Qubes target."
+  method! connect _ modname _args =
+    Fmt.strf
+      "@[<v 2>\
+       %s.connect ~domid:0 () >>= fun qrexec ->@ \
+       Lwt.async (fun () ->@ \
+       OS.Lifecycle.await_shutdown_request () >>= fun _ ->@ \
+       %s.disconnect qrexec);@ \
+       Lwt.return (`Ok qrexec)@]"
+      modname modname
+end

--- a/lib/mirage_impl_qrexec.mli
+++ b/lib/mirage_impl_qrexec.mli
@@ -1,0 +1,1 @@
+val qrexec_qubes : Functoria.job Functoria.impl

--- a/lib/mirage_impl_qubesdb.ml
+++ b/lib/mirage_impl_qubesdb.ml
@@ -1,0 +1,22 @@
+open Functoria
+module Key = Mirage_key
+open Mirage_impl_misc
+open Rresult
+
+type qubesdb = QUBES_DB
+let qubesdb = Type QUBES_DB
+
+let qubesdb_conf = object
+  inherit base_configurable
+  method ty = qubesdb
+  method name = "qubesdb"
+  method module_name = "Qubes.DB"
+  method! packages = Key.pure [ package ~min:"0.4" "mirage-qubes" ]
+  method! configure i =
+    match get_target i with
+    | `Qubes | `Xen -> R.ok ()
+    | _ -> R.error_msg "Qubes DB invoked for an unsupported target; qubes and xen are supported"
+  method! connect _ modname _args = Fmt.strf "%s.connect ~domid:0 ()" modname
+end
+
+let default_qubesdb = impl qubesdb_conf

--- a/lib/mirage_impl_qubesdb.mli
+++ b/lib/mirage_impl_qubesdb.mli
@@ -1,0 +1,5 @@
+type qubesdb
+
+val qubesdb : qubesdb Functoria.typ
+
+val default_qubesdb : qubesdb Functoria.impl

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -1,0 +1,63 @@
+open Functoria
+
+type random = RANDOM
+let random = Type RANDOM
+
+let stdlib_random_conf = object
+  inherit base_configurable
+  method ty = random
+  method name = "random"
+  method module_name = "Stdlibrandom"
+  method! packages = Mirage_key.pure [ package "mirage-random" ]
+  method! connect _ modname _ = Fmt.strf "Lwt.return (%s.initialize ())" modname
+end
+
+let stdlib_random = impl stdlib_random_conf
+
+(* This is to check that entropy is a dependency if "tls" is in
+   the package array. *)
+let enable_entropy, is_entropy_enabled =
+  let r = ref false in
+  let f () = r := true in
+  let g () = !r in
+  (f, g)
+
+let nocrypto = impl @@ object
+    inherit base_configurable
+    method ty = job
+    method name = "nocrypto"
+    method module_name = "Nocrypto_entropy"
+    method! packages =
+      Mirage_key.match_ Mirage_key.(value target) @@ function
+      | `Xen | `Qubes ->
+        [ package ~min:"0.5.4" ~sublibs:["mirage"] "nocrypto";
+          package ~ocamlfind:[] "zarith-xen" ]
+      | `Virtio | `Hvt | `Muen ->
+        [ package ~min:"0.5.4" ~sublibs:["mirage"] "nocrypto";
+          package ~ocamlfind:[] "zarith-freestanding" ]
+      | `Unix | `MacOSX ->
+        [ package ~min:"0.5.4" ~sublibs:["lwt"] "nocrypto" ]
+
+    method! build _ = Rresult.R.ok (enable_entropy ())
+    method! connect i _ _ =
+      match Mirage_impl_misc.get_target i with
+      | `Xen | `Qubes | `Virtio | `Hvt | `Muen -> "Nocrypto_entropy_mirage.initialize ()"
+      | `Unix | `MacOSX -> "Nocrypto_entropy_lwt.initialize ()"
+  end
+
+let nocrypto_random_conf = object
+  inherit base_configurable
+  method ty = random
+  method name = "random"
+  method module_name = "Nocrypto.Rng"
+  method! packages = Mirage_key.pure [ package ~min:"0.5.4" "nocrypto" ]
+  method! deps = [abstract nocrypto]
+end
+
+let nocrypto_random = impl nocrypto_random_conf
+
+let default_random =
+  match_impl (Mirage_key.value @@ Mirage_key.prng ()) [
+    `Stdlib  , stdlib_random;
+    `Nocrypto, nocrypto_random;
+  ] ~default:stdlib_random

--- a/lib/mirage_impl_random.mli
+++ b/lib/mirage_impl_random.mli
@@ -1,0 +1,13 @@
+type random
+
+val random : random Functoria.typ
+
+val stdlib_random : random Functoria.impl
+
+val default_random : random Functoria.impl
+
+val nocrypto : Functoria.job Functoria.impl
+
+val nocrypto_random : random Functoria.impl
+
+val is_entropy_enabled : unit -> bool

--- a/lib/mirage_impl_reporter.ml
+++ b/lib/mirage_impl_reporter.ml
@@ -1,0 +1,52 @@
+open Functoria
+module Key = Mirage_key
+open Mirage_impl_pclock
+open Mirage_impl_misc
+
+type reporter = job
+let reporter = job
+
+let pp_level ppf = function
+  | Logs.Error    -> Fmt.string ppf "Logs.Error"
+  | Logs.Warning  -> Fmt.string ppf "Logs.Warning"
+  | Logs.Info     -> Fmt.string ppf "Logs.Info"
+  | Logs.Debug    -> Fmt.string ppf "Logs.Debug"
+  | Logs.App      -> Fmt.string ppf "Logs.App"
+
+let mirage_log ?ring_size ~default =
+  let logs = Key.logs in
+  impl @@ object
+    inherit base_configurable
+    method ty = pclock @-> reporter
+    method name = "mirage_logs"
+    method module_name = "Mirage_logs.Make"
+    method! packages = Key.pure [ package ~min:"0.3.0" "mirage-logs"]
+    method! keys = [ Key.abstract logs ]
+    method! connect _ modname = function
+      | [ pclock ] ->
+        Fmt.strf
+          "@[<v 2>\
+           let ring_size = %a in@ \
+           let reporter = %s.create ?ring_size %s in@ \
+           Mirage_runtime.set_level ~default:%a %a;@ \
+           %s.set_reporter reporter;@ \
+           Lwt.return reporter"
+          Fmt.(Dump.option int) ring_size
+          modname pclock
+          pp_level default
+          pp_key logs
+          modname
+    | _ -> failwith (connect_err "log" 1)
+  end
+
+let default_reporter
+    ?(clock=default_posix_clock) ?ring_size ?(level=Logs.Info) () =
+  mirage_log ?ring_size ~default:level $ clock
+
+let no_reporter = impl @@ object
+    inherit base_configurable
+    method ty = reporter
+    method name = "no_reporter"
+    method module_name = "Mirage_runtime"
+    method! connect _ _ _ = "assert false"
+  end

--- a/lib/mirage_impl_reporter.mli
+++ b/lib/mirage_impl_reporter.mli
@@ -1,0 +1,12 @@
+type reporter = Functoria.job
+
+val reporter : reporter Functoria.typ
+
+val default_reporter :
+     ?clock:Mirage_impl_pclock.pclock Functoria.impl
+  -> ?ring_size:int
+  -> ?level:Logs.level
+  -> unit
+  -> reporter Functoria.impl
+
+val no_reporter : reporter Functoria.impl

--- a/lib/mirage_impl_resolver.ml
+++ b/lib/mirage_impl_resolver.ml
@@ -1,0 +1,54 @@
+open Functoria
+module Key = Mirage_key
+open Mirage_impl_misc
+open Mirage_impl_time
+open Mirage_impl_stackv4
+open Rresult
+
+type resolver = Resolver
+let resolver = Type Resolver
+
+let resolver_unix_system = impl @@ object
+    inherit base_configurable
+    method ty = resolver
+    method name = "resolver_unix"
+    method module_name = "Resolver_lwt"
+    method! packages =
+      Key.(if_ is_unix)
+        [ package ~min:"3.1.0" ~ocamlfind:[] "mirage-conduit" ;
+          package ~min:"1.0.0" "conduit-lwt-unix"; ]
+        []
+    method! configure i =
+      match get_target i with
+      | `Unix | `MacOSX -> R.ok ()
+      | _ -> R.error_msg "Unix resolver not supported on non-UNIX targets."
+    method! connect _ _modname _ = "Lwt.return Resolver_lwt_unix.system"
+  end
+
+let meta_ipv4 ppf s =
+  Fmt.pf ppf "(Ipaddr.V4.of_string_exn %S)" (Ipaddr.V4.to_string s)
+
+let resolver_dns_conf ~ns ~ns_port = impl @@ object
+    inherit base_configurable
+    method ty = time @-> stackv4 @-> resolver
+    method name = "resolver"
+    method module_name = "Resolver_mirage.Make_with_stack"
+    method! packages =
+      Key.pure [
+        package ~min:"3.0.1" "mirage-conduit" ;
+      ]
+    method! connect _ modname = function
+      | [ _t ; stack ] ->
+        let meta_ns = Fmt.Dump.option meta_ipv4 in
+        let meta_port = Fmt.(Dump.option int) in
+        Fmt.strf
+          "let ns = %a in@;\
+           let ns_port = %a in@;\
+           let res = %s.R.init ?ns ?ns_port ~stack:%s () in@;\
+           Lwt.return res@;"
+          meta_ns ns meta_port ns_port modname stack
+      | _ -> failwith (connect_err "resolver" 2)
+  end
+
+let resolver_dns ?ns ?ns_port ?(time = default_time) stack =
+  resolver_dns_conf ~ns ~ns_port $ time $ stack

--- a/lib/mirage_impl_resolver.mli
+++ b/lib/mirage_impl_resolver.mli
@@ -1,0 +1,12 @@
+type resolver
+
+val resolver : resolver Functoria.typ
+
+val resolver_dns :
+     ?ns:Ipaddr.V4.t
+  -> ?ns_port:int
+  -> ?time:Mirage_impl_time.time Functoria.impl
+  -> Mirage_impl_stackv4.stackv4 Functoria.impl
+  -> resolver Functoria.impl
+
+val resolver_unix_system : resolver Functoria.impl

--- a/lib/mirage_impl_stackv4.ml
+++ b/lib/mirage_impl_stackv4.ml
@@ -1,0 +1,112 @@
+module Key = Mirage_key
+open Functoria
+open Mirage_impl_arpv4
+open Mirage_impl_ethernet
+open Mirage_impl_ip
+open Mirage_impl_mclock
+open Mirage_impl_misc
+open Mirage_impl_network
+open Mirage_impl_qubesdb
+open Mirage_impl_random
+open Mirage_impl_tcp
+open Mirage_impl_time
+open Mirage_impl_udp
+
+type stackv4 = STACKV4
+let stackv4 = Type STACKV4
+
+let add_suffix s ~suffix = if suffix = "" then s else s^"_"^suffix
+
+let stackv4_direct_conf ?(group="") () = impl @@ object
+    inherit base_configurable
+    method ty =
+      time @-> random @-> network @->
+      ethernet @-> arpv4 @-> ipv4 @-> Mirage_impl_icmp.icmpv4 @-> udpv4 @-> tcpv4 @->
+      stackv4
+    val name = add_suffix "stackv4_" ~suffix:group
+    method name = name
+    method module_name = "Tcpip_stack_direct.Make"
+    method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["stack-direct"] "tcpip" ]
+    method! connect _i modname = function
+      | [ _t; _r; interface; ethif; arp; ip; icmp; udp; tcp ] ->
+        Fmt.strf
+          "%s.connect %s %s %s %s %s %s %s"
+          modname interface ethif arp ip icmp udp tcp
+      | _ -> failwith (connect_err "direct stackv4" 9)
+  end
+
+let direct_stackv4
+    ?(clock=default_monotonic_clock)
+    ?(random=default_random)
+    ?(time=default_time)
+    ?group
+    network eth arp ip =
+  stackv4_direct_conf ?group ()
+  $ time $ random $ network
+  $ eth $ arp $ ip
+  $ Mirage_impl_icmp.direct_icmpv4 ip
+  $ direct_udp ~random ip
+  $ direct_tcp ~clock ~random ~time ip
+
+let dhcp_ipv4_stack ?group ?(time = default_time) ?(arp = arp ?clock:None ?time:None) tap =
+  let config = dhcp time tap in
+  let e = etif tap in
+  let a = arp e in
+  let i = ipv4_of_dhcp config e a in
+  direct_stackv4 ?group tap e a i
+
+let static_ipv4_stack ?group ?config ?(arp = arp ?clock:None ?time:None) tap =
+  let e = etif tap in
+  let a = arp e in
+  let i = create_ipv4 ?group ?config e a in
+  direct_stackv4 ?group tap e a i
+
+let qubes_ipv4_stack ?group ?(qubesdb = default_qubesdb) ?(arp = arp ?clock:None ?time:None) tap =
+  let e = etif tap in
+  let a = arp e in
+  let i = ipv4_qubes qubesdb e a in
+  direct_stackv4 ?group tap e a i
+
+let stackv4_socket_conf ?(group="") ips = impl @@ object
+    inherit base_configurable
+    method ty = stackv4
+    val name = add_suffix "stackv4_socket" ~suffix:group
+    method name = name
+    method module_name = "Tcpip_stack_socket"
+    method! keys = [ Key.abstract ips ]
+    method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["stack-socket"; "unix"] "tcpip" ]
+    method! deps = [abstract (socket_udpv4 None); abstract (socket_tcpv4 None)]
+    method! connect _i modname = function
+      | [ udpv4 ; tcpv4 ] ->
+        Fmt.strf
+          "%s.connect %a %s %s"
+          modname pp_key ips udpv4 tcpv4
+      | _ -> failwith (connect_err "socket stack" 2)
+  end
+
+let socket_stackv4 ?group ipv4s =
+  stackv4_socket_conf ?group (Key.V4.ips ?group ipv4s)
+
+(** Generic stack *)
+
+let generic_stackv4
+    ?group ?config
+    ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
+    ?(net_key = Key.value @@ Key.net ?group ())
+    (tap : network impl) : stackv4 impl =
+  let eq a b = Key.(pure ((=) a) $ b) in
+  let choose qubes socket dhcp =
+    if qubes then `Qubes
+    else if socket then `Socket
+    else if dhcp then `Dhcp
+    else `Static
+  in
+  let p = Functoria_key.((pure choose)
+          $ eq `Qubes Key.(value target)
+          $ eq `Socket net_key
+          $ eq true dhcp_key) in
+  match_impl p [
+    `Dhcp, dhcp_ipv4_stack ?group tap;
+    `Socket, socket_stackv4 ?group [Ipaddr.V4.any];
+    `Qubes, qubes_ipv4_stack ?group tap;
+  ] ~default:(static_ipv4_stack ?config ?group tap)

--- a/lib/mirage_impl_stackv4.mli
+++ b/lib/mirage_impl_stackv4.mli
@@ -1,0 +1,49 @@
+type stackv4
+
+val stackv4 : stackv4 Functoria.typ
+
+val direct_stackv4 :
+     ?clock:Mirage_impl_mclock.mclock Functoria.impl
+  -> ?random:Mirage_impl_random.random Functoria.impl
+  -> ?time:Mirage_impl_time.time Functoria.impl
+  -> ?group:string
+  -> Mirage_impl_network.network Functoria.impl
+  -> Mirage_impl_ethernet.ethernet Functoria.impl
+  -> Mirage_impl_arpv4.arpv4 Functoria.impl
+  -> Mirage_impl_ip.ipv4 Functoria.impl
+  -> stackv4 Functoria.impl
+
+val socket_stackv4 :
+  ?group:string -> Ipaddr.V4.t list -> stackv4 Functoria.impl
+
+val qubes_ipv4_stack :
+     ?group:string
+  -> ?qubesdb:Mirage_impl_qubesdb.qubesdb Functoria.impl
+  -> ?arp:(   Mirage_impl_ethernet.ethernet Functoria.impl
+           -> Mirage_impl_arpv4.arpv4 Functoria.impl)
+  -> Mirage_impl_network.network Functoria.impl
+  -> stackv4 Functoria.impl
+
+val dhcp_ipv4_stack :
+     ?group:string
+  -> ?time:Mirage_impl_time.time Functoria.impl
+  -> ?arp:(   Mirage_impl_ethernet.ethernet Functoria.impl
+           -> Mirage_impl_arpv4.arpv4 Functoria.impl)
+  -> Mirage_impl_network.network Functoria.impl
+  -> stackv4 Functoria.impl
+
+val static_ipv4_stack :
+     ?group:string
+  -> ?config:Mirage_impl_ip.ipv4_config
+  -> ?arp:(   Mirage_impl_ethernet.ethernet Functoria.impl
+           -> Mirage_impl_arpv4.arpv4 Functoria.impl)
+  -> Mirage_impl_network.network Functoria.impl
+  -> stackv4 Functoria.impl
+
+val generic_stackv4 :
+     ?group:string
+  -> ?config:Mirage_impl_ip.ipv4_config
+  -> ?dhcp_key:bool Functoria.value
+  -> ?net_key:[`Direct | `Socket] Functoria.value
+  -> Mirage_impl_network.network Functoria.impl
+  -> stackv4 Functoria.impl

--- a/lib/mirage_impl_syslog.ml
+++ b/lib/mirage_impl_syslog.ml
@@ -1,0 +1,138 @@
+module Key = Mirage_key
+open Functoria
+open Mirage_impl_console
+open Mirage_impl_kv_ro
+open Mirage_impl_misc
+open Mirage_impl_pclock
+open Mirage_impl_stackv4
+
+type syslog_config = {
+  hostname : string;
+  server   : Ipaddr.V4.t option;
+  port     : int option;
+  truncate : int option;
+}
+
+let syslog_config ?port ?truncate ?server hostname = {
+  hostname ; server ; port ; truncate
+}
+
+let default_syslog_config =
+  let hostname = "no_name"
+  and server = None
+  and port = None
+  and truncate = None
+  in
+  { hostname ; server ; port ; truncate }
+
+type syslog = SYSLOG
+let syslog = Type SYSLOG
+
+let opt p s = Fmt.(option @@ prefix (unit ("~"^^s^^":")) p)
+let opt_int = opt Fmt.int
+let opt_string = opt (fun pp v -> Format.fprintf pp "%S" v)
+
+let syslog_udp_conf config =
+  let endpoint = Key.syslog config.server
+  and port = Key.syslog_port config.port
+  and hostname = Key.syslog_hostname config.hostname
+  in
+  impl @@ object
+    inherit base_configurable
+    method ty = console @-> pclock @-> stackv4 @-> syslog
+    method name = "udp_syslog"
+    method module_name = "Logs_syslog_mirage.Udp"
+    method! packages = Key.pure [ package ~min:"0.1.0" ~sublibs:["mirage"] "logs-syslog" ]
+    method! keys = [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
+    method! connect _i modname = function
+      | [ console ; pclock ; stack ] ->
+        Fmt.strf
+          "@[<v 2>\
+           match %a with@ \
+           | None -> Lwt.return_unit@ \
+           | Some server ->@ \
+             let port = %a in@ \
+             let reporter =@ \
+               %s.create %s %s %s ~hostname:%a ?port server %a ()@ \
+             in@ \
+             Logs.set_reporter reporter;@ \
+             Lwt.return_unit@]"
+          pp_key endpoint
+          pp_key port
+          modname console pclock stack
+          pp_key hostname
+          (opt_int "truncate") config.truncate
+      | _ -> failwith (connect_err "syslog udp" 3)
+  end
+
+let syslog_udp ?(config = default_syslog_config) ?(console = default_console) ?(clock = default_posix_clock) stack =
+  syslog_udp_conf config $ console $ clock $ stack
+
+let syslog_tcp_conf config =
+  let endpoint = Key.syslog config.server
+  and port = Key.syslog_port config.port
+  and hostname = Key.syslog_hostname config.hostname
+  in
+  impl @@ object
+    inherit base_configurable
+    method ty = console @-> pclock @-> stackv4 @-> syslog
+    method name = "tcp_syslog"
+    method module_name = "Logs_syslog_mirage.Tcp"
+    method! packages = Key.pure [ package ~min:"0.1.0" ~sublibs:["mirage"] "logs-syslog" ]
+    method! keys = [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
+    method! connect _i modname = function
+      | [ console ; pclock ; stack ] ->
+        Fmt.strf
+          "@[<v 2>\
+           match %a with@ \
+           | None -> Lwt.return_unit@ \
+           | Some server ->@ \
+             let port = %a in@ \
+             %s.create %s %s %s ~hostname:%a ?port server %a () >>= function@ \
+             | Ok reporter -> Logs.set_reporter reporter; Lwt.return_unit@ \
+             | Error e -> invalid_arg e@]"
+          pp_key endpoint
+          pp_key port
+          modname console pclock stack
+          pp_key hostname
+          (opt_int "truncate") config.truncate
+      | _ -> failwith (connect_err "syslog tcp" 3)
+  end
+
+let syslog_tcp ?(config = default_syslog_config) ?(console = default_console) ?(clock = default_posix_clock) stack =
+  syslog_tcp_conf config $ console $ clock $ stack
+
+let syslog_tls_conf ?keyname config =
+  let endpoint = Key.syslog config.server
+  and port = Key.syslog_port config.port
+  and hostname = Key.syslog_hostname config.hostname
+  in
+  impl @@ object
+    inherit base_configurable
+    method ty = console @-> pclock @-> stackv4 @-> kv_ro @-> syslog
+    method name = "tls_syslog"
+    method module_name = "Logs_syslog_mirage_tls.Tls"
+    method! packages = Key.pure [ package ~min:"0.1.0" ~sublibs:["mirage" ; "mirage.tls"] "logs-syslog" ]
+    method! keys = [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
+    method! connect _i modname = function
+      | [ console ; pclock ; stack ; kv ] ->
+        Fmt.strf
+          "@[<v 2>\
+           match %a with@ \
+           | None -> Lwt.return_unit@ \
+           | Some server ->@ \
+             let port = %a in@ \
+             %s.create %s %s %s %s ~hostname:%a ?port server %a %a () >>= function@ \
+             | Ok reporter -> Logs.set_reporter reporter; Lwt.return_unit@ \
+             | Error e -> invalid_arg e@]"
+          pp_key endpoint
+          pp_key port
+          modname console pclock stack kv
+          pp_key hostname
+          (opt_int "truncate") config.truncate
+          (opt_string "keyname") keyname
+      | _ -> failwith (connect_err "syslog tls" 4)
+  end
+
+let syslog_tls ?(config = default_syslog_config) ?keyname ?(console = default_console) ?(clock = default_posix_clock) stack kv =
+  syslog_tls_conf ?keyname config $ console $ clock $ stack $ kv

--- a/lib/mirage_impl_syslog.mli
+++ b/lib/mirage_impl_syslog.mli
@@ -1,0 +1,35 @@
+type syslog
+
+val syslog : syslog Functoria.typ
+
+type syslog_config =
+  { hostname: string
+  ; server: Ipaddr.V4.t option
+  ; port: int option
+  ; truncate: int option }
+
+val syslog_config :
+  ?port:int -> ?truncate:int -> ?server:Ipaddr.V4.t -> string -> syslog_config
+
+val syslog_udp :
+     ?config:syslog_config
+  -> ?console:Mirage_impl_console.console Functoria.impl
+  -> ?clock:Mirage_impl_pclock.pclock Functoria.impl
+  -> Mirage_impl_stackv4.stackv4 Functoria.impl
+  -> syslog Functoria.impl
+
+val syslog_tcp :
+     ?config:syslog_config
+  -> ?console:Mirage_impl_console.console Functoria.impl
+  -> ?clock:Mirage_impl_pclock.pclock Functoria.impl
+  -> Mirage_impl_stackv4.stackv4 Functoria.impl
+  -> syslog Functoria.impl
+
+val syslog_tls :
+     ?config:syslog_config
+  -> ?keyname:string
+  -> ?console:Mirage_impl_console.console Functoria.impl
+  -> ?clock:Mirage_impl_pclock.pclock Functoria.impl
+  -> Mirage_impl_stackv4.stackv4 Functoria.impl
+  -> Mirage_impl_kv_ro.kv_ro Functoria.impl
+  -> syslog Functoria.impl

--- a/lib/mirage_impl_tcp.ml
+++ b/lib/mirage_impl_tcp.ml
@@ -1,0 +1,56 @@
+module Key = Mirage_key
+module Name = Functoria_app.Name
+open Functoria
+open Mirage_impl_ip
+open Mirage_impl_mclock
+open Mirage_impl_misc
+open Mirage_impl_random
+open Mirage_impl_time
+open Rresult
+
+type 'a tcp = TCP
+type tcpv4 = v4 tcp
+type tcpv6 = v6 tcp
+
+let tcp = Type TCP
+let tcpv4 : tcpv4 typ = tcp
+let tcpv6 : tcpv6 typ = tcp
+
+(* Value restriction ... *)
+let tcp_direct_conf () = object
+  inherit base_configurable
+  method ty = (ip: 'a ip typ) @-> time @-> mclock @-> random @-> (tcp: 'a tcp typ)
+  method name = "tcp"
+  method module_name = "Tcp.Flow.Make"
+  method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["tcp"] "tcpip"
+  method! connect _ modname = function
+    | [ip; _time; clock; _random] -> Fmt.strf "%s.connect %s %s" modname ip clock
+    | _ -> failwith (connect_err "direct tcp" 4)
+end
+
+(* Value restriction ... *)
+let tcp_direct_func () = impl (tcp_direct_conf ())
+
+let direct_tcp
+    ?(clock=default_monotonic_clock)
+    ?(random=default_random)
+    ?(time=default_time) ip =
+  tcp_direct_func () $ ip $ time $ clock $ random
+
+let tcpv4_socket_conf ipv4_key = object
+  inherit base_configurable
+  method ty = tcpv4
+  val name = Name.create "tcpv4_socket" ~prefix:"tcpv4_socket"
+  method name = name
+  method module_name = "Tcpv4_socket"
+  method! keys = [ Key.abstract ipv4_key ]
+  method! packages =
+    Key.(if_ is_unix) [ package ~min:"3.5.0" ~sublibs:["tcpv4-socket"; "unix"] "tcpip" ] []
+  method! configure i =
+    match get_target i with
+    | `Unix | `MacOSX -> R.ok ()
+    | _  -> R.error_msg "TCPv4 socket not supported on non-UNIX targets."
+  method! connect _ modname _ = Fmt.strf "%s.connect %a" modname pp_key ipv4_key
+end
+
+let socket_tcpv4 ?group ip = impl (tcpv4_socket_conf @@ Key.V4.socket ?group ip)

--- a/lib/mirage_impl_tcp.mli
+++ b/lib/mirage_impl_tcp.mli
@@ -1,0 +1,20 @@
+type 'a tcp
+
+val tcp : 'a tcp Functoria.typ
+
+type tcpv4 = Mirage_impl_ip.v4 tcp
+
+type tcpv6 = Mirage_impl_ip.v6 tcp
+
+val tcpv4 : tcpv4 Functoria.typ
+
+val tcpv6 : tcpv6 Functoria.typ
+
+val direct_tcp :
+     ?clock:Mirage_impl_mclock.mclock Functoria.impl
+  -> ?random:Mirage_impl_random.random Functoria.impl
+  -> ?time:Mirage_impl_time.time Functoria.impl
+  -> 'a Mirage_impl_ip.ip Functoria.impl
+  -> 'a tcp Functoria.impl
+
+val socket_tcpv4 : ?group:string -> Ipaddr.V4.t option -> tcpv4 Functoria.impl

--- a/lib/mirage_impl_time.ml
+++ b/lib/mirage_impl_time.ml
@@ -1,0 +1,13 @@
+open Functoria
+
+type time = TIME
+let time = Type TIME
+
+let time_conf = object
+  inherit base_configurable
+  method ty = time
+  method name = "time"
+  method module_name = "OS.Time"
+end
+
+let default_time = impl time_conf

--- a/lib/mirage_impl_time.mli
+++ b/lib/mirage_impl_time.mli
@@ -1,0 +1,5 @@
+type time
+
+val time : time Functoria.typ
+
+val default_time : time Functoria.impl

--- a/lib/mirage_impl_tracing.ml
+++ b/lib/mirage_impl_tracing.ml
@@ -1,0 +1,51 @@
+module Key = Mirage_key
+open Functoria
+open Mirage_impl_misc
+open Rresult
+
+type tracing = job
+let tracing = job
+
+let mprof_trace ~size () =
+  let unix_trace_file = "trace.ctf" in
+  let key = Key.tracing_size size in
+  impl @@ object
+    inherit base_configurable
+    method ty = job
+    method name = "mprof_trace"
+    method module_name = "MProf"
+    method! keys = [ Key.abstract key ]
+    method! packages =
+      Key.match_ Key.(value target) @@ function
+      | `Xen | `Qubes -> [ package "mirage-profile"; package "mirage-profile-xen" ]
+      | `Virtio | `Hvt | `Muen -> []
+      | `Unix | `MacOSX -> [ package "mirage-profile"; package "mirage-profile-unix" ]
+    method! build _ =
+      match query_ocamlfind ["lwt.tracing"] with
+      | Error _ | Ok [] ->
+        R.error_msg "lwt.tracing module not found. Hint:\
+                     opam pin add lwt https://github.com/mirage/lwt.git#tracing"
+      | Ok _ -> Ok ()
+    method! connect i _ _ = match get_target i with
+      | `Virtio | `Hvt | `Muen -> failwith  "tracing is not currently implemented for solo5 targets"
+      | `Unix | `MacOSX ->
+        Fmt.strf
+          "Lwt.return ())@.\
+           let () = (@ \
+           @[<v 2> let buffer = MProf_unix.mmap_buffer ~size:%a %S in@ \
+           let trace_config = MProf.Trace.Control.make buffer MProf_unix.timestamper in@ \
+           MProf.Trace.Control.start trace_config@]"
+          Key.serialize_call (Key.abstract key)
+          unix_trace_file;
+      | `Xen | `Qubes ->
+        Fmt.strf
+          "Lwt.return ())@.\
+           let () = (@ \
+           @[<v 2> let trace_pages = MProf_xen.make_shared_buffer ~size:%a in@ \
+           let buffer = trace_pages |> Io_page.to_cstruct |> Cstruct.to_bigarray in@ \
+           let trace_config = MProf.Trace.Control.make buffer MProf_xen.timestamper in@ \
+           MProf.Trace.Control.start trace_config;@ \
+           MProf_xen.share_with (module Gnt.Gntshr) (module OS.Xs) ~domid:0 trace_pages@ \
+           |> OS.Main.run@]"
+          Key.serialize_call (Key.abstract key)
+  end

--- a/lib/mirage_impl_tracing.mli
+++ b/lib/mirage_impl_tracing.mli
@@ -1,0 +1,5 @@
+type tracing = Functoria.job
+
+val tracing : tracing Functoria.typ
+
+val mprof_trace : size:int -> unit -> tracing Functoria.impl

--- a/lib/mirage_impl_udp.ml
+++ b/lib/mirage_impl_udp.ml
@@ -1,0 +1,51 @@
+module Key = Mirage_key
+module Name = Functoria_app.Name
+open Functoria
+open Mirage_impl_ip
+open Mirage_impl_misc
+open Mirage_impl_random
+open Rresult
+
+type 'a udp = UDP
+type udpv4 = v4 udp
+type udpv6 = v6 udp
+
+let udp = Type UDP
+let udpv4: udpv4 typ = udp
+let udpv6: udpv6 typ = udp
+
+(* Value restriction ... *)
+let udp_direct_conf () = object
+  inherit base_configurable
+  method ty = (ip: 'a ip typ) @-> random @-> (udp: 'a udp typ)
+  method name = "udp"
+  method module_name = "Udp.Make"
+  method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["udp"] "tcpip"
+  method! connect _ modname = function
+    | [ ip; _random ] -> Fmt.strf "%s.connect %s" modname ip
+    | _  -> failwith (connect_err "udp" 2)
+end
+
+(* Value restriction ... *)
+let udp_direct_func () = impl (udp_direct_conf ())
+let direct_udp ?(random=default_random) ip = udp_direct_func () $ ip $ random
+
+let udpv4_socket_conf ipv4_key = object
+  inherit base_configurable
+  method ty = udpv4
+  val name = Name.create "udpv4_socket" ~prefix:"udpv4_socket"
+  method name = name
+  method module_name = "Udpv4_socket"
+  method! keys = [ Key.abstract ipv4_key ]
+  method! packages =
+    Key.(if_ is_unix)
+      [ package ~min:"3.5.0" ~sublibs:["udpv4-socket"; "unix"] "tcpip" ]
+      []
+  method! configure i =
+    match get_target i with
+    | `Unix | `MacOSX -> R.ok ()
+    | _ -> R.error_msg "UDPv4 socket not supported on non-UNIX targets."
+  method! connect _ modname _ = Fmt.strf "%s.connect %a" modname pp_key ipv4_key
+end
+
+let socket_udpv4 ?group ip = impl (udpv4_socket_conf @@ Key.V4.socket ?group ip)

--- a/lib/mirage_impl_udp.mli
+++ b/lib/mirage_impl_udp.mli
@@ -1,0 +1,16 @@
+type 'a udp
+
+val udp : 'a udp Functoria.typ
+
+type udpv4 = Mirage_impl_ip.v4 udp
+type udpv6 = Mirage_impl_ip.v6 udp
+
+val udpv4 : udpv4 Functoria.typ
+val udpv6 : udpv6 Functoria.typ
+
+val direct_udp :
+?random:Mirage_impl_random.random Functoria.impl -> 'a Mirage_impl_ip.ip
+Functoria.impl -> 'a udp Functoria.impl
+
+val socket_udpv4:
+?group:string -> Ipaddr.V4.t option -> udpv4 Functoria.impl


### PR DESCRIPTION
This creates several modules named `Mirage_impl_*`. The first part of `mirage.ml`, that deals with implementations, can be expressed as reexport of these modules.

There are two goals to that refactoring:
- `mirage.ml` becomes smaller
- details not relevant to `mirage.mli` can be exported there and tested. This will benefit to #928, #929, #930.

`mirage.mli` is not changed, so the public API is not broken.

Does that look like a good architecture? If that sounds OK I'll convert the other parts (ethernet, ARP, ip, etc).