### PR TITLE
adjust to arp and ethernet changes

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,5 +1,5 @@
 eval `opam config env`
 opam depext -uiy mirage
 cd ~
-git clone -b master https://github.com/mirage/mirage-skeleton.git
+git clone -b ethernet https://github.com/hannesm/mirage-skeleton.git
 make -C mirage-skeleton && rm -rf mirage-skeleton

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="sh ./.travis-ci.sh"
    - PINS="mirage:. mirage-types:. mirage-types-lwt:. mirage-runtime:."
-   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
+   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git#arp"
    - PACKAGE=mirage
  matrix:
    - DISTRO=debian-testing OCAML_VERSION=4.04 EXTRA_ENV="MODE=xen"

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -99,7 +99,6 @@ let etif = Mirage_impl_ethernet.etif
 type arpv4 = Mirage_impl_arpv4.arpv4
 let arpv4 = Mirage_impl_arpv4.arpv4
 let arp = Mirage_impl_arpv4.arp
-let farp = Mirage_impl_arpv4.farp
 
 type v4 = Mirage_impl_ip.v4
 type v6 = Mirage_impl_ip.v6

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -260,10 +260,8 @@ type arpv4
 val arpv4: arpv4 typ
 (** Implementation of the [Mirage_types.ARPV4] signature. *)
 
