### PR TITLE
Use pp and of_string from Ipaddr modules instead of s-expressions

### DIFF
--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -38,21 +38,23 @@ module Arg = struct
 
   include Functoria_runtime.Arg
 
-  let make of_string pp: _ Cmdliner.Arg.converter =
+  let make of_string to_string :_ Cmdliner.Arg.converter =
     let parser s = match of_string s with
-      | Some ip -> `Ok ip
-      | None -> `Error ("Can't parse ip address: "^s)
+      | Error (`Msg m) -> `Error ("Can't parse ip address: "^s^": "^m)
+      | Ok ip -> `Ok ip
+    and pp ppf ip =
+      Fmt.string ppf (to_string ip)
     in
     parser, pp
 
   module type S = sig
     type t
-    val of_string : string -> t option
-    val pp : Format.formatter -> t -> unit
+    val of_string : string -> (t, [ `Msg of string ]) result
+    val to_string : t -> string
   end
 
   let of_module (type t) (module M:S with type t = t) =
-    make M.of_string M.pp
+    make M.of_string M.to_string
 
   let ip = of_module (module Ipaddr)
   let ipv4_address = of_module (module Ipaddr.V4)
@@ -62,8 +64,8 @@ module Arg = struct
     in
     let parse str =
       match Ipaddr.V4.Prefix.of_address_string str with
-      | None -> `Error (str ^ " is not a valid IPv4 address and netmask")
-      | Some n -> `Ok n
+      | Error (`Msg m) -> `Error (str ^ " is not a valid IPv4 address and netmask: " ^ m)
+      | Ok n -> `Ok n
     in
     parse, serialize
 

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -48,18 +48,17 @@ module Arg = struct
   module type S = sig
     type t
     val of_string : string -> t option
-    val pp_hum : Format.formatter -> t -> unit
+    val pp : Format.formatter -> t -> unit
   end
 
   let of_module (type t) (module M:S with type t = t) =
-    make M.of_string M.pp_hum
+    make M.of_string M.pp
 
   let ip = of_module (module Ipaddr)
   let ipv4_address = of_module (module Ipaddr.V4)
   let ipv4 =
     let serialize fmt (prefix, ip) =
-      Format.fprintf fmt "(Ipaddr.V4.Prefix.of_address_string_exn \"%s\")"
-      @@ Ipaddr.V4.Prefix.to_address_string prefix ip
+      Format.fprintf fmt "%S" @@ Ipaddr.V4.Prefix.to_address_string prefix ip
     in
     let parse str =
       match Ipaddr.V4.Prefix.of_address_string str with

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -40,7 +40,7 @@ module Arg: sig
   module type S = sig
     type t
     val of_string: string -> t option
-    val pp_hum: Format.formatter -> t -> unit
+    val pp: Format.formatter -> t -> unit
   end
   (** [S] is the signature used by {!of_module} to create a
       command-line argument converter. *)

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -33,14 +33,15 @@ module Arg: sig
 
   include module type of Functoria_runtime.Arg
 
-  val make: (string -> 'a option) -> 'a Fmt.t -> 'a Cmdliner.Arg.converter
+  val make: (string -> ('a, [ `Msg of string ]) result) -> ('a -> string) ->
+    'a Cmdliner.Arg.converter
   (** [make of_string pp] is the command-line argument converter using
       on [of_string] and [pp]. *)
 
   module type S = sig
     type t
-    val of_string: string -> t option
-    val pp: Format.formatter -> t -> unit
+    val of_string: string -> (t, [ `Msg of string ]) result
+    val to_string: t -> string
   end
   (** [S] is the signature used by {!of_module} to create a
       command-line argument converter. *)

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build & >= "1.1.0"}
-  "ipaddr"             {>= "2.6.0"}
+  "ipaddr"             {>= "2.9.0"}
   "functoria-runtime"  {>= "2.2.2"}
   "fmt"
   "logs"

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build & >= "1.1.0"}
-  "ipaddr"             {>= "2.9.0"}
+  "ipaddr"             {>= "3.0.0"}
   "functoria-runtime"  {>= "2.2.2"}
   "fmt"
   "logs"

--- a/mirage.opam
+++ b/mirage.opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build & >= "1.1.0"}
-  "ipaddr"             {>= "2.6.0"}
+  "ipaddr"             {>= "2.9.0"}
   "functoria"          {>= "2.2.3"}
   "bos"
   "astring"

--- a/mirage.opam
+++ b/mirage.opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build & >= "1.1.0"}
-  "ipaddr"             {>= "2.9.0"}
+  "ipaddr"             {>= "3.0.0"}
   "functoria"          {>= "2.2.3"}
   "bos"
   "astring"


### PR DESCRIPTION
The problem I try to solve: a hello world (not stripped, no lto, hvt target) is on my machine 3MB in binary size. I investigated why this is the case. A major consumer of binary size is the sexplib library, which is required by the ocaml-ipaddr library at the moment.

Mirage itself also uses the s-expression conversion for arguments. This PR uses pp and of_string instead.

Once ipaddr will split its sexp usage into a separate library (as uri did recently, introducing uri.sexp), a resulting hello world unikernel will use only 2MB in binary size.

This PR is ready for review, and I'm interested in your feedback. At its current state, it assumes that "forall ip. of_string_exn (pp ip) = ip", is this reasonable? I tried to use `to_string` instead, but `Ipaddr.V6.to_string` has a different signature (by having the optional labeled keyword `v4`) than `Ipaddr.V4.to_string`.