### PR TITLE
Test fs module

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,7 @@
+break-cases=all
+break-infix=fit-or-vertical
+field-space=loose
+margin=79
+parens-tuple=always
+sequence-style=terminator
+type-decl=sparse

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
    - POST_INSTALL_HOOK="sh ./.travis-ci.sh"
    - PINS="mirage.dev:. mirage-types.dev:. mirage-types-lwt.dev:. mirage-runtime.dev:."
    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
-   - TESTS=false #testing via travis-ci.sh
  matrix:
    - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.04 EXTRA_ENV="MODE=xen"
    - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.04 EXTRA_ENV="MODE=hvt"

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -84,8 +84,8 @@ let ramdisk = Mirage_impl_block.ramdisk
 let block_of_xenstore_id = Mirage_impl_block.block_of_xenstore_id
 let block_of_file = Mirage_impl_block.block_of_file
 
-type fs = Mirage_impl_fs.fs
-let fs = Mirage_impl_fs.fs
+type fs = Mirage_impl_fs.t
+let fs = Mirage_impl_fs.typ
 let fat = Mirage_impl_fs.fat
 let fat_of_files = Mirage_impl_fs.fat_of_files
 let generic_kv_ro = Mirage_impl_fs.generic_kv_ro

--- a/lib/mirage_impl_fs.ml
+++ b/lib/mirage_impl_fs.ml
@@ -8,18 +8,29 @@ open Mirage_impl_misc
 open Rresult
 
 type fs = FS
+
 let fs = Type FS
 
-let fat_conf = impl @@ object
-    inherit base_configurable
-    method ty = (block @-> fs)
-    method! packages = Key.pure [ package ~min:"0.12.0" "fat-filesystem" ]
-    method name = "fat"
-    method module_name = "Fat.FS"
-    method! connect _ modname l = match l with
-      | [ block_name ] -> Fmt.strf "%s.connect %s" modname block_name
-      | _ -> failwith (connect_err "fat" 1)
-  end
+let fat_conf =
+  impl
+  @@ object
+       inherit base_configurable
+
+       method ty = block @-> fs
+
+       method! packages = Key.pure [package ~min:"0.12.0" "fat-filesystem"]
+
+       method name = "fat"
+
+       method module_name = "Fat.FS"
+
+       method! connect _ modname l =
+         match l with
+         | [block_name] ->
+             Fmt.strf "%s.connect %s" modname block_name
+         | _ ->
+             failwith (connect_err "fat" 1)
+     end
 
 let fat block = fat_conf $ block
 
@@ -27,14 +38,13 @@ let fat_shell_script fmt ~block_file ~root ~dir ~regexp =
   let open Functoria_app.Codegen in
   append fmt "#!/bin/sh";
   append fmt "";
-  append fmt "echo This uses the 'fat' command-line tool to \
-              build a simple FAT";
+  append fmt
+    "echo This uses the 'fat' command-line tool to build a simple FAT";
   append fmt "echo filesystem image.";
   append fmt "";
   append fmt "FAT=$(which fat)";
   append fmt "if [ ! -x \"${FAT}\" ]; then";
-  append fmt "  echo I couldn\\'t find the 'fat' command-line \
-              tool.";
+  append fmt "  echo I couldn\\'t find the 'fat' command-line tool.";
   append fmt "  echo Try running 'opam install fat-filesystem'";
   append fmt "  exit 1";
   append fmt "fi";
@@ -47,59 +57,74 @@ let fat_shell_script fmt ~block_file ~root ~dir ~regexp =
   append fmt "${FAT} add ${IMG} %s" regexp;
   append fmt "echo Created '%s'" block_file
 
-let fat_block ?(dir=".") ?(regexp="*") () =
+let fat_block ?(dir = ".") ?(regexp = "*") () =
   let name =
-    Name.(ocamlify @@ create (Fmt.strf "fat%s:%s" dir regexp) ~prefix:"fat_block")
+    Name.(
+      ocamlify @@ create (Fmt.strf "fat%s:%s" dir regexp) ~prefix:"fat_block")
   in
   let block_file = name ^ ".img" in
