### PR TITLE
Use String.split_on_char instead of Astring in mirage-runtime

### DIFF
--- a/lib_runtime/dune
+++ b/lib_runtime/dune
@@ -2,4 +2,4 @@
   (name        mirage_runtime)
   (public_name mirage-runtime)
   (wrapped     false)
-  (libraries   functoria-runtime ipaddr astring logs fmt))
+  (libraries   functoria-runtime ipaddr logs fmt))

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -87,10 +87,10 @@ module Arg = struct
       with Not_found -> "warning"
     in
     let parser str =
-      match Astring.String.cut ~sep:":" str with
-      | None            -> `Ok (`All    , level_of_string str)
-      | Some ("*", str) -> `Ok (`All    , level_of_string str)
-      | Some (src, str) -> `Ok (`Src src, level_of_string str)
+      match String.split_on_char ':' str with
+      | [] -> `Ok (`All, level_of_string str)
+      | [ src ; lvl ] -> `Ok (`Src src, level_of_string lvl)
+      | _ -> `Error ("Can't parse log threshold: "^str)
     in
     let serialize ppf = function
       | `All  , l -> Fmt.string ppf (string_of_level l)

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -22,7 +22,6 @@ depends: [
   "ipaddr"             {>= "2.6.0"}
   "functoria-runtime"  {>= "2.2.2"}
   "fmt"
-  "astring"
   "logs"
 ]
 synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"


### PR DESCRIPTION
fewer dependencies are better, and split_on_char exists since 4.04.0 -- mirage depends on >=4.04.2.

most unikernels won't see an improvement in binary size, since they usually use parse-argv that depends (rightfully!) on Astring -- but we have the `no_argv` device -- if your unikernel is not interested in boot arguments that can leverage ~300kB of binary size.

no, I've no plans to remove the fmt and/or logs dependency from mirage-runtime ;)