### PR TITLE
mirage-clock 2.x only API change is type t = unit, which is fine with mirage

### DIFF
--- a/lib/mirage_impl_mclock.ml
+++ b/lib/mirage_impl_mclock.ml
@@ -10,8 +10,8 @@ let monotonic_clock_conf = object
   method module_name = "Mclock"
   method! packages =
     Mirage_key.(if_ is_unix)
-      [ package ~min:"1.2.0" ~max:"2.0.0" "mirage-clock-unix" ]
-      [ package ~min:"1.2.0" ~max:"2.0.0" "mirage-clock-freestanding" ]
+      [ package ~min:"1.2.0" ~max:"3.0.0" "mirage-clock-unix" ]
+      [ package ~min:"1.2.0" ~max:"3.0.0" "mirage-clock-freestanding" ]
   method! connect _ modname _args = Fmt.strf "%s.connect ()" modname
 end
 

--- a/lib/mirage_impl_pclock.ml
+++ b/lib/mirage_impl_pclock.ml
@@ -10,8 +10,8 @@ let posix_clock_conf = object
   method module_name = "Pclock"
   method! packages =
     Mirage_key.(if_ is_unix)
-      [ package ~min:"1.2.0" ~max:"2.0.0" "mirage-clock-unix" ]
-      [ package ~min:"1.2.0" ~max:"2.0.0" "mirage-clock-freestanding" ]
+      [ package ~min:"1.2.0" ~max:"3.0.0" "mirage-clock-unix" ]
+      [ package ~min:"1.2.0" ~max:"3.0.0" "mirage-clock-freestanding" ]
   method! connect _ modname _args = Fmt.strf "%s.connect ()" modname
 end
 


### PR DESCRIPTION
i.e. all unikernels are fine with this. ref https://github.com/mirage/mirage-clock/pull/38 https://github.com/mirage/mirage-clock/pull/39 https://github.com/ocaml/opam-repository/pull/13207