### PR TITLE
default to socket stack on unix and macosx when using generic_stackv4

### DIFF
--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -390,9 +390,10 @@ val dhcp_ipv4_stack: ?group:string -> ?random:random impl -> ?time:time impl -> 
 val static_ipv4_stack: ?group:string -> ?config:ipv4_config -> ?arp:(ethernet impl -> arpv4 impl) -> network impl -> stackv4 impl
 
 (** Generic stack using a [dhcp] and a [net] keys: {!Key.net} and {!Key.dhcp}.
-    - If [target] = [Qubes] then {!qubes_ipv4_stack} is used.
-    - If [net] = [socket] then {!socket_stackv4} is used.
+    - If [target] = [Qubes] then {!qubes_ipv4_stack} is used
+    - Else, if [net] = [socket] then {!socket_stackv4} is used
     - Else, if [dhcp] then {!dhcp_ipv4_stack} is used
+    - Else, if [unix or macosx] then {!socket_stackv4} is used
     - Else, {!static_ipv4_stack} is used.
 
     If a key is not provided, it uses {!Key.net} or {!Key.dhcp} (with the
@@ -401,7 +402,7 @@ val static_ipv4_stack: ?group:string -> ?config:ipv4_config -> ?arp:(ethernet im
 val generic_stackv4:
   ?group:string -> ?config:ipv4_config ->
   ?dhcp_key:bool value ->
-  ?net_key:[ `Direct | `Socket ] value ->
+  ?net_key:[ `Direct | `Socket ] option value ->
   network impl -> stackv4 impl
 
 (** {2 Resolver configuration} *)

--- a/lib/mirage_impl_stackv4.mli
+++ b/lib/mirage_impl_stackv4.mli
@@ -45,6 +45,6 @@ val generic_stackv4 :
      ?group:string
   -> ?config:Mirage_impl_ip.ipv4_config
   -> ?dhcp_key:bool Functoria.value
-  -> ?net_key:[`Direct | `Socket] Functoria.value
+  -> ?net_key:[`Direct | `Socket] option Functoria.value
   -> Mirage_impl_network.network Functoria.impl
   -> stackv4 Functoria.impl

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -278,17 +278,17 @@ let dhcp ?group () =
   create_simple
     ~doc ?group ~stage:`Configure ~default:false Arg.bool "dhcp"
 
-let net ?group (): [`Socket | `Direct] Key.key =
+let net ?group (): [`Socket | `Direct] option Key.key =
   let conv = Cmdliner.Arg.enum ["socket", `Socket ; "direct", `Direct] in
   let serialize fmt = function
-    | `Socket -> Fmt.pf fmt "`Socket"
-    | `Direct -> Fmt.pf fmt "`Direct"
+    | `Socket -> Fmt.string fmt "`Socket"
+    | `Direct -> Fmt.string fmt "`Direct"
   in
   let conv = Arg.conv ~conv ~runtime_conv:"net" ~serialize in
   let doc =
     Fmt.strf "Use $(i,socket) or $(i,direct) group for %a." pp_group group
   in
-  create_simple ~doc ?group ~stage:`Configure ~default:`Direct conv "net"
+  create_simple ~doc ?group ~stage:`Configure ~default:None (Arg.some conv) "net"
 
 (** {3 Network keys} *)
 

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -93,7 +93,7 @@ val prng : ?group:string -> unit -> [ `Stdlib | `Nocrypto ] key
 val dhcp : ?group:string -> unit -> bool key
 (** Enable dhcp. Is either [true] or [false]. *)
 
-val net : ?group:string -> unit -> [ `Direct | `Socket ] key
+val net : ?group:string -> unit -> [ `Direct | `Socket ] option key
 (** The type of stack. Is either ["direct"] or ["socket"]. *)
 
 (** {3 Network keys} *)


### PR DESCRIPTION
currently, when compiling for unix, the default network stack is the direct one -- unless `--net=socket` is provided. various unikernels contain the following boilerplate in the config.ml:
```OCaml
let net =
  if_impl Key.is_unix
    (socket_stackv4 [Ipaddr.V4.any])
    (static_ipv4_stack ~config:address default_network)
```
to use the socket stack by default on unix. This is not a good idea in several aspects, including that now on unix it is no longer possible to configure a direct stack.