### PR TITLE
upper bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
  global:
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="sh ./.travis-ci.sh"
-   - PINS="mirage.dev:. mirage-types.dev:. mirage-types-lwt.dev:. mirage-runtime.dev:."
+   - PINS="mirage:. mirage-types:. mirage-types-lwt:. mirage-runtime:."
    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
  matrix:
    - PACKAGE=mirage DISTRO=debian-testing OCAML_VERSION=4.04 EXTRA_ENV="MODE=xen"

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -32,9 +32,9 @@ include Functoria
 
 (* Mirage implementation backing the target. *)
 let backend_predicate = function
-  | `Xen | `Qubes                     -> "mirage_xen"
+  | `Xen | `Qubes -> "mirage_xen"
   | `Virtio | `Hvt | `Muen | `Genode  -> "mirage_solo5"
-  | `Unix | `MacOSX                   -> "mirage_unix"
+  | `Unix | `MacOSX -> "mirage_unix"
 
 (** {2 Devices} *)
 
@@ -355,7 +355,8 @@ module Substitutions = struct
 
   let defaults i =
     let blocks =
-      List.map (fun b -> Block b, Fpath.(to_string ((Info.build_dir i) / b.filename)))
+      List.map
+        (fun b -> Block b, Fpath.(to_string ((Info.build_dir i) / b.filename)))
         (Hashtbl.fold (fun _ v acc -> v :: acc) Mirage_impl_block.all_blocks [])
     and networks =
       List.mapi (fun i n -> Network n, Fmt.strf "%s%d" detected_bridge_name i)
@@ -657,7 +658,10 @@ let pkg_config pkgs args =
   Lazy.force opam_prefix >>= fun prefix ->
   (* the order here matters (at least for ancient 0.26, distributed with
        ubuntu 14.04 versions): use share before lib! *)
-  let value = Fmt.strf "%s/share/pkgconfig:%s/lib/pkgconfig%s" prefix prefix pkg_config_fallback in
+  let value =
+    Fmt.strf "%s/share/pkgconfig:%s/lib/pkgconfig%s"
+      prefix prefix pkg_config_fallback
+  in
   Bos.OS.Env.set_var var (Some value) >>= fun () ->
   let cmd = Bos.Cmd.(v "pkg-config" % pkgs %% of_list args) in
   Bos.OS.Cmd.run_out cmd |> Bos.OS.Cmd.out_string >>| fun (data, _) ->
@@ -696,14 +700,15 @@ let ldpostflags pkg = pkg_config pkg ["--variable=ldpostflags"]
 let find_ld pkg =
   match pkg_config pkg ["--variable=ld"] with
   | Ok (ld::_) ->
-    Log.info (fun m -> m "using %s as ld (pkg-config %s --variable=ld)" ld pkg) ;
+    Log.info (fun m -> m "using %s as ld (pkg-config %s --variable=ld)" ld pkg);
     ld
   | Ok [] ->
-    Log.warn (fun m -> m "pkg-config %s --variable=ld returned nothing, using ld" pkg) ;
+    Log.warn
+      (fun m -> m "pkg-config %s --variable=ld returned nothing, using ld" pkg);
     "ld"
   | Error msg ->
     Log.warn (fun m -> m "error %a while pkg-config %s --variable=ld, using ld"
-                 Rresult.R.pp_msg msg pkg) ;
+                 Rresult.R.pp_msg msg pkg);
     "ld"
 
 let solo5_pkg = function
@@ -718,29 +723,35 @@ let link info name target target_debug =
   let libs = Info.libraries info in
   match target with
   | `Unix | `MacOSX ->
-    Bos.OS.Cmd.run Bos.Cmd.(v "ln" % "-nfs" % "_build/main.native" % name) >>= fun () ->
+    let link = Bos.Cmd.(v "ln" % "-nfs" % "_build/main.native" % name) in
+    Bos.OS.Cmd.run link >>= fun () ->
     Ok name
   | `Xen | `Qubes ->
     extra_c_artifacts "xen" libs >>= fun c_artifacts ->
     static_libs "mirage-xen" >>= fun static_libs ->
     let linker =
-      Bos.Cmd.(v "ld" % "-d" % "-static" % "-nostdlib" % "_build/main.native.o" %%
-               of_list c_artifacts %% of_list static_libs)
+      Bos.Cmd.(v "ld" % "-d" % "-static" % "-nostdlib" %
+               "_build/main.native.o" %%
+               of_list c_artifacts %%
+               of_list static_libs)
     in
     let out = name ^ ".xen" in
-    Bos.OS.Cmd.run_out Bos.Cmd.(v "uname" % "-m") |> Bos.OS.Cmd.out_string >>= fun (machine, _) ->
+    let uname_cmd = Bos.Cmd.(v "uname" % "-m") in
+    Bos.OS.Cmd.(run_out uname_cmd |> out_string) >>= fun (machine, _) ->
     if String.is_prefix ~affix:"arm" machine then begin
       (* On ARM:
          - we must convert the ELF image to an ARM boot executable zImage,
            while on x86 we leave it as it is.
          - we need to link libgcc.a (otherwise we get undefined references to:
            __aeabi_dcmpge, __aeabi_dadd, ...) *)
-      Bos.OS.Cmd.run_out Bos.Cmd.(v "gcc" % "-print-libgcc-file-name") |> Bos.OS.Cmd.out_string >>= fun (libgcc, _) ->
+      let libgcc_cmd = Bos.Cmd.(v "gcc" % "-print-libgcc-file-name") in
+      Bos.OS.Cmd.(run_out libgcc_cmd |> out_string) >>= fun (libgcc, _) ->
       let elf = name ^ ".elf" in
       let link = Bos.Cmd.(linker % libgcc % "-o" % elf) in
       Log.info (fun m -> m "linking with %a" Bos.Cmd.pp link);
       Bos.OS.Cmd.run link >>= fun () ->
-      Bos.OS.Cmd.run Bos.Cmd.(v "objcopy" % "-O" % "binary" % elf % out) >>= fun () ->
+      let objcopy_cmd = Bos.Cmd.(v "objcopy" % "-O" % "binary" % elf % out) in
+      Bos.OS.Cmd.run objcopy_cmd  >>= fun () ->
       Ok out
     end else begin
       let link = Bos.Cmd.(linker % "-o" % out) in
@@ -773,8 +784,16 @@ let link info name target target_debug =
       in
       pkg_config pkg ["--variable=libdir"] >>= function
       | [ libdir ] ->
