### PR TITLE
changes entries for 3.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+### v3.4.0 (2019-01-08)
+
+* use ipaddr 3.0 without s-expression dependency (#956, by @hannesm)
+* use mirage-clock 2.x and tcpip 3.6.x libraries (#960, #962, by @hannesm)
+* default to socket stack on unix and macos (#958, by @hannesm)
+* use String.split_on_char in mirage-runtime to avoid astring dependency (#957, by @hannesm)
+* add build-dependency on mirage to each unikernel (#953, by @hannesm)
+
 ### 3.3.1 (2018-11-21)
 
 * fix regression: --yes was not passed to opam in 3.3.0 (#950, by @hannesm)


### PR DESCRIPTION
once https://github.com/ocaml/opam-repository/pull/13232 is merged, the CI here should be restarted... and if the CI works fine, we can cut a release