-  impl @@ object
-    inherit Mirage_impl_block.block_conf block_file as super
-    method! packages =
-      Key.map (List.cons (package ~min:"0.12.0" ~build:true "fat-filesystem")) super#packages
-    method! build i =
-      let root = Info.build_dir i in
-      let file = Fmt.strf "make-%s-image.sh" name in
-      let dir = Fpath.of_string dir |> R.error_msg_to_invalid_arg in
-      Log.info (fun m -> m "Generating block generator script: %s" file);
-      with_output ~mode:0o755 (Fpath.v file)
-        (fun oc () ->
-           let fmt = Format.formatter_of_out_channel oc in
-           fat_shell_script fmt ~block_file ~root ~dir ~regexp;
-           R.ok ())
-        "fat shell script" >>= fun () ->
-      Log.info (fun m -> m "Executing block generator script: ./%s" file);
-      Bos.OS.Cmd.run (Bos.Cmd.v ("./" ^ file)) >>= fun () ->
-      super#build i
+  impl
+  @@ object
+       inherit Mirage_impl_block.block_conf block_file as super
 
-    method! clean i =
-      let file = Fmt.strf "make-%s-image.sh" name in
-      Bos.OS.File.delete (Fpath.v file) >>= fun () ->
-      Bos.OS.File.delete (Fpath.v block_file) >>= fun () ->
-      super#clean i
-  end
+       method! packages =
+         Key.map
+           (List.cons (package ~min:"0.12.0" ~build:true "fat-filesystem"))
+           super#packages
+
+       method! build i =
+         let root = Info.build_dir i in
+         let file = Fmt.strf "make-%s-image.sh" name in
+         let dir = Fpath.of_string dir |> R.error_msg_to_invalid_arg in
+         Log.info (fun m -> m "Generating block generator script: %s" file);
+         with_output ~mode:0o755 (Fpath.v file)
+           (fun oc () ->
+             let fmt = Format.formatter_of_out_channel oc in
+             fat_shell_script fmt ~block_file ~root ~dir ~regexp;
+             R.ok () )
+           "fat shell script"
+         >>= fun () ->
+         Log.info (fun m -> m "Executing block generator script: ./%s" file);
+         Bos.OS.Cmd.run (Bos.Cmd.v ("./" ^ file)) >>= fun () -> super#build i
+
+       method! clean i =
+         let file = Fmt.strf "make-%s-image.sh" name in
+         Bos.OS.File.delete (Fpath.v file)
+         >>= fun () ->
+         Bos.OS.File.delete (Fpath.v block_file) >>= fun () -> super#clean i
+     end
 
 let fat_of_files ?dir ?regexp () = fat @@ fat_block ?dir ?regexp ()
 
+let kv_ro_of_fs_conf =
+  impl
+  @@ object
+       inherit base_configurable
 
-let kv_ro_of_fs_conf = impl @@ object
-    inherit base_configurable
-    method ty = fs @-> kv_ro
-    method name = "kv_ro_of_fs"
-    method module_name = "Mirage_fs_lwt.To_KV_RO"
-    method! packages = Key.pure [ package "mirage-fs-lwt" ]
-    method! connect _ modname = function
-      | [ fs ] -> Fmt.strf "%s.connect %s" modname fs
-      | _ -> failwith (connect_err "kv_ro_of_fs" 1)
-  end
+       method ty = fs @-> kv_ro
+
+       method name = "kv_ro_of_fs"
+
+       method module_name = "Mirage_fs_lwt.To_KV_RO"
+
+       method! packages = Key.pure [package "mirage-fs-lwt"]
+
+       method! connect _ modname =
+         function
+         | [fs] ->
+             Fmt.strf "%s.connect %s" modname fs
+         | _ ->
+             failwith (connect_err "kv_ro_of_fs" 1)
+     end
 
 let kv_ro_of_fs x = kv_ro_of_fs_conf $ x
 
 (** generic kv_ro. *)
 
 let generic_kv_ro ?group ?(key = Key.value @@ Key.kv_ro ?group ()) dir =