-        Bos.OS.Cmd.run Bos.Cmd.(v "solo5-hvt-configure" % (libdir ^ "/src") %% of_list tender_mods) >>= fun () ->
-        Bos.OS.Cmd.run Bos.Cmd.(v "make" % "-f" % "Makefile.solo5-hvt" % "solo5-hvt") >>= fun () ->
+        let config_cmd =
+          Bos.Cmd.(v "solo5-hvt-configure" %
+                   (libdir ^ "/src") %%
+                   of_list tender_mods)
+        in
+        Bos.OS.Cmd.run config_cmd >>= fun () ->
+        let make_cmd =
+          Bos.Cmd.(v "make" % "-f" % "Makefile.solo5-hvt" % "solo5-hvt")
+        in
+        Bos.OS.Cmd.run make_cmd >>= fun () ->
         Ok out
       | _ -> R.error_msg ("pkg-config " ^ pkg ^ " --variable=libdir failed")
     else
@@ -866,23 +885,26 @@ module Project = struct
         Key.(abstract no_depext);
       ]
       method! packages =
+        (* XXX: use %%VERSION_NUM%% here instead of hardcoding a version? *)
+        let min = "3.3.0" and max = "3.4.0" in
         let common = [
           package ~build:true ~min:"4.04.2" "ocaml";
           package "lwt";
-          (* XXX: use %%VERSION_NUM%% here instead of hardcoding a version? *)
-          package ~min:"3.2.0" "mirage-types-lwt";
-          package ~min:"3.2.0" "mirage-types";
-          package ~min:"3.2.0" "mirage-runtime" ;
+          package ~min ~max "mirage-types-lwt";
+          package ~min ~max "mirage-types";
+          package ~min ~max "mirage-runtime" ;
           package ~build:true "ocamlfind" ;
           package ~build:true "ocamlbuild" ;
         ] in
         Key.match_ Key.(value target) @@ function
-        | `Unix | `MacOSX -> [ package ~min:"3.0.0" "mirage-unix" ] @ common
-        | `Xen | `Qubes -> [ package ~min:"3.0.4" "mirage-xen" ] @ common
+        | `Unix | `MacOSX ->
+          package ~min:"3.1.0" ~max:"3.2.0" "mirage-unix" :: common
+        | `Xen | `Qubes ->
+          package ~min:"3.1.0" ~max:"3.2.0" "mirage-xen" :: common
         | `Virtio | `Hvt | `Muen | `Genode as tgt ->
-          let pkg, _ = solo5_pkg tgt in
-          [ package ~min:"0.4.0" ~ocamlfind:[] pkg ;
-            package ~min:"0.4.0" "mirage-solo5" ] @ common
+          package ~min:"0.4.0" ~max:"0.5.0" ~ocamlfind:[] (fst (solo5_pkg tgt)) ::
+          package ~min:"0.5.0" ~max:"0.6.0" "mirage-solo5" ::
+          common
 
       method! build = build
       method! configure = configure
@@ -898,8 +920,8 @@ include Functoria_app.Make (Project)
 (** {Custom registration} *)
 
 let (++) acc x = match acc, x with
