### PR TITLE
fix parsing of "-l debug" for log sources, as mentioned by @cfcs

### DIFF
--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -88,7 +88,7 @@ module Arg = struct
     in
     let parser str =
       match String.split_on_char ':' str with
-      | [] -> `Ok (`All, level_of_string str)
+      | [ _ ] -> `Ok (`All, level_of_string str)
       | [ src ; lvl ] -> `Ok (`Src src, level_of_string lvl)
       | _ -> `Error ("Can't parse log threshold: "^str)
     in


### PR DESCRIPTION
as commented in https://github.com/mirage/mirage/pull/957#issuecomment-450776686, `String.split_on_char` does never return the empty list.