### PR TITLE
remove conflicts from opam - mirage generates code with such lower bounds

### DIFF
--- a/mirage.opam
+++ b/mirage.opam
@@ -25,14 +25,6 @@ depends: [
   "logs"
   "mirage-runtime"     {>= "3.2.0"}
 ]
-conflicts: [
-  "nocrypto" {< "0.4.0"}
-  "cstruct"  {< "1.0.1"}
-  "io-page"  {< "1.4.0"}
-  "crunch"   {< "1.2.2"}
-  "mirage-solo5" {< "0.4.0"}
-  "tcpip" {< "3.5.0"}
-]
 synopsis: "The MirageOS library operating system"
 description: """
 MirageOS is a library operating system that constructs unikernels for


### PR DESCRIPTION
no need to keep this information a second time