### PR TITLE
avoid zarith-freestanding / zarith-xen build dependency

### DIFF
--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -30,14 +30,10 @@ let nocrypto = impl @@ object
     method module_name = "Nocrypto_entropy"
     method! packages =
       Mirage_key.match_ Mirage_key.(value target) @@ function
-      | `Xen | `Qubes ->
-        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto";
-          package ~max:"2.0" ~ocamlfind:[] "zarith-xen" ]
-      | `Virtio | `Hvt | `Muen | `Genode ->
-        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto";
-          package ~max:"2.0" ~ocamlfind:[] "zarith-freestanding" ]
       | `Unix | `MacOSX ->
         [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["lwt"] "nocrypto" ]
+      | _ ->
+        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto"]
 
     method! build _ = Rresult.R.ok (enable_entropy ())
     method! connect i _ _ =

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -33,7 +33,8 @@ let nocrypto = impl @@ object
       | `Unix | `MacOSX ->
         [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["lwt"] "nocrypto" ]
       | _ ->
-        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto"]
+        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto" ;
+          package ~min:"0.4.1" ~max:"0.5.0" "mirage-entropy" ]
 
     method! build _ = Rresult.R.ok (enable_entropy ())
     method! connect i _ _ =


### PR DESCRIPTION
this is already taken care of by nocrypto. this is also not needed here.

how zarith (and gmp) "cross-compilation" works at the moment:
zarith-freestanding(-xen) require gmp-freestanding(-xen), that uses the CFLAGS
of ocaml-freestanding(mirage-xen-posix) via pkg-config to compile zarith+gmp for
the desired target.

the above build (of the C artifacts) results in archive files
(libgmp-freestanding.a and libzarith-freestanding.a), which are installed via
opam. in addition, the META file of zarith is extended with
'freestanding_linkopts = "-lzarith-freestanding -L@gmp-freestanding -lgmp-freestanding"'
(similar for xen). this line is picked up by mirage (once zarith is in the
dependency cone, and the target is a solo5 one) via ocamlfind predicates to
link the final unikernel.

now, at build time - no line of OCaml depends on build products of
zarith-freestanding/gmp-freestanding -- but it is crucial to have
"if the target is solo5(xen), then zarith-freestanding and
gmp-freestanding(-xen) must be installed" (otherwise the linkopt won't exist
and won't be picked up during the final link).

to ensure this, the nocrypto package has the following in their depends:
("mirage-no-solo5" | "mirage-solo5" & "zarith-freestanding") (and similar for
xen using the "mirage-no-xen" package). This is sufficient, and no further
dependencies are needed in the MirageOS utility.

This may be of interest to @emillon and @avsm (who're working on dunifying mirage)!? (and no, the above current state is nothing we should strive for keeping, i.e. zarith-freestanding/xen modifying the zarith META file is a very brittle step)