-  match_impl key [
-    `Fat    , kv_ro_of_fs @@ fat_of_files ~dir () ;
-    `Archive, archive_of_files ~dir () ;
-    `Crunch , crunch dir ;
-    `Direct , direct_kv_ro dir ;
-  ] ~default:(direct_kv_ro dir)
+  match_impl key
+    [ (`Fat, kv_ro_of_fs @@ fat_of_files ~dir ())
+    ; (`Archive, archive_of_files ~dir ())
+    ; (`Crunch, crunch dir)
+    ; (`Direct, direct_kv_ro dir) ]
+    ~default:(direct_kv_ro dir)

--- a/lib/mirage_impl_fs.ml
+++ b/lib/mirage_impl_fs.ml
@@ -7,16 +7,16 @@ open Mirage_impl_kv_ro
 open Mirage_impl_misc
 open Rresult
 
-type fs = FS
+type t = FS
 
-let fs = Type FS
+let typ = Type FS
 
 let fat_conf =
   impl
   @@ object
        inherit base_configurable
 
-       method ty = block @-> fs
+       method ty = block @-> typ
 
        method! packages = Key.pure [package ~min:"0.12.0" "fat-filesystem"]
 
@@ -101,7 +101,7 @@ let kv_ro_of_fs_conf =
   @@ object
        inherit base_configurable
 
-       method ty = fs @-> kv_ro
+       method ty = typ @-> kv_ro
 
        method name = "kv_ro_of_fs"
 

--- a/lib/mirage_impl_fs.ml
+++ b/lib/mirage_impl_fs.ml
@@ -36,26 +36,27 @@ let fat block = fat_conf $ block
 
 let fat_shell_script fmt ~block_file ~root ~dir ~regexp =
   let open Functoria_app.Codegen in
-  append fmt "#!/bin/sh";
-  append fmt "";
   append fmt
-    "echo This uses the 'fat' command-line tool to build a simple FAT";
-  append fmt "echo filesystem image.";
-  append fmt "";
-  append fmt "FAT=$(which fat)";
-  append fmt "if [ ! -x \"${FAT}\" ]; then";
-  append fmt "  echo I couldn\\'t find the 'fat' command-line tool.";
-  append fmt "  echo Try running 'opam install fat-filesystem'";
-  append fmt "  exit 1";
-  append fmt "fi";
-  append fmt "";
-  append fmt "IMG=$(pwd)/%s" block_file;
-  append fmt "rm -f ${IMG}";
-  append fmt "cd %a" Fpath.pp (Fpath.append root dir);
-  append fmt "SIZE=$(du -s . | cut -f 1)";
-  append fmt "${FAT} create ${IMG} ${SIZE}KiB";
-  append fmt "${FAT} add ${IMG} %s" regexp;
-  append fmt "echo Created '%s'" block_file
+    {|#!/bin/sh
+
+echo This uses the 'fat' command-line tool to build a simple FAT
+echo filesystem image.
+
+FAT=$(which fat)
+if [ ! -x "${FAT}" ]; then
+  echo I couldn\'t find the 'fat' command-line tool.
+  echo Try running 'opam install fat-filesystem'
+  exit 1
+fi
+
+IMG=$(pwd)/%s
+rm -f ${IMG}
+cd %a
+SIZE=$(du -s . | cut -f 1)
+${FAT} create ${IMG} ${SIZE}KiB
+${FAT} add ${IMG} %s
+echo Created '%s'|}
+    block_file Fpath.pp (Fpath.append root dir) regexp block_file
 
 let fat_block ?(dir = ".") ?(regexp = "*") () =
   let name =

--- a/lib/mirage_impl_fs.mli
+++ b/lib/mirage_impl_fs.mli
@@ -1,12 +1,12 @@
-type fs
+type t
 
-val fs : fs Functoria.typ
+val typ : t Functoria.typ
 