-  | _       , None   -> acc
-  | None    , Some x -> Some [x]
+  | _ , None -> acc
+  | None, Some x -> Some [x]
   | Some acc, Some x -> Some (acc @ [x])
 
 (* TODO: ideally we'd combine these *)

--- a/lib/mirage_impl_argv.ml
+++ b/lib/mirage_impl_argv.ml
@@ -6,7 +6,8 @@ let argv_unix = impl @@ object
     method ty = Functoria_app.argv
     method name = "argv_unix"
     method module_name = "Bootvar"
-    method! packages = Key.pure [ package "mirage-bootvar-unix" ]
+    method! packages =
+      Key.pure [ package ~min:"0.1.0" ~max:"0.2.0" "mirage-bootvar-unix" ]
     method! connect _ _ _ = "Bootvar.argv ()"
   end
 
@@ -15,7 +16,8 @@ let argv_solo5 = impl @@ object
     method ty = Functoria_app.argv
     method name = "argv_solo5"
     method module_name = "Bootvar"
-    method! packages = Key.pure [ package ~min:"0.3.0" "mirage-bootvar-solo5" ]
+    method! packages =
+      Key.pure [ package ~min:"0.3.0" ~max:"0.4.0" "mirage-bootvar-solo5" ]
     method! connect _ _ _ = "Bootvar.argv ()"
   end
 
@@ -32,7 +34,8 @@ let argv_xen = impl @@ object
     method ty = Functoria_app.argv
     method name = "argv_xen"
     method module_name = "Bootvar"
-    method! packages = Key.pure [ package ~min:"0.4.0" "mirage-bootvar-xen" ]
+    method! packages =
+      Key.pure [ package ~min:"0.4.0" ~max:"0.5.0" "mirage-bootvar-xen" ]
     method! connect _ _ _ = Fmt.strf
       (* Some hypervisor configurations try to pass some extra arguments.
        * They means well, but we can't do much with them,

--- a/lib/mirage_impl_arpv4.ml
+++ b/lib/mirage_impl_arpv4.ml
@@ -13,7 +13,8 @@ let arpv4_conf = object
   method ty = ethernet @-> mclock @-> time @-> arpv4
   method name = "arpv4"
   method module_name = "Arpv4.Make"
-  method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["arpv4"] "tcpip" ]
+  method! packages =
+    Key.pure [ package ~min:"3.5.0" ~max:"3.6.0" ~sublibs:["arpv4"] "tcpip" ]
   method! connect _ modname = function
     | [ eth ; clock ; _time ] -> Fmt.strf "%s.connect %s %s" modname eth clock
     | _ -> failwith (connect_err "arpv4" 3)
@@ -32,7 +33,8 @@ let farp_conf = object
   method ty = ethernet @-> mclock @-> time @-> arpv4
   method name = "arp"
   method module_name = "Arp.Make"
-  method! packages = Key.pure [ package ~min:"0.2.0" ~sublibs:["mirage"] "arp" ]
+  method! packages =
+    Key.pure [ package ~min:"0.2.0" ~max:"0.3.0" ~sublibs:["mirage"] "arp" ]
   method! connect _ modname = function
     | [ eth ; clock ; _time ] -> Fmt.strf "%s.connect %s %s" modname eth clock
     | _ -> failwith (connect_err "arp" 3)

--- a/lib/mirage_impl_block.ml
+++ b/lib/mirage_impl_block.ml
@@ -27,7 +27,7 @@ let make_block_t =
     b
 
 let xen_block_packages =
-  [ package ~min:"1.5.0" ~sublibs:["front"] "mirage-block-xen" ]
+  [ package ~min:"1.5.0" ~max:"2.0.0" ~sublibs:["front"] "mirage-block-xen" ]
 
 (* this class takes a string rather than an int as `id` to allow the user to
    pass stuff like "/dev/xvdi1", which mirage-block-xen also understands *)
@@ -69,8 +69,9 @@ class block_conf file =
       Key.match_ Key.(value target) @@ function
       | `Xen | `Qubes -> xen_block_packages
       | `Virtio | `Hvt | `Muen | `Genode ->
-        [ package ~min:"0.3.0" "mirage-block-solo5" ]
-      | `Unix | `MacOSX -> [ package ~min:"2.5.0" "mirage-block-unix" ]
+        [ package ~min:"0.4.0" ~max:"0.5.0" "mirage-block-solo5" ]
+      | `Unix | `MacOSX ->
+        [ package ~min:"2.5.0" ~max:"3.0.0" "mirage-block-unix" ]
 
     method! configure _ =
       let _block = make_block_t file in
@@ -133,7 +134,7 @@ let archive_conf = impl @@ object
     method name = "archive"
     method module_name = "Tar_mirage.Make_KV_RO"
     method! packages =
-      Key.pure [ package ~min:"0.8.0" "tar-mirage" ]
+      Key.pure [ package ~min:"0.9.0" ~max:"0.10.0" "tar-mirage" ]
     method! connect _ modname = function
       | [ block ] -> Fmt.strf "%s.connect %s" modname block
       | _ -> failwith (connect_err "archive" 1)

--- a/lib/mirage_impl_conduit.ml
+++ b/lib/mirage_impl_conduit.ml
@@ -10,10 +10,7 @@ let conduit_with_connectors connectors = impl @@ object
     method ty = conduit
     method name = Functoria_app.Name.create "conduit" ~prefix:"conduit"
     method module_name = "Conduit_mirage"
-    method! packages =
-      Mirage_key.pure [
-        package ~min:"3.0.1" "mirage-conduit";
-      ]
+    method! packages = Mirage_key.pure [ pkg ]
     method! deps = abstract nocrypto :: List.map abstract connectors
 
     method! connect _i _ = function

--- a/lib/mirage_impl_conduit_connector.ml
+++ b/lib/mirage_impl_conduit_connector.ml
@@ -6,15 +6,14 @@ open Mirage_impl_stackv4
 type conduit_connector = Conduit_connector
 let conduit_connector = Type Conduit_connector
 
+let pkg = package ~min:"3.0.1" ~max:"4.0.0" "mirage-conduit"
+
 let tcp_conduit_connector = impl @@ object
     inherit base_configurable
     method ty = stackv4 @-> conduit_connector
     method name = "tcp_conduit_connector"
     method module_name = "Conduit_mirage.With_tcp"
-    method! packages =
-      Mirage_key.pure [
-        package ~min:"3.0.1" "mirage-conduit";
-      ]
+    method! packages = Mirage_key.pure [ pkg ]
     method! connect _ modname = function
       | [ stack ] -> Fmt.strf "Lwt.return (%s.connect %s)@;" modname stack
       | _ -> failwith (connect_err "tcp conduit" 1)
@@ -27,11 +26,8 @@ let tls_conduit_connector = impl @@ object
     method module_name = "Conduit_mirage"
     method! packages =
       Mirage_key.pure [
-        package ~min:"0.8.0" ~sublibs:["mirage"] "tls" ;
-        package "mirage-flow-lwt";
-        package "mirage-kv-lwt";
-        package "mirage-clock";
-        package ~min:"3.0.1" "mirage-conduit" ;
+        package ~min:"0.9.2" ~max:"0.10.0" ~sublibs:["mirage"] "tls" ;
+        pkg
       ]
     method! deps = [ abstract nocrypto ]
     method! connect _ _ _ = "Lwt.return Conduit_mirage.with_tls"

--- a/lib/mirage_impl_conduit_connector.mli
+++ b/lib/mirage_impl_conduit_connector.mli
@@ -4,3 +4,5 @@ val tcp_conduit_connector :
   (Mirage_impl_stackv4.stackv4 -> conduit_connector) Functoria.impl
 
 val tls_conduit_connector : conduit_connector Functoria.impl
+
+val pkg : Functoria.package

--- a/lib/mirage_impl_console.ml
+++ b/lib/mirage_impl_console.ml
@@ -11,7 +11,8 @@ let console_unix str = impl @@ object
     val name = Name.ocamlify @@ "console_unix_" ^ str
     method name = name
     method module_name = "Console_unix"
-    method! packages = Key.pure [ package ~min:"2.2.0" "mirage-console-unix" ]
+    method! packages =
+      Key.pure [ package ~min:"2.2.0" ~max:"3.0.0" "mirage-console-unix" ]
     method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
   end
 
@@ -21,7 +22,8 @@ let console_xen str = impl @@ object
     val name = Name.ocamlify @@ "console_xen_" ^ str
     method name = name
     method module_name = "Console_xen"
-    method! packages = Key.pure [ package ~min:"2.2.0" "mirage-console-xen" ]
+    method! packages =
+      Key.pure [ package ~min:"2.2.0" ~max:"3.0.0" "mirage-console-xen" ]
     method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
   end
 
@@ -31,7 +33,8 @@ let console_solo5 str = impl @@ object
     val name = Name.ocamlify @@ "console_solo5_" ^ str
     method name = name
     method module_name = "Console_solo5"
-    method! packages = Key.pure [ package ~min:"0.3.0" "mirage-console-solo5" ]
+    method! packages =
+      Key.pure [ package ~min:"0.3.0" ~max:"0.4.0" "mirage-console-solo5" ]
     method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
   end
 

--- a/lib/mirage_impl_ethernet.ml
+++ b/lib/mirage_impl_ethernet.ml
@@ -11,7 +11,8 @@ let ethernet_conf = object
   method ty = network @-> ethernet
   method name = "ethif"
   method module_name = "Ethif.Make"
-  method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["ethif"] "tcpip" ]
+  method! packages =
+    Key.pure [ package ~min:"3.5.0" ~max:"3.6.0" ~sublibs:["ethif"] "tcpip" ]
   method! connect _ modname = function
     | [ eth ] -> Fmt.strf "%s.connect %s" modname eth
     | _ -> failwith (connect_err "ethernet" 1)

--- a/lib/mirage_impl_fs.ml
+++ b/lib/mirage_impl_fs.ml
@@ -11,26 +11,21 @@ type t = FS
 
 let typ = Type FS
 
-let fat_conf =
-  impl
-  @@ object
-       inherit base_configurable
+let fat_pkg = package ~min:"0.12.0" ~max:"0.13.0" "fat-filesystem"
 
