### PR TITLE
[RFC] TCP/IP stack MTU, layering, and write allocation discipline changes

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,5 +1,5 @@
 eval `opam config env`
 opam depext -uiy mirage
 cd ~
-git clone -b master https://github.com/mirage/mirage-skeleton.git
+git clone -b layering https://github.com/hannesm/mirage-skeleton.git
 make -C mirage-skeleton && rm -rf mirage-skeleton

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="sh ./.travis-ci.sh"
    - PINS="mirage:. mirage-types:. mirage-types-lwt:. mirage-runtime:."
-   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
+   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git#layering"
    - PACKAGE=mirage
  matrix:
    - DISTRO=debian-testing OCAML_VERSION=4.04 EXTRA_ENV="MODE=xen"

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -887,7 +887,7 @@ module Project = struct
       ]
       method! packages =
         (* XXX: use %%VERSION_NUM%% here instead of hardcoding a version? *)
-        let min = "3.4.0" and max = "3.5.0" in
+        let min = "3.5.0" and max = "3.6.0" in
         let common = [
           package ~build:true ~min:"4.04.2" "ocaml";
           package "lwt";

--- a/lib/mirage_impl_arpv4.ml
+++ b/lib/mirage_impl_arpv4.ml
@@ -13,7 +13,7 @@ let arp_conf = object
   method name = "arp"
   method module_name = "Arp.Make"
   method! packages =
-    Key.pure [ package ~min:"1.0.0" ~max:"2.0.0" "arp-mirage" ]
+    Key.pure [ package ~min:"2.0.0" ~max:"3.0.0" "arp-mirage" ]
   method! connect _ modname = function
     | [ eth ; _time ] -> Fmt.strf "%s.connect %s" modname eth
     | _ -> failwith (connect_err "arp" 3)

--- a/lib/mirage_impl_ethernet.ml
+++ b/lib/mirage_impl_ethernet.ml
@@ -12,7 +12,7 @@ let ethernet_conf = object
   method name = "ethernet"
   method module_name = "Ethernet.Make"
   method! packages =
-    Key.pure [ package ~min:"1.0.0" ~max:"2.0.0" "ethernet" ]
+    Key.pure [ package ~min:"2.0.0" ~max:"3.0.0" "ethernet" ]
   method! connect _ modname = function
     | [ eth ] -> Fmt.strf "%s.connect %s" modname eth
     | _ -> failwith (connect_err "ethernet" 1)

--- a/lib/mirage_impl_ip.ml
+++ b/lib/mirage_impl_ip.ml
@@ -33,7 +33,7 @@ let (@??) x y = opt_map Key.abstract x @? y
 
 (* convenience function for linking tcpip.unix or .xen for checksums *)
 let right_tcpip_library ?ocamlfind ~sublibs pkg =
-  let min = "3.7.0" and max = "3.8.0" in
+  let min = "3.7.1" and max = "3.8.0" in
   Key.match_ Key.(value target) @@ function
   |`MacOSX | `Unix ->
     [ package ~min ~max ?ocamlfind ~sublibs:("unix"::sublibs) pkg ]
@@ -62,7 +62,7 @@ let ipv4_keyed_conf ?network ?gateway () = impl @@ object
   end
 
 let charrua_pkg =
-  Key.pure [ package ~min:"0.11.0" ~max:"0.12.0" "charrua-client-mirage" ]
+  Key.pure [ package ~min:"0.12.0" ~max:"0.13.0" "charrua-client-mirage" ]
 
 let dhcp_conf = impl @@ object
     inherit base_configurable

--- a/lib/mirage_impl_network.ml
+++ b/lib/mirage_impl_network.ml
@@ -17,14 +17,14 @@ let network_conf (intf : string Key.key) =
     method! keys = [ key ]
     method! packages =
       Key.match_ Key.(value target) @@ function
-      | `Unix -> [ package ~min:"2.3.0" ~max:"3.0.0" "mirage-net-unix" ]
-      | `MacOSX -> [ package ~min:"1.4.0" ~max:"2.0.0" "mirage-net-macosx" ]
-      | `Xen -> [ package ~min:"1.7.0" ~max:"2.0.0" "mirage-net-xen"]
+      | `Unix -> [ package ~min:"2.6.0" ~max:"3.0.0" "mirage-net-unix" ]
+      | `MacOSX -> [ package ~min:"1.6.0" ~max:"2.0.0" "mirage-net-macosx" ]
+      | `Xen -> [ package ~min:"1.10.0" ~max:"2.0.0" "mirage-net-xen"]
       | `Qubes ->
-        [ package ~min:"1.7.0" ~max:"2.0.0" "mirage-net-xen" ;
+        [ package ~min:"1.10.0" ~max:"2.0.0" "mirage-net-xen" ;
           Mirage_impl_qubesdb.pkg ]
       | `Virtio | `Hvt | `Muen | `Genode ->
-        [ package ~min:"0.4.0" ~max:"0.5.0" "mirage-net-solo5" ]
+        [ package ~min:"0.4.2" ~max:"0.5.0" "mirage-net-solo5" ]
     method! connect _ modname _ =
       Fmt.strf "%s.connect %a" modname Key.serialize_call key
     method! configure i =

--- a/mirage-types-lwt.opam
+++ b/mirage-types-lwt.opam
@@ -26,11 +26,11 @@ depends:   [
   "mirage-time-lwt" {>= "1.1.0"}
   "mirage-random" {>= "1.2.0"}
   "mirage-flow-lwt" {>= "1.5.0"}
-  "mirage-protocols-lwt" {>= "1.4.1"}
+  "mirage-protocols-lwt" {>= "2.0.0"}
   "mirage-stack-lwt" {>= "1.3.0"}
   "mirage-console-lwt" {>= "2.3.5"}
   "mirage-block-lwt" {>= "1.1.0"}
-  "mirage-net-lwt" {>= "1.2.0"}
+  "mirage-net-lwt" {>= "2.0.0"}
   "mirage-fs-lwt" {>= "1.1.1"}
   "mirage-kv-lwt" {>= "1.1.0"}
   "mirage-channel-lwt" {>= "3.1.0"}

--- a/mirage-types.opam
+++ b/mirage-types.opam
@@ -25,10 +25,10 @@ depends: [
   "mirage-random" {>= "1.2.0"}
   "mirage-flow" {>= "1.5.0"}
   "mirage-console" {>= "2.3.5"}
-  "mirage-protocols" {>= "1.4.1"}
+  "mirage-protocols" {>= "2.0.0"}
   "mirage-stack" {>= "1.3.0"}
   "mirage-block" {>= "1.1.0"}
-  "mirage-net" {>= "1.2.0"}
+  "mirage-net" {>= "2.0.0"}
   "mirage-fs" {>= "1.1.1"}
   "mirage-kv" {>= "1.1.1"}
   "mirage-channel" {>= "3.1.0"}


### PR DESCRIPTION
A brief list of changes:

- Ethernet encapsulation is done in Ethernet - currently done in Arp and IPv4 and IPv6 libraries
- MTU is passed from the network interface upwards - currently passed into the Ethernet layer
- Write buffer allocation is done by the network interface, which knows best about page boundary restrictions, etc. - currently done in IPv4, IPv6, ARP using Io_page.get 1
- write functions signature change throughout the stack up to Ip: the buffer to send is no longer given directly, instead a size argument and a fill function of type (buffer -> int).
- IPv4 applies fragmentation!
- no longer used function are removed


I did performance evaluation as follows (I'm pretty sure this is not exhaustive, and likely others have better ideas on how to actually do such a benchmark):
- Server: the MirageOS unikernel iperf_server (TCP, thanks to Taka), https://github.com/hannesm/mirage_iperf, virtualized with Solo5/hvt, deployed on a PC Engines (AMD Embedded G series GX-412TC, 1 GHz quad Jaguar core)
- Client: iperf on Unix running on my Lenovo X250, arguments -i 1 -t 20
- Connection was a 1 GBit/s copper cable (a switch was in between the devices)

The latest released opam packages (mirage 3.4.1, tcpip 3.7.0):
Throughput = 16.97 [MBs/sec]
gc minor words 214425271.000000 promoted words 4421898.000000 major words 4428911.000000 minor collections 884 major collections 131 heap_words 61440

With the changes above:
Throughput = 16.85 [MBs/sec]
gc minor words 212194711.000000 promoted words 4286488.000000 major words 4293501.000000 minor collections 876 major collections 132 heap_words 61440

I don't think there's any significant difference between old and new.

This PR adjusts only version constraints in mirage, the actual changes are in PRs in other repositories:
Interfaces:
- [x] https://github.com/mirage/mirage-net/pull/16 and https://github.com/mirage/mirage-net/pull/18 https://github.com/ocaml/opam-repository/pull/13511
- [x] https://github.com/mirage/mirage-protocols/pull/15 https://github.com/ocaml/opam-repository/pull/13516

Mirage-net providers:
- [x] https://github.com/mirage/mirage-net-macosx/pull/31 and https://github.com/mirage/mirage-net-macosx/pull/32 https://github.com/ocaml/opam-repository/pull/13519
- [x] https://github.com/mirage/ocaml-tuntap/pull/32 (providing `get_mtu`) https://github.com/ocaml/opam-repository/pull/13513
- [x] https://github.com/mirage/mirage-net-unix/pull/46 https://github.com/ocaml/opam-repository/pull/13521
- [x] https://github.com/mirage/mirage-net-solo5/pull/28 https://github.com/ocaml/opam-repository/pull/13518
- [x] https://github.com/mirage/mirage-net-xen/pull/82 https://github.com/ocaml/opam-repository/pull/13520
- [x] https://github.com/mirage/mirage-vnetif/pull/26 https://github.com/ocaml/opam-repository/pull/13517

Network layers:
- [x] https://github.com/mirage/ethernet/pull/3 https://github.com/ocaml/opam-repository/pull/13522
- [x] https://github.com/mirage/arp/pull/13 https://github.com/ocaml/opam-repository/pull/13522
- [x] https://github.com/mirage/mirage-tcpip/pull/394 https://github.com/ocaml/opam-repository/pull/13527
- [x] https://github.com/mirage/charrua-core/pull/94 https://github.com/ocaml/opam-repository/pull/13529

Applications
- [x] https://github.com/mirage/mirage-skeleton/pull/264
- [ ] https://github.com/mirage/mirage-skeleton/pull/265