### PR TITLE
regression in 3.3.0: opam install no longer gets --yes passed

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -503,7 +503,7 @@ let configure_makefile ~no_depext ~opam_name =
                   all:: build\n\
                   \n\
                   depend depends::%s\n\
-                  \t$(OPAM) install --deps-only .\n\
+                  \t$(OPAM) install -y --deps-only .\n\
                   \n\
                   build::\n\
                   \tmirage build\n\


### PR DESCRIPTION
sorry for that. if CI passes, I'll merge and release 3.3.1.