-       method ty = block @-> typ
-
-       method! packages = Key.pure [package ~min:"0.12.0" "fat-filesystem"]
-
-       method name = "fat"
-
-       method module_name = "Fat.FS"
-
-       method! connect _ modname l =
-         match l with
-         | [block_name] ->
-             Fmt.strf "%s.connect %s" modname block_name
-         | _ ->
-             failwith (connect_err "fat" 1)
-     end
+let fat_conf = impl @@ object
+    inherit base_configurable
+    method ty = block @-> typ
+    method! packages = Mirage_key.pure [ fat_pkg ]
+    method name = "fat"
+    method module_name = "Fat.FS"
+    method! connect _ modname l =
+      match l with
+      | [block_name] ->
+        Fmt.strf "%s.connect %s" modname block_name
+      | _ ->
+        failwith (connect_err "fat" 1)
+  end
 
 let fat block = fat_conf $ block
 
@@ -64,59 +59,44 @@ let fat_block ?(dir = ".") ?(regexp = "*") () =
       ocamlify @@ create (Fmt.strf "fat%s:%s" dir regexp) ~prefix:"fat_block")
   in
   let block_file = name ^ ".img" in
-  impl
-  @@ object
-       inherit Mirage_impl_block.block_conf block_file as super
-
-       method! packages =
-         Key.map
-           (List.cons (package ~min:"0.12.0" ~build:true "fat-filesystem"))
-           super#packages
-
-       method! build i =
-         let root = Info.build_dir i in
-         let file = Fmt.strf "make-%s-image.sh" name in
-         let dir = Fpath.of_string dir |> R.error_msg_to_invalid_arg in
-         Log.info (fun m -> m "Generating block generator script: %s" file);
-         with_output ~mode:0o755 (Fpath.v file)
-           (fun oc () ->
-             let fmt = Format.formatter_of_out_channel oc in
-             fat_shell_script fmt ~block_file ~root ~dir ~regexp;
-             R.ok () )
-           "fat shell script"
-         >>= fun () ->
-         Log.info (fun m -> m "Executing block generator script: ./%s" file);
-         Bos.OS.Cmd.run (Bos.Cmd.v ("./" ^ file)) >>= fun () -> super#build i
-
-       method! clean i =
-         let file = Fmt.strf "make-%s-image.sh" name in
-         Bos.OS.File.delete (Fpath.v file)
-         >>= fun () ->
-         Bos.OS.File.delete (Fpath.v block_file) >>= fun () -> super#clean i
-     end
+  impl @@ object
+    inherit Mirage_impl_block.block_conf block_file as super
+    method! packages = Key.map (List.cons fat_pkg) super#packages
+    method! build i =
+      let root = Info.build_dir i in
+      let file = Fmt.strf "make-%s-image.sh" name in
+      let dir = Fpath.of_string dir |> R.error_msg_to_invalid_arg in
+      Log.info (fun m -> m "Generating block generator script: %s" file);
+      with_output ~mode:0o755 (Fpath.v file)
+        (fun oc () ->
+           let fmt = Format.formatter_of_out_channel oc in
+           fat_shell_script fmt ~block_file ~root ~dir ~regexp;
+           R.ok () )
+        "fat shell script"
+      >>= fun () ->
+      Log.info (fun m -> m "Executing block generator script: ./%s" file);
+      Bos.OS.Cmd.run (Bos.Cmd.v ("./" ^ file)) >>= fun () -> super#build i
+    method! clean i =
+      let file = Fmt.strf "make-%s-image.sh" name in
+      Bos.OS.File.delete (Fpath.v file)
+      >>= fun () ->
+      Bos.OS.File.delete (Fpath.v block_file) >>= fun () -> super#clean i
+  end
 
 let fat_of_files ?dir ?regexp () = fat @@ fat_block ?dir ?regexp ()
 
 let kv_ro_of_fs_conf =
-  impl
-  @@ object
-       inherit base_configurable
-
-       method ty = typ @-> kv_ro
-
-       method name = "kv_ro_of_fs"
-
-       method module_name = "Mirage_fs_lwt.To_KV_RO"
-
-       method! packages = Key.pure [package "mirage-fs-lwt"]
-
-       method! connect _ modname =
-         function
-         | [fs] ->
-             Fmt.strf "%s.connect %s" modname fs
-         | _ ->
-             failwith (connect_err "kv_ro_of_fs" 1)
-     end
+  impl @@ object
+    inherit base_configurable
+    method ty = typ @-> kv_ro
+    method name = "kv_ro_of_fs"
+    method module_name = "Mirage_fs_lwt.To_KV_RO"
+    method! packages =
+      Key.pure [package ~min:"1.0.0" ~max:"2.0.0" "mirage-fs-lwt"]
+    method! connect _ modname = function
+      | [fs] -> Fmt.strf "%s.connect %s" modname fs
+      | _ -> failwith (connect_err "kv_ro_of_fs" 1)
+  end
 
 let kv_ro_of_fs x = kv_ro_of_fs_conf $ x
 

--- a/lib/mirage_impl_gui.ml
+++ b/lib/mirage_impl_gui.ml
@@ -12,7 +12,7 @@ let gui_qubes = impl @@ object
   val name = Name.ocamlify @@ "gui"
   method name = name
   method module_name = "Qubes.GUI"
