### PR TITLE
avoid opam pin during installation of dependencies in generated makefile

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -493,23 +493,23 @@ let configure_makefile ~opam_name =
       append fmt "-include Makefile.user";
       newline fmt;
       append fmt "OPAM = opam\n\
-                  DEPEXT ?= opam depext --yes --update %s\n\
+                  DEPEXT ?= $(OPAM) pin add -k path --no-action --yes %s . &&\\\n\
+                  \t$(OPAM) depext --yes --update %s ;\\\n\
+                  \t$(OPAM) pin remove --no-action %s\n\
                   \n\
                   .PHONY: all depend depends clean build\n\
                   all:: build\n\
                   \n\
                   depend depends::\n\
-                  \t$(OPAM) pin add -k path --no-action --yes %s .\n\
                   \t$(DEPEXT)\n\
-                  \t$(OPAM) install --yes --deps-only %s\n\
-                  \t$(OPAM) pin remove --no-action %s\n\
+                  \t$(OPAM) install --deps-only .\n\
                   \n\
                   build::\n\
                   \tmirage build\n\
                   \n\
                   clean::\n\
                   \tmirage clean\n"
-        opam_name opam_name opam_name opam_name;
+        opam_name opam_name opam_name;
       R.ok ())
     "Makefile"
 

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -176,6 +176,12 @@ let target_debug =
   let key = Arg.flag ~stage:`Configure doc in
   Key.create "target_debug" key
 
+let no_depext =
+  let doc = "Disable call to depext when generating Makefile." in
+  let doc = Arg.info ~docs:mirage_section ~docv:"BOOL" ~doc ["no-depext"] in
+  let key = Arg.flag ~stage:`Configure doc in
+  Key.create "no_depext" key
+
 (** {3 Tracing} *)
 
 let tracing_size default =

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -166,7 +166,7 @@ let is_unix =
 let warn_error =
   let doc = "Enable -warn-error when compiling OCaml sources." in
   let doc = Arg.info ~docs:mirage_section ~docv:"BOOL" ~doc ["warn-error"] in
-  let key = Arg.(opt ~stage:`Configure bool false doc) in
+  let key = Arg.flag ~stage:`Configure doc in
   Key.create "warn_error" key
 
 let target_debug =

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -52,7 +52,10 @@ val warn_error: bool key
     default, but might might enabled by default in later releases. *)
 
 val target_debug: bool key
-(** Enables target-specific support for debugging. *)
+(** [-g]. Enables target-specific support for debugging. *)
+
+val no_depext: bool key
+(** [--no-depext]. Disables opam depext in depend target of generated Makefile. *)
 
 val tracing_size: int -> int key
 (** [--tracing-size]: Key setting the tracing ring buffer size. *)


### PR DESCRIPTION
unfortunately, opam depext AFAICT doesn't support a local opam file, it needs
 to get the opam file pinned

addresses #852