-val fat : Mirage_impl_block.block Functoria.impl -> fs Functoria.impl
+val fat : Mirage_impl_block.block Functoria.impl -> t Functoria.impl
 
-val fat_of_files : ?dir:string -> ?regexp:string -> unit -> fs Functoria.impl
+val fat_of_files : ?dir:string -> ?regexp:string -> unit -> t Functoria.impl
 
-val kv_ro_of_fs : fs Functoria.impl -> Mirage_impl_kv_ro.kv_ro Functoria.impl
+val kv_ro_of_fs : t Functoria.impl -> Mirage_impl_kv_ro.kv_ro Functoria.impl
 
 val generic_kv_ro :
      ?group:string

--- a/lib/mirage_impl_fs.mli
+++ b/lib/mirage_impl_fs.mli
@@ -13,3 +13,11 @@ val generic_kv_ro :
   -> ?key:[`Archive | `Crunch | `Direct | `Fat] Functoria.value
   -> string
   -> Mirage_impl_kv_ro.kv_ro Functoria.impl
+
+val fat_shell_script :
+     Format.formatter
+  -> block_file:string
+  -> root:Fpath.t
+  -> dir:Fpath.t
+  -> regexp:string
+  -> unit

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,4 @@
+(test
+ (name test_generated_files)
+ (libraries mirage)
+)

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,5 @@
 (test
  (name test_generated_files)
  (libraries mirage)
+ (package mirage)
 )

--- a/test/test_generated_files.expected
+++ b/test/test_generated_files.expected
@@ -1,0 +1,23 @@
+output_fat
+==========
+
+#!/bin/sh
+
+echo This uses the 'fat' command-line tool to build a simple FAT
+echo filesystem image.
+
+FAT=$(which fat)
+if [ ! -x "${FAT}" ]; then
+  echo I couldn\'t find the 'fat' command-line tool.
+  echo Try running 'opam install fat-filesystem'
+  exit 1
+fi
+
+IMG=$(pwd)/BLOCK_FILE
+rm -f ${IMG}
+cd ROOT/DIR
+SIZE=$(du -s . | cut -f 1)
+${FAT} create ${IMG} ${SIZE}KiB
+${FAT} add ${IMG} REGEXP
+echo Created 'BLOCK_FILE'
+

--- a/test/test_generated_files.ml
+++ b/test/test_generated_files.ml
@@ -1,0 +1,33 @@
+let with_fmt_str k =
+  let buf = Buffer.create 0 in
+  let fmt = Format.formatter_of_buffer buf in
+  k fmt;
+  Format.pp_print_flush fmt ();
+  Buffer.contents buf
+
+let redact_line n s =
+  (* At the moment it is not possible to inject argv & time so we remove the
+   * generated line.
+   * See https://github.com/mirage/functoria/pull/159 *)
+  let lines = String.split_on_char '\n' s in
+  let redacted_lines =
+    List.mapi (fun i line -> if i + 1 = n then "# REDACTED" else line) lines
+  in
+  String.concat "\n" redacted_lines
+
+let print_banner s =
+  print_endline s;
+  print_endline @@ String.make (String.length s) '=';
+  print_newline ()
+
+let test_output_fat =
+  Mirage_impl_fs.fat_shell_script ~block_file:"BLOCK_FILE"
+    ~root:(Fpath.v "ROOT") ~dir:(Fpath.v "DIR") ~regexp:"REGEXP"
+
+let () =
+  let tests = [("output_fat", test_output_fat)] in
+  List.iter
+    (fun (name, f) ->
+      print_banner name;
+      print_endline @@ with_fmt_str f )
+    tests


### PR DESCRIPTION
We have to start from somewhere!

This sets up tests for the code generation in the FS module, and normalizes the code a bit:
- `ocamlformat` - I reused an existing config so that at least we have terminator sequences & vertical type declarations (this is not enforced in CI yet)
- rename `fs` to `t` & `typ`

As follow ups, I'll setup ppx codegen in a module that generates some nontrivial ocaml, and next I'll convert the rest at the same time if there's not much going on.