-  method! packages = Key.pure [ package ~min:"0.4" "mirage-qubes" ]
+  method! packages = Key.pure [ Mirage_impl_qubesdb.pkg ]
   method! configure i =
     match get_target i with
     | `Qubes -> R.ok ()

--- a/lib/mirage_impl_http.ml
+++ b/lib/mirage_impl_http.ml
@@ -9,7 +9,8 @@ let http_server conduit = impl @@ object
     method ty = http
     method name = "http"
     method module_name = "Cohttp_mirage.Server_with_conduit"
-    method! packages = Mirage_key.pure [ package ~min:"1.0.0" "cohttp-mirage" ]
+    method! packages =
+      Mirage_key.pure [ package ~min:"1.0.0" ~max:"2.0.0" "cohttp-mirage" ]
     method! deps = [ abstract conduit ]
     method! connect _i modname = function
       | [ conduit ] -> Fmt.strf "%s.connect %s" modname conduit

--- a/lib/mirage_impl_icmp.ml
+++ b/lib/mirage_impl_icmp.ml
@@ -13,7 +13,7 @@ let icmpv4_direct_conf () = object
   method ty : ('a ip -> 'a icmp) typ = ip @-> icmp
   method name = "icmpv4"
   method module_name = "Icmpv4.Make"
-  method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["icmpv4"] "tcpip"
+  method! packages = right_tcpip_library ~sublibs:["icmpv4"] "tcpip"
   method! connect _ modname = function
     | [ ip ] -> Fmt.strf "%s.connect %s" modname ip
     | _  -> failwith (connect_err "icmpv4" 1)

--- a/lib/mirage_impl_ip.ml
+++ b/lib/mirage_impl_ip.ml
@@ -62,7 +62,7 @@ let ipv4_keyed_conf ?network ?gateway () = impl @@ object
   end
 
 let charrua_pkg =
-  Key.pure [ package ~min:"0.11" ~max:"0.12" "charrua-client-mirage" ]
+  Key.pure [ package ~min:"0.11.0" ~max:"0.12.0" "charrua-client-mirage" ]
 
 let dhcp_conf = impl @@ object
     inherit base_configurable

--- a/lib/mirage_impl_ip.ml
+++ b/lib/mirage_impl_ip.ml
@@ -32,18 +32,22 @@ let (@?) x l = match x with Some s -> s :: l | None -> l
 let (@??) x y = opt_map Key.abstract x @? y
 
 (* convenience function for linking tcpip.unix or .xen for checksums *)
-let right_tcpip_library ?min ?max ?ocamlfind ~sublibs pkg =
+let right_tcpip_library ?ocamlfind ~sublibs pkg =
+  let min = "3.5.0" and max = "3.6.0" in
   Key.match_ Key.(value target) @@ function
-  |`MacOSX | `Unix                  -> [ package ?min ?max ?ocamlfind ~sublibs:("unix"::sublibs) pkg ]
-  |`Qubes  | `Xen                   -> [ package ?min ?max ?ocamlfind ~sublibs:("xen"::sublibs) pkg ]
-  |`Virtio | `Hvt | `Muen | `Genode -> [ package ?min ?max ?ocamlfind ~sublibs pkg ]
+  |`MacOSX | `Unix ->
+    [ package ~min ~max ?ocamlfind ~sublibs:("unix"::sublibs) pkg ]
+  |`Qubes  | `Xen ->
+    [ package ~min ~max ?ocamlfind ~sublibs:("xen"::sublibs) pkg ]
+  |`Virtio | `Hvt | `Muen | `Genode ->
+    [ package ~min ~max ?ocamlfind ~sublibs pkg ]
 
 let ipv4_keyed_conf ?network ?gateway () = impl @@ object
     inherit base_configurable
     method ty = random @-> mclock @-> ethernet @-> arpv4 @-> ipv4
     method name = Name.create "ipv4" ~prefix:"ipv4"
     method module_name = "Static_ipv4.Make"
-    method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["ipv4"] "tcpip"
+    method! packages = right_tcpip_library ~sublibs:["ipv4"] "tcpip"
     method! keys = network @?? gateway @?? []
     method! connect _ modname = function
     | [ _random ; mclock ; etif ; arp ] ->
@@ -57,12 +61,15 @@ let ipv4_keyed_conf ?network ?gateway () = impl @@ object
       | _ -> failwith (connect_err "ipv4 keyed" 4)
   end
 
+let charrua_pkg =
+  Key.pure [ package ~min:"0.11" ~max:"0.12" "charrua-client-mirage" ]
+
 let dhcp_conf = impl @@ object
     inherit base_configurable
     method ty = random @-> time @-> network @-> Mirage_impl_dhcp.dhcp
     method name = "dhcp_client"
     method module_name = "Dhcp_client_mirage.Make"
-    method! packages = Key.pure [ package ~min:"0.10" "charrua-client-mirage" ]
+    method! packages = charrua_pkg
     method! connect _ modname = function
       | [ _random; _time; network ] -> Fmt.strf "%s.connect %s " modname network
       | _ -> failwith (connect_err "dhcp" 3)
@@ -73,7 +80,7 @@ let ipv4_dhcp_conf = impl @@ object
     method ty = Mirage_impl_dhcp.dhcp @-> random @-> mclock @-> ethernet @-> arpv4 @-> ipv4
     method name = Name.create "dhcp_ipv4" ~prefix:"dhcp_ipv4"
     method module_name = "Dhcp_ipv4.Make"
-    method! packages = Key.pure [ package "charrua-client-mirage" ]
+    method! packages = charrua_pkg
     method! connect _ modname = function
       | [ dhcp ; _random ; mclock ; ethernet ; arp ] ->
         Fmt.strf "%s.connect@[@ %s@ %s@ %s@ %s@]"
@@ -115,7 +122,8 @@ let ipv4_qubes_conf = impl @@ object
     method ty = qubesdb @-> random @-> mclock @-> ethernet @-> arpv4 @-> ipv4
     method name = Name.create "qubes_ipv4" ~prefix:"qubes_ipv4"
     method module_name = "Qubesdb_ipv4.Make"
-    method! packages = Key.pure [ package ~min:"0.6" "mirage-qubes-ipv4" ]
+    method! packages =
+      Key.pure [ package ~min:"0.6" ~max:"0.7" "mirage-qubes-ipv4" ]
     method! connect _ modname = function
       | [  db ; _random ; mclock ;etif; arp ] ->
         Fmt.strf "%s.connect@[@ %s@ %s@ %s@ %s@]" modname db mclock etif arp
@@ -132,7 +140,7 @@ let ipv6_conf ?addresses ?netmasks ?gateways () = impl @@ object
     method ty = ethernet @-> random @-> time @-> mclock @-> ipv6
     method name = Name.create "ipv6" ~prefix:"ipv6"
     method module_name = "Ipv6.Make"
-    method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["ipv6"] "tcpip"
+    method! packages = right_tcpip_library ~sublibs:["ipv6"] "tcpip"
     method! keys = addresses @?? netmasks @?? gateways @?? []
     method! connect _ modname = function
       | [ etif ; _random ; _time ; clock ] ->

--- a/lib/mirage_impl_ip.mli
+++ b/lib/mirage_impl_ip.mli
@@ -71,9 +71,7 @@ val ipv4_qubes :
   -> ipv4 impl
 
 val right_tcpip_library :
-     ?min:string
-  -> ?max:string
-  -> ?ocamlfind:string list
+     ?ocamlfind:string list
   -> sublibs:string list
   -> string
   -> package list value

--- a/lib/mirage_impl_kv_ro.ml
+++ b/lib/mirage_impl_kv_ro.ml
@@ -14,7 +14,10 @@ let crunch dirname = impl @@ object
     method name = name
     method module_name = String.Ascii.capitalize name
     method! packages =
-      Key.pure [ package "io-page"; package ~min:"2.0.0" ~build:true "crunch" ]
+      Key.pure [
+        package ~min:"2.0.0" ~max:"3.0.0" "io-page";
+        package ~min:"2.0.0" ~max:"3.0.0" ~build:true "crunch"
+      ]
     method! connect _ modname _ = Fmt.strf "%s.connect ()" modname
     method! build _i =
       let dir = Fpath.(v dirname) in
@@ -36,7 +39,8 @@ let direct_kv_ro_conf dirname = impl @@ object
     val name = Name.create ("direct" ^ dirname) ~prefix:"direct"
     method name = name
     method module_name = "Kvro_fs_unix"
-    method! packages = Key.pure [ package ~min:"1.3.0" "mirage-fs-unix" ]
+    method! packages =
+      Key.pure [ package ~min:"1.5.0" ~max:"2.0.0" "mirage-fs-unix" ]
     method! connect i _modname _names =
       let path = Fpath.(Info.build_dir i / dirname) in
       Fmt.strf "Kvro_fs_unix.connect \"%a\"" Fpath.pp path

--- a/lib/mirage_impl_mclock.ml
+++ b/lib/mirage_impl_mclock.ml
@@ -10,8 +10,8 @@ let monotonic_clock_conf = object
   method module_name = "Mclock"
   method! packages =
     Mirage_key.(if_ is_unix)
-      [ package ~min:"1.2.0" "mirage-clock-unix" ]
-      [ package ~min:"1.2.0" "mirage-clock-freestanding" ]
+      [ package ~min:"1.2.0" ~max:"2.0.0" "mirage-clock-unix" ]
+      [ package ~min:"1.2.0" ~max:"2.0.0" "mirage-clock-freestanding" ]
   method! connect _ modname _args = Fmt.strf "%s.connect ()" modname
 end
 

--- a/lib/mirage_impl_network.ml
+++ b/lib/mirage_impl_network.ml
@@ -17,11 +17,14 @@ let network_conf (intf : string Key.key) =
     method! keys = [ key ]
     method! packages =
       Key.match_ Key.(value target) @@ function
-      | `Unix -> [ package ~min:"2.3.0" "mirage-net-unix" ]
-      | `MacOSX -> [ package ~min:"1.3.0" "mirage-net-macosx" ]
-      | `Xen -> [ package ~min:"1.7.0" "mirage-net-xen"]
-      | `Qubes -> [ package ~min:"1.7.0" "mirage-net-xen" ; package ~min:"0.4" "mirage-qubes" ]
-      | `Virtio | `Hvt | `Muen | `Genode -> [ package ~min:"0.3.0" "mirage-net-solo5" ]
+      | `Unix -> [ package ~min:"2.3.0" ~max:"3.0.0" "mirage-net-unix" ]
+      | `MacOSX -> [ package ~min:"1.4.0" ~max:"2.0.0" "mirage-net-macosx" ]
+      | `Xen -> [ package ~min:"1.7.0" ~max:"2.0.0" "mirage-net-xen"]
+      | `Qubes ->
+        [ package ~min:"1.7.0" ~max:"2.0.0" "mirage-net-xen" ;
+          Mirage_impl_qubesdb.pkg ]
+      | `Virtio | `Hvt | `Muen | `Genode ->
+        [ package ~min:"0.4.0" ~max:"0.5.0" "mirage-net-solo5" ]
     method! connect _ modname _ =
       Fmt.strf "%s.connect %a" modname Key.serialize_call key
     method! configure i =

--- a/lib/mirage_impl_pclock.ml
+++ b/lib/mirage_impl_pclock.ml
@@ -10,8 +10,8 @@ let posix_clock_conf = object
   method module_name = "Pclock"
   method! packages =
     Mirage_key.(if_ is_unix)
-      [ package ~min:"1.2.0" "mirage-clock-unix" ]
-      [ package ~min:"1.2.0" "mirage-clock-freestanding" ]
+      [ package ~min:"1.2.0" ~max:"2.0.0" "mirage-clock-unix" ]
+      [ package ~min:"1.2.0" ~max:"2.0.0" "mirage-clock-freestanding" ]
   method! connect _ modname _args = Fmt.strf "%s.connect ()" modname
 end
 

--- a/lib/mirage_impl_qrexec.ml
+++ b/lib/mirage_impl_qrexec.ml
@@ -11,7 +11,7 @@ let qrexec_qubes = impl @@ object
   val name = Name.ocamlify @@ "qrexec_"
   method name = name
   method module_name = "Qubes.RExec"
-  method! packages = Key.pure [ package ~min:"0.4" "mirage-qubes" ]
+  method! packages = Key.pure [ Mirage_impl_qubesdb.pkg ]
   method! configure i =
     match Mirage_impl_misc.get_target i with
     | `Qubes -> R.ok ()