-val arp: ?clock:mclock impl -> ?time:time impl -> ethernet impl -> arpv4 impl
-
-val farp : ?clock:mclock impl -> ?time:time impl -> ethernet impl -> arpv4 impl
-(** Functional ARP implementation provided by the arp library *)
+val arp : ?time:time impl -> ethernet impl -> arpv4 impl
+(** ARP implementation provided by the arp library *)
 
 (** {2 IP configuration}
 

--- a/lib/mirage_impl_arpv4.ml
+++ b/lib/mirage_impl_arpv4.ml
@@ -1,48 +1,26 @@
 module Key = Mirage_key
 open Functoria
 open Mirage_impl_ethernet
-open Mirage_impl_mclock
 open Mirage_impl_time
 open Mirage_impl_misc
 
 type arpv4 = Arpv4
 let arpv4 = Type Arpv4
 
-let arpv4_conf = object
+let arp_conf = object
   inherit base_configurable
-  method ty = ethernet @-> mclock @-> time @-> arpv4
-  method name = "arpv4"
-  method module_name = "Arpv4.Make"
-  method! packages =
-    Key.pure [ package ~min:"3.6.0" ~max:"3.7.0" ~sublibs:["arpv4"] "tcpip" ]
-  method! connect _ modname = function
-    | [ eth ; clock ; _time ] -> Fmt.strf "%s.connect %s %s" modname eth clock
-    | _ -> failwith (connect_err "arpv4" 3)
-end
-
-let arp_func = impl arpv4_conf
-let arp
-    ?(clock = default_monotonic_clock)
-    ?(time = default_time)
-    (eth : ethernet impl) =
-  arp_func $ eth $ clock $ time
-
-
-let farp_conf = object
-  inherit base_configurable
-  method ty = ethernet @-> mclock @-> time @-> arpv4
+  method ty = ethernet @-> time @-> arpv4
   method name = "arp"
   method module_name = "Arp.Make"
   method! packages =
-    Key.pure [ package ~min:"0.2.0" ~max:"0.3.0" ~sublibs:["mirage"] "arp" ]
+    Key.pure [ package ~min:"1.0.0" ~max:"2.0.0" "arp-mirage" ]
   method! connect _ modname = function
-    | [ eth ; clock ; _time ] -> Fmt.strf "%s.connect %s %s" modname eth clock
+    | [ eth ; _time ] -> Fmt.strf "%s.connect %s" modname eth
     | _ -> failwith (connect_err "arp" 3)
 end
 
-let farp_func = impl farp_conf
-let farp
-    ?(clock = default_monotonic_clock)
+let arp_func = impl arp_conf
+let arp
     ?(time = default_time)
     (eth : ethernet impl) =
-  farp_func $ eth $ clock $ time
+  arp_func $ eth $ time

--- a/lib/mirage_impl_arpv4.mli
+++ b/lib/mirage_impl_arpv4.mli
@@ -3,13 +3,6 @@ type arpv4
 val arpv4 : arpv4 Functoria.typ
 
 val arp :
-     ?clock:Mirage_impl_mclock.mclock Functoria.impl
-  -> ?time:Mirage_impl_time.time Functoria.impl
-  -> Mirage_impl_ethernet.ethernet Functoria.impl
-  -> arpv4 Functoria.impl
-
-val farp :
-     ?clock:Mirage_impl_mclock.mclock Functoria.impl
-  -> ?time:Mirage_impl_time.time Functoria.impl
+     ?time:Mirage_impl_time.time Functoria.impl
   -> Mirage_impl_ethernet.ethernet Functoria.impl
   -> arpv4 Functoria.impl

--- a/lib/mirage_impl_ethernet.ml
+++ b/lib/mirage_impl_ethernet.ml
@@ -9,10 +9,10 @@ let ethernet = Type ETHERNET
 let ethernet_conf = object
   inherit base_configurable
   method ty = network @-> ethernet
-  method name = "ethif"
-  method module_name = "Ethif.Make"
+  method name = "ethernet"
+  method module_name = "Ethernet.Make"
   method! packages =
-    Key.pure [ package ~min:"3.6.0" ~max:"3.7.0" ~sublibs:["ethif"] "tcpip" ]
+    Key.pure [ package ~min:"0.1.0" ~max:"0.2.0" "ethernet" ]
   method! connect _ modname = function
     | [ eth ] -> Fmt.strf "%s.connect %s" modname eth
     | _ -> failwith (connect_err "ethernet" 1)

--- a/lib/mirage_impl_ip.ml
+++ b/lib/mirage_impl_ip.ml
@@ -33,7 +33,7 @@ let (@??) x y = opt_map Key.abstract x @? y
 
 (* convenience function for linking tcpip.unix or .xen for checksums *)
 let right_tcpip_library ?ocamlfind ~sublibs pkg =
-  let min = "3.6.0" and max = "3.7.0" in
+  let min = "3.7.0" and max = "3.8.0" in
   Key.match_ Key.(value target) @@ function
   |`MacOSX | `Unix ->
     [ package ~min ~max ?ocamlfind ~sublibs:("unix"::sublibs) pkg ]

--- a/lib/mirage_impl_stackv4.ml
+++ b/lib/mirage_impl_stackv4.ml
@@ -48,20 +48,20 @@ let direct_stackv4
   $ direct_udp ~random ip
   $ direct_tcp ~clock ~random ~time ip
 
-let dhcp_ipv4_stack ?group ?(random = default_random) ?(time = default_time) ?(arp = arp ?clock:None ?time:None) tap =
+let dhcp_ipv4_stack ?group ?(random = default_random) ?(time = default_time) ?(arp = arp ?time:None) tap =
   let config = dhcp random time tap in
   let e = etif tap in
   let a = arp e in
   let i = ipv4_of_dhcp config e a in
   direct_stackv4 ?group tap e a i
 
-let static_ipv4_stack ?group ?config ?(arp = arp ?clock:None ?time:None) tap =
+let static_ipv4_stack ?group ?config ?(arp = arp ?time:None) tap =
   let e = etif tap in
   let a = arp e in
   let i = create_ipv4 ?group ?config e a in
   direct_stackv4 ?group tap e a i
 
-let qubes_ipv4_stack ?group ?(qubesdb = default_qubesdb) ?(arp = arp ?clock:None ?time:None) tap =
+let qubes_ipv4_stack ?group ?(qubesdb = default_qubesdb) ?(arp = arp ?time:None) tap =
   let e = etif tap in
   let a = arp e in
   let i = ipv4_qubes qubesdb e a in


### PR DESCRIPTION
originally, they were part of tcpip, and there was an alternative arp implementation in a separate repository.

in https://github.com/mirage/mirage-tcpip/issues/386, we discussed to remove the tcpip-builtin arp implementation and use the alternative one by default. to avoid cyclic opam package dependencies, the ethernet (used by arp) package needed to be split out from tcpip as well.

This PR is good to go, but needs to be merged together with:
- [x] https://github.com/mirage/mirage-tcpip/pull/390
- [x] https://github.com/mirage/arp/pull/9
- [x] https://github.com/mirage/charrua-core/pull/91
- [ ] a release of https://github.com/mirage/ethernet
- [x] https://github.com/mirage/mirage-skeleton/pull/263

Feedback is welcome, the set of PRs do not change the API of network layers (though, I plan to do this in subsequent PRs to avoid that e.g. IP needs to know of the ethernet implementation). A successful build of mirage-skeleton with the above changes is at https://travis-ci.org/mirage/mirage-dev/builds/487722396

Merge plan: rather sooner than later ;)