--- a/lib/mirage_impl_qubesdb.ml
+++ b/lib/mirage_impl_qubesdb.ml
@@ -6,12 +6,14 @@ open Rresult
 type qubesdb = QUBES_DB
 let qubesdb = Type QUBES_DB
 
+let pkg = package ~min:"0.4" ~max:"0.7" "mirage-qubes"
+
 let qubesdb_conf = object
   inherit base_configurable
   method ty = qubesdb
   method name = "qubesdb"
   method module_name = "Qubes.DB"
-  method! packages = Key.pure [ package ~min:"0.4" "mirage-qubes" ]
+  method! packages = Key.pure [ pkg ]
   method! configure i =
     match get_target i with
     | `Qubes | `Xen -> R.ok ()

--- a/lib/mirage_impl_qubesdb.mli
+++ b/lib/mirage_impl_qubesdb.mli
@@ -3,3 +3,5 @@ type qubesdb
 val qubesdb : qubesdb Functoria.typ
 
 val default_qubesdb : qubesdb Functoria.impl
+
+val pkg : Functoria.package

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -8,7 +8,8 @@ let stdlib_random_conf = object
   method ty = random
   method name = "random"
   method module_name = "Mirage_random_stdlib"
-  method! packages = Mirage_key.pure [ package "mirage-random-stdlib" ]
+  method! packages =
+    Mirage_key.pure [ package ~max:"0.1.0" "mirage-random-stdlib" ]
   method! connect _ modname _ = Fmt.strf "%s.initialize ()" modname
 end
 
@@ -30,18 +31,19 @@ let nocrypto = impl @@ object
     method! packages =
       Mirage_key.match_ Mirage_key.(value target) @@ function
       | `Xen | `Qubes ->
-        [ package ~min:"0.5.4" ~sublibs:["mirage"] "nocrypto";
-          package ~ocamlfind:[] "zarith-xen" ]
+        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto";
+          package ~max:"2.0" ~ocamlfind:[] "zarith-xen" ]
       | `Virtio | `Hvt | `Muen | `Genode ->
-        [ package ~min:"0.5.4" ~sublibs:["mirage"] "nocrypto";
-          package ~ocamlfind:[] "zarith-freestanding" ]
+        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto";
+          package ~max:"2.0" ~ocamlfind:[] "zarith-freestanding" ]
       | `Unix | `MacOSX ->
-        [ package ~min:"0.5.4" ~sublibs:["lwt"] "nocrypto" ]
+        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["lwt"] "nocrypto" ]
 
     method! build _ = Rresult.R.ok (enable_entropy ())
     method! connect i _ _ =
       match Mirage_impl_misc.get_target i with
-      | `Xen | `Qubes | `Virtio | `Hvt | `Muen | `Genode -> "Nocrypto_entropy_mirage.initialize ()"
+      | `Xen | `Qubes | `Virtio | `Hvt | `Muen | `Genode ->
+        "Nocrypto_entropy_mirage.initialize ()"
       | `Unix | `MacOSX -> "Nocrypto_entropy_lwt.initialize ()"
   end
 
@@ -50,7 +52,8 @@ let nocrypto_random_conf = object
   method ty = random
   method name = "random"
   method module_name = "Nocrypto.Rng"
-  method! packages = Mirage_key.pure [ package ~min:"0.5.4" "nocrypto" ]
+  method! packages =
+    Mirage_key.pure [ package ~min:"0.5.4" ~max:"0.6.0" "nocrypto" ]
   method! deps = [abstract nocrypto]
 end
 

--- a/lib/mirage_impl_reporter.ml
+++ b/lib/mirage_impl_reporter.ml
@@ -20,7 +20,8 @@ let mirage_log ?ring_size ~default =
     method ty = pclock @-> reporter
     method name = "mirage_logs"
     method module_name = "Mirage_logs.Make"
-    method! packages = Key.pure [ package ~min:"0.3.0" "mirage-logs"]
+    method! packages =
+      Key.pure [ package ~min:"0.3.0" ~max:"0.4.0" "mirage-logs" ]
     method! keys = [ Key.abstract logs ]
     method! connect _ modname = function
       | [ pclock ] ->

--- a/lib/mirage_impl_resolver.ml
+++ b/lib/mirage_impl_resolver.ml
@@ -15,8 +15,8 @@ let resolver_unix_system = impl @@ object
     method module_name = "Resolver_lwt"
     method! packages =
       Key.(if_ is_unix)
-        [ package ~min:"3.1.0" ~ocamlfind:[] "mirage-conduit" ;
-          package ~min:"1.0.0" "conduit-lwt-unix"; ]
+        [ Mirage_impl_conduit_connector.pkg ;
+          package ~min:"1.0.0" ~max:"2.0.0" "conduit-lwt-unix"; ]
         []
     method! configure i =
       match get_target i with
@@ -34,9 +34,7 @@ let resolver_dns_conf ~ns ~ns_port = impl @@ object
     method name = "resolver"
     method module_name = "Resolver_mirage.Make_with_stack"
     method! packages =
-      Key.pure [
-        package ~min:"3.0.1" "mirage-conduit" ;
-      ]
+      Key.pure [ Mirage_impl_conduit_connector.pkg ]
     method! connect _ modname = function
       | [ _t ; stack ] ->
         let meta_ns = Fmt.Dump.option meta_ipv4 in

--- a/lib/mirage_impl_stackv4.ml
+++ b/lib/mirage_impl_stackv4.ml
@@ -26,7 +26,7 @@ let stackv4_direct_conf ?(group="") () = impl @@ object
     val name = add_suffix "stackv4_" ~suffix:group
     method name = name
     method module_name = "Tcpip_stack_direct.Make"
-    method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["stack-direct"] "tcpip" ]
+    method! packages = right_tcpip_library ~sublibs:["stack-direct"] "tcpip"
     method! connect _i modname = function
       | [ _t; _r; interface; ethif; arp; ip; icmp; udp; tcp ] ->
         Fmt.strf
@@ -74,7 +74,7 @@ let stackv4_socket_conf ?(group="") ips = impl @@ object
     method name = name
     method module_name = "Tcpip_stack_socket"
     method! keys = [ Key.abstract ips ]
-    method! packages = Key.pure [ package ~min:"3.5.0" ~sublibs:["stack-socket"; "unix"] "tcpip" ]
+    method! packages = right_tcpip_library ~sublibs:["stack-socket"] "tcpip"
     method! deps = [abstract (socket_udpv4 None); abstract (socket_tcpv4 None)]
     method! connect _i modname = function
       | [ udpv4 ; tcpv4 ] ->

--- a/lib/mirage_impl_syslog.ml
+++ b/lib/mirage_impl_syslog.ml
@@ -32,6 +32,9 @@ let opt p s = Fmt.(option @@ prefix (unit ("~"^^s^^":")) p)
 let opt_int = opt Fmt.int
 let opt_string = opt (fun pp v -> Format.fprintf pp "%S" v)
 
+let pkg sublibs =
+  Key.pure [ package ~min:"0.2.0" ~max:"0.3.0" ~sublibs "logs-syslog" ]
+
 let syslog_udp_conf config =
   let endpoint = Key.syslog config.server
   and port = Key.syslog_port config.port
@@ -42,8 +45,9 @@ let syslog_udp_conf config =
     method ty = console @-> pclock @-> stackv4 @-> syslog
     method name = "udp_syslog"
     method module_name = "Logs_syslog_mirage.Udp"
-    method! packages = Key.pure [ package ~min:"0.1.0" ~sublibs:["mirage"] "logs-syslog" ]
-    method! keys = [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
+    method! packages = pkg ["mirage"]
+    method! keys =
+      [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
     method! connect _i modname = function
       | [ console ; pclock ; stack ] ->
         Fmt.strf
@@ -78,8 +82,9 @@ let syslog_tcp_conf config =
     method ty = console @-> pclock @-> stackv4 @-> syslog
     method name = "tcp_syslog"
     method module_name = "Logs_syslog_mirage.Tcp"
-    method! packages = Key.pure [ package ~min:"0.1.0" ~sublibs:["mirage"] "logs-syslog" ]
-    method! keys = [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
+    method! packages = pkg ["mirage"]
+    method! keys =
+      [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
     method! connect _i modname = function
       | [ console ; pclock ; stack ] ->
         Fmt.strf
@@ -112,7 +117,7 @@ let syslog_tls_conf ?keyname config =
     method ty = console @-> pclock @-> stackv4 @-> kv_ro @-> syslog
     method name = "tls_syslog"
     method module_name = "Logs_syslog_mirage_tls.Tls"
-    method! packages = Key.pure [ package ~min:"0.1.0" ~sublibs:["mirage" ; "mirage.tls"] "logs-syslog" ]
+    method! packages = pkg ["mirage" ; "mirage.tls"]
     method! keys = [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
     method! connect _i modname = function
       | [ console ; pclock ; stack ; kv ] ->

--- a/lib/mirage_impl_tcp.ml
+++ b/lib/mirage_impl_tcp.ml
@@ -22,7 +22,7 @@ let tcp_direct_conf () = object
   method ty = (ip: 'a ip typ) @-> time @-> mclock @-> random @-> (tcp: 'a tcp typ)
   method name = "tcp"
   method module_name = "Tcp.Flow.Make"
-  method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["tcp"] "tcpip"
+  method! packages = right_tcpip_library ~sublibs:["tcp"] "tcpip"
   method! connect _ modname = function
     | [ip; _time; clock; _random] -> Fmt.strf "%s.connect %s %s" modname ip clock
     | _ -> failwith (connect_err "direct tcp" 4)
@@ -44,8 +44,7 @@ let tcpv4_socket_conf ipv4_key = object
   method name = name
   method module_name = "Tcpv4_socket"
   method! keys = [ Key.abstract ipv4_key ]
-  method! packages =
-    Key.(if_ is_unix) [ package ~min:"3.5.0" ~sublibs:["tcpv4-socket"; "unix"] "tcpip" ] []
+  method! packages = right_tcpip_library ~sublibs:["tcpv4-socket"] "tcpip"
   method! configure i =
     match get_target i with
     | `Unix | `MacOSX -> R.ok ()

--- a/lib/mirage_impl_tracing.ml
+++ b/lib/mirage_impl_tracing.ml
@@ -17,9 +17,13 @@ let mprof_trace ~size () =
     method! keys = [ Key.abstract key ]
     method! packages =
       Key.match_ Key.(value target) @@ function
-      | `Xen | `Qubes -> [ package "mirage-profile"; package "mirage-profile-xen" ]
+      | `Xen | `Qubes ->
+        [ package ~max:"1.0.0" "mirage-profile";
+          package ~max:"1.0.0" "mirage-profile-xen" ]
       | `Virtio | `Hvt | `Muen | `Genode -> []
-      | `Unix | `MacOSX -> [ package "mirage-profile"; package "mirage-profile-unix" ]
+      | `Unix | `MacOSX ->
+        [ package ~max:"1.0.0" "mirage-profile";
+          package ~max:"1.0.0" "mirage-profile-unix" ]
     method! build _ =
       match query_ocamlfind ["lwt.tracing"] with
       | Error _ | Ok [] ->
@@ -27,7 +31,8 @@ let mprof_trace ~size () =
                      opam pin add lwt https://github.com/mirage/lwt.git#tracing"
       | Ok _ -> Ok ()
     method! connect i _ _ = match get_target i with
-      | `Virtio | `Hvt | `Muen | `Genode -> failwith  "tracing is not currently implemented for solo5 targets"
+      | `Virtio | `Hvt | `Muen | `Genode ->
+        failwith  "tracing is not currently implemented for solo5 targets"
       | `Unix | `MacOSX ->
         Fmt.strf
           "Lwt.return ())@.\

--- a/lib/mirage_impl_udp.ml
+++ b/lib/mirage_impl_udp.ml
@@ -20,7 +20,7 @@ let udp_direct_conf () = object
   method ty = (ip: 'a ip typ) @-> random @-> (udp: 'a udp typ)
   method name = "udp"
   method module_name = "Udp.Make"
-  method! packages = right_tcpip_library ~min:"3.5.0" ~sublibs:["udp"] "tcpip"
+  method! packages = right_tcpip_library ~sublibs:["udp"] "tcpip"
   method! connect _ modname = function
     | [ ip; _random ] -> Fmt.strf "%s.connect %s" modname ip
     | _  -> failwith (connect_err "udp" 2)
@@ -38,9 +38,7 @@ let udpv4_socket_conf ipv4_key = object
   method module_name = "Udpv4_socket"
   method! keys = [ Key.abstract ipv4_key ]
   method! packages =
-    Key.(if_ is_unix)
-      [ package ~min:"3.5.0" ~sublibs:["udpv4-socket"; "unix"] "tcpip" ]
-      []
+    right_tcpip_library ~sublibs:["udpv4-socket"] "tcpip"
   method! configure i =
     match get_target i with
     | `Unix | `MacOSX -> R.ok ()

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build & >= "1.1.0"}
   "ipaddr"             {>= "2.6.0"}
-  "functoria-runtime"  {>= "2.0.0"}
+  "functoria-runtime"  {>= "2.2.2"}
   "fmt"
   "astring"
   "logs"

--- a/mirage-types-lwt.opam
+++ b/mirage-types-lwt.opam
@@ -21,7 +21,7 @@ depends:   [
   "cstruct" {>="1.4.0"}
   "io-page" {>="1.4.0"}
   "ipaddr"
-  "mirage-types" {>= "3.2.0"}
+  "mirage-types" {>= "3.3.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-time-lwt" {>= "1.0.0"}
   "mirage-random" {>= "1.0.0"}

--- a/mirage.opam
+++ b/mirage.opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build & >= "1.1.0"}
   "ipaddr"             {>= "2.6.0"}
-  "functoria"          {>= "2.2.0"}
+  "functoria"          {>= "2.2.2"}
   "bos"
   "astring"
   "logs"

--- a/mirage.opam
+++ b/mirage.opam
@@ -24,7 +24,7 @@ depends: [
   "bos"
   "astring"
   "logs"
-  "mirage-runtime"     {>= "3.2.0"}
+  "mirage-runtime"     {>= "3.3.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """


### PR DESCRIPTION
extracted from #944, superseeds #855:
- some packages (tcpip, mirage-qubes, fat, conduit etc.) to variables to avoid repeating the version constraints
- if version `< 1.0.0` then `~min:"a.b.c"` `~max:"a.(b+1).0"`
- if version `> 1.0.0` then `~min:"a.b.c" `~max:"(a+1).0.0"`
- an exception is tcpip with `~min:"3.5.0"` `~max:"3.6.0"`
- `mirage-block-ramdisk` is still unconstrained
- is this ok for e.g. `charrua` (which uses 0.x, constrained to `< 0.11`), `mirage-qubes` (also 0.x, constrained to `< 0.7`), `mirage-profile*` (constraint to `< 1.0.0`)

~~may result in CI failure (until #938 is merged)~~