### PR TITLE
Releng 3.5.0

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,5 +1,5 @@
 eval `opam config env`
 opam depext -uiy mirage
 cd ~
-git clone -b layering https://github.com/hannesm/mirage-skeleton.git
+git clone -b releng-3.5.0 https://github.com/hannesm/mirage-skeleton.git
 make -C mirage-skeleton && rm -rf mirage-skeleton

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,5 +1,5 @@
 eval `opam config env`
 opam depext -uiy mirage
 cd ~
-git clone -b releng-3.5.0 https://github.com/hannesm/mirage-skeleton.git
+git clone https://github.com/mirage/mirage-skeleton.git
 make -C mirage-skeleton && rm -rf mirage-skeleton

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ env:
    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git#releng-3.5.0"
    - PACKAGE=mirage
  matrix:
-   - DISTRO=debian-testing OCAML_VERSION=4.04 EXTRA_ENV="MODE=xen"
-   - DISTRO=alpine OCAML_VERSION=4.04 EXTRA_ENV="MODE=hvt"
-   - DISTRO=ubuntu-16.04 OCAML_VERSION=4.05 EXTRA_ENV="MODE=unix"
+   - DISTRO=alpine OCAML_VERSION=4.05 EXTRA_ENV="MODE=unix"
    - DISTRO=ubuntu-16.04 OCAML_VERSION=4.05 EXTRA_ENV="MODE=virtio"
    - DISTRO=ubuntu-16.04 OCAML_VERSION=4.06 EXTRA_ENV="MODE=xen"
    - DISTRO=debian-testing OCAML_VERSION=4.06 EXTRA_ENV="MODE=muen"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
    - POST_INSTALL_HOOK="sh ./.travis-ci.sh"
    - PINS="mirage:. mirage-types:. mirage-types-lwt:. mirage-runtime:."
-   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git#layering"
+   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git#releng-3.5.0"
    - PACKAGE=mirage
  matrix:
    - DISTRO=debian-testing OCAML_VERSION=4.04 EXTRA_ENV="MODE=xen"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+### v3.5.0 (2019-03-03)
+
+* Rename Mirage_impl_kv_ro to Mirage_impl_kv, and introduce `rw` (#975, by @hannesm)
+* Adapt to mirage-kv 2.0.0 changes (#975, by @hannesm)
+* Adapt to mirage-protocols and mirag-net 2.0.0 changes (#972, by @hannesm)
+* mirage-types-lwt: remove unneeded io-page dependency (#971, by @hannesm)
+* Fix regression introduced in v3.4.0 that "-l *:debug" did no longer work (#970, by @hannesm)
+* Adjust various upper bounds (mirage-unix, cohttp-mirage, mirage-bootvar-xen) (#967, by @hannesm)
+
 ### v3.4.1 (2019-02-05)
 
 * Provide a httpaf_server device, and a cohttp_server device (#955, by @anmonteiro)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 * Adapt to mirage-kv 2.0.0 changes (#975, by @hannesm)
 * Adapt to mirage-protocols and mirag-net 2.0.0 changes (#972, by @hannesm)
 * mirage-types-lwt: remove unneeded io-page dependency (#971, by @hannesm)
-* Fix regression introduced in v3.4.0 that "-l *:debug" did no longer work (#970, by @hannesm)
+* Fix regression introduced in 3.4.0 that "-l *:debug" did no longer work (#970, by @hannesm)
 * Adjust various upper bounds (mirage-unix, cohttp-mirage, mirage-bootvar-xen) (#967, by @hannesm)
 
 ### v3.4.1 (2019-02-05)
@@ -32,7 +32,7 @@
 ### 3.3.0 (2018-11-18)
 
 New target: (via solo5) Genode:
-"Genode[4][5][6] is a free and open-source operating system framework consisting
+"Genode is a free and open-source operating system framework consisting
 of a microkernel abstraction layer and a collection of userspace components. The
 framework is notable as one of the few open-source operating systems not derived
 from a proprietary OS, such as Unix. The characteristic design philosophy is

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -900,9 +900,9 @@ module Project = struct
         ] in
         Key.match_ Key.(value target) @@ function
         | `Unix | `MacOSX ->
-          package ~min:"3.1.0" ~max:"3.3.0" "mirage-unix" :: common
+          package ~min:"3.1.0" ~max:"4.0.0" "mirage-unix" :: common
         | `Xen | `Qubes ->
-          package ~min:"3.1.0" ~max:"3.2.0" "mirage-xen" :: common
+          package ~min:"3.1.0" ~max:"4.0.0" "mirage-xen" :: common
         | `Virtio | `Hvt | `Muen | `Genode as tgt ->
           package ~min:"0.4.0" ~max:"0.5.0" ~ocamlfind:[] (fst (solo5_pkg tgt)) ::
           package ~min:"0.5.0" ~max:"0.6.0" "mirage-solo5" ::

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -66,10 +66,15 @@ let console = Mirage_impl_console.console
 let default_console = Mirage_impl_console.default_console
 let custom_console = Mirage_impl_console.custom_console
 
-type kv_ro = Mirage_impl_kv_ro.kv_ro
-let kv_ro = Mirage_impl_kv_ro.kv_ro
-let direct_kv_ro = Mirage_impl_kv_ro.direct_kv_ro
-let crunch = Mirage_impl_kv_ro.crunch
+type kv_ro = Mirage_impl_kv.ro
+let kv_ro = Mirage_impl_kv.ro
+let direct_kv_ro = Mirage_impl_kv.direct_kv_ro
+let crunch = Mirage_impl_kv.crunch
+
+type kv_rw = Mirage_impl_kv.rw
+let kv_rw = Mirage_impl_kv.rw
+let direct_kv_rw = Mirage_impl_kv.direct_kv_rw
+let kv_rw_mem = Mirage_impl_kv.mem_kv_rw
 
 type block = Mirage_impl_block.block
 let block = Mirage_impl_block.block

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -189,6 +189,28 @@ val direct_kv_ro: string -> kv_ro impl
 (** Direct access to the underlying filesystem as a key/value
     store. For Xen backends, this is equivalent to [crunch]. *)
 
+val generic_kv_ro:
+  ?group:string ->
+  ?key:[ `Archive | `Crunch | `Direct | `Fat ] value -> string -> kv_ro impl
+(** Generic key/value that will choose dynamically between
+    {!fat}, {!archive} and {!crunch}.  To use a filesystem implementation,
+    try {!kv_ro_of_fs}.
+
+    If no key is provided, it uses {!Key.kv_ro} to create a new one.
+*)
+
+type kv_rw
+(** Abstract type for read-write key/value store. *)
+
+val kv_rw: kv_rw typ
+(** Implementations of the [Mirage_types.KV_RW] signature. *)
+
+val direct_kv_rw: string -> kv_rw impl
+(** Direct access to the underlying filesystem as a key/value
+    store. Only available on Unix backends. *)
+
+val kv_rw_mem: ?clock:pclock impl -> unit -> kv_rw impl
+(** An in-memory key-value store using [mirage-kv-mem]. *)
 
 
 (** {2 Filesystem} *)
@@ -212,18 +234,6 @@ val fat_of_files: ?dir:string -> ?regexp:string -> unit -> fs impl
 val kv_ro_of_fs: fs impl -> kv_ro impl
 (** Consider a filesystem implementation as a read-only key/value
     store. *)
-
-(** {2 Generic key/value stores} *)
-
-val generic_kv_ro:
-  ?group:string ->
-  ?key:[ `Archive | `Crunch | `Direct | `Fat ] value -> string -> kv_ro impl
-(** Generic key/value that will choose dynamically between
-    {!fat}, {!archive} and {!crunch}.  To use a filesystem implementation,
-    try {!kv_ro_of_fs}.
-
-    If no key is provided, it uses {!Key.kv_ro} to create a new one.
-*)
 
 
 (** {2 Network interfaces} *)

--- a/lib/mirage_impl_block.ml
+++ b/lib/mirage_impl_block.ml
@@ -134,7 +134,7 @@ let archive_conf = impl @@ object
     method name = "archive"
     method module_name = "Tar_mirage.Make_KV_RO"
     method! packages =
-      Key.pure [ package ~min:"0.9.0" ~max:"0.10.0" "tar-mirage" ]
+      Key.pure [ package ~min:"1.0.0" ~max:"2.0.0" "tar-mirage" ]
     method! connect _ modname = function
       | [ block ] -> Fmt.strf "%s.connect %s" modname block
       | _ -> failwith (connect_err "archive" 1)

--- a/lib/mirage_impl_block.ml
+++ b/lib/mirage_impl_block.ml
@@ -3,7 +3,6 @@ module Name = Functoria_app.Name
 module Key = Mirage_key
 open Mirage_impl_misc
 open Rresult
-open Mirage_impl_kv_ro
 
 type block = BLOCK
 let block = Type BLOCK
@@ -130,7 +129,7 @@ let tar_block dir =
 
 let archive_conf = impl @@ object
     inherit base_configurable
-    method ty = block @-> kv_ro
+    method ty = block @-> Mirage_impl_kv.ro
     method name = "archive"
     method module_name = "Tar_mirage.Make_KV_RO"
     method! packages =

--- a/lib/mirage_impl_block.mli
+++ b/lib/mirage_impl_block.mli
@@ -9,9 +9,9 @@ val generic_block :
   -> block Functoria.impl
 
 val archive_of_files :
-  ?dir:string -> unit -> Mirage_impl_kv_ro.kv_ro Functoria.impl
+  ?dir:string -> unit -> Mirage_impl_kv.ro Functoria.impl
 
-val archive : block Functoria.impl -> Mirage_impl_kv_ro.kv_ro Functoria.impl
+val archive : block Functoria.impl -> Mirage_impl_kv.ro Functoria.impl
 
 val ramdisk : string -> block Functoria.impl
 

--- a/lib/mirage_impl_conduit_connector.ml
+++ b/lib/mirage_impl_conduit_connector.ml
@@ -26,7 +26,7 @@ let tls_conduit_connector = impl @@ object
     method module_name = "Conduit_mirage"
     method! packages =
       Mirage_key.pure [
-        package ~min:"0.9.2" ~max:"0.10.0" ~sublibs:["mirage"] "tls" ;
+        package ~min:"0.10.0" ~max:"0.11.0" ~sublibs:["mirage"] "tls" ;
         pkg
       ]
     method! deps = [ abstract nocrypto ]

--- a/lib/mirage_impl_fs.ml
+++ b/lib/mirage_impl_fs.ml
@@ -92,7 +92,7 @@ let kv_ro_of_fs_conf =
     method name = "kv_ro_of_fs"
     method module_name = "Mirage_fs_lwt.To_KV_RO"
     method! packages =
-      Key.pure [package ~min:"1.0.0" ~max:"2.0.0" "mirage-fs-lwt"]
+      Key.pure [package ~min:"2.0.0" ~max:"3.0.0" "mirage-fs-lwt"]
     method! connect _ modname = function
       | [fs] -> Fmt.strf "%s.connect %s" modname fs
       | _ -> failwith (connect_err "kv_ro_of_fs" 1)

--- a/lib/mirage_impl_fs.ml
+++ b/lib/mirage_impl_fs.ml
@@ -3,7 +3,6 @@ module Key = Mirage_key
 module Name = Functoria_app.Name
 open Functoria
 open Mirage_impl_block
-open Mirage_impl_kv_ro
 open Mirage_impl_misc
 open Rresult
 
@@ -88,7 +87,7 @@ let fat_of_files ?dir ?regexp () = fat @@ fat_block ?dir ?regexp ()
 let kv_ro_of_fs_conf =
   impl @@ object
     inherit base_configurable
-    method ty = typ @-> kv_ro
+    method ty = typ @-> Mirage_impl_kv.ro
     method name = "kv_ro_of_fs"
     method module_name = "Mirage_fs_lwt.To_KV_RO"
     method! packages =
@@ -106,6 +105,6 @@ let generic_kv_ro ?group ?(key = Key.value @@ Key.kv_ro ?group ()) dir =
   match_impl key
     [ (`Fat, kv_ro_of_fs @@ fat_of_files ~dir ())
     ; (`Archive, archive_of_files ~dir ())
-    ; (`Crunch, crunch dir)
-    ; (`Direct, direct_kv_ro dir) ]
-    ~default:(direct_kv_ro dir)
+    ; (`Crunch, Mirage_impl_kv.crunch dir)
+    ; (`Direct, Mirage_impl_kv.direct_kv_ro dir) ]
+    ~default:(Mirage_impl_kv.direct_kv_ro dir)

--- a/lib/mirage_impl_fs.mli
+++ b/lib/mirage_impl_fs.mli
@@ -6,13 +6,13 @@ val fat : Mirage_impl_block.block Functoria.impl -> t Functoria.impl
 
 val fat_of_files : ?dir:string -> ?regexp:string -> unit -> t Functoria.impl
 
-val kv_ro_of_fs : t Functoria.impl -> Mirage_impl_kv_ro.kv_ro Functoria.impl
+val kv_ro_of_fs : t Functoria.impl -> Mirage_impl_kv.ro Functoria.impl
 
 val generic_kv_ro :
      ?group:string
   -> ?key:[`Archive | `Crunch | `Direct | `Fat] Functoria.value
   -> string
-  -> Mirage_impl_kv_ro.kv_ro Functoria.impl
+  -> Mirage_impl_kv.ro Functoria.impl
 
 val fat_shell_script :
      Format.formatter

--- a/lib/mirage_impl_http.ml
+++ b/lib/mirage_impl_http.ml
@@ -10,7 +10,7 @@ let cohttp_server conduit = impl @@ object
     method name = "http"
     method module_name = "Cohttp_mirage.Server_with_conduit"
     method! packages =
-      Mirage_key.pure [ package ~min:"2.0.0" ~max:"3.0.0" "cohttp-mirage" ]
+      Mirage_key.pure [ package ~min:"2.1.0" ~max:"3.0.0" "cohttp-mirage" ]
     method! deps = [ abstract conduit ]
     method! connect _i modname = function
       | [ conduit ] -> Fmt.strf "%s.connect %s" modname conduit

--- a/lib/mirage_impl_ip.ml
+++ b/lib/mirage_impl_ip.ml
@@ -123,7 +123,7 @@ let ipv4_qubes_conf = impl @@ object
     method name = Name.create "qubes_ipv4" ~prefix:"qubes_ipv4"
     method module_name = "Qubesdb_ipv4.Make"
     method! packages =
-      Key.pure [ package ~min:"0.6" ~max:"0.7" "mirage-qubes-ipv4" ]
+      Key.pure [ package ~min:"0.7" ~max:"0.8" "mirage-qubes-ipv4" ]
     method! connect _ modname = function
       | [  db ; _random ; mclock ;etif; arp ] ->
         Fmt.strf "%s.connect@[@ %s@ %s@ %s@ %s@]" modname db mclock etif arp

--- a/lib/mirage_impl_kv.mli
+++ b/lib/mirage_impl_kv.mli
@@ -1,0 +1,15 @@
+type ro
+
+val ro : ro Functoria.typ
+
+val direct_kv_ro : string -> ro Functoria.impl
+
+val crunch : string -> ro Functoria.impl
+
+type rw
+
+val rw : rw Functoria.typ
+
+val direct_kv_rw : string -> rw Functoria.impl
+
+val mem_kv_rw : ?clock:Mirage_impl_pclock.pclock Functoria.impl -> unit -> rw Functoria.impl

--- a/lib/mirage_impl_kv_ro.ml
+++ b/lib/mirage_impl_kv_ro.ml
@@ -15,7 +15,7 @@ let crunch dirname = impl @@ object
     method module_name = String.Ascii.capitalize name
     method! packages =
       Key.pure [
-        package ~min:"2.0.0" ~max:"3.0.0" "io-page";
+        package "mirage-kv-mem";
         package ~min:"2.0.0" ~max:"3.0.0" ~build:true "crunch"
       ]
     method! connect _ modname _ = Fmt.strf "%s.connect ()" modname

--- a/lib/mirage_impl_kv_ro.ml
+++ b/lib/mirage_impl_kv_ro.ml
@@ -16,7 +16,7 @@ let crunch dirname = impl @@ object
     method! packages =
       Key.pure [
         package "mirage-kv-mem";
-        package ~min:"2.0.0" ~max:"3.0.0" ~build:true "crunch"
+        package ~min:"3.0.0" ~max:"4.0.0" ~build:true "crunch"
       ]
     method! connect _ modname _ = Fmt.strf "%s.connect ()" modname
     method! build _i =

--- a/lib/mirage_impl_kv_ro.mli
+++ b/lib/mirage_impl_kv_ro.mli
@@ -1,7 +1,0 @@
-type kv_ro
-
-val kv_ro : kv_ro Functoria.typ
-
-val direct_kv_ro : string -> kv_ro Functoria.impl
-
-val crunch : string -> kv_ro Functoria.impl

--- a/lib/mirage_impl_mclock.ml
+++ b/lib/mirage_impl_mclock.ml
@@ -10,8 +10,8 @@ let monotonic_clock_conf = object
   method module_name = "Mclock"
   method! packages =
     Mirage_key.(if_ is_unix)
-      [ package ~min:"1.2.0" ~max:"3.0.0" "mirage-clock-unix" ]
-      [ package ~min:"1.2.0" ~max:"3.0.0" "mirage-clock-freestanding" ]
+      [ package ~min:"2.0.0" ~max:"3.0.0" "mirage-clock-unix" ]
+      [ package ~min:"2.0.0" ~max:"3.0.0" "mirage-clock-freestanding" ]
   method! connect _ modname _args = Fmt.strf "%s.connect ()" modname
 end
 

--- a/lib/mirage_impl_pclock.ml
+++ b/lib/mirage_impl_pclock.ml
@@ -10,8 +10,8 @@ let posix_clock_conf = object
   method module_name = "Pclock"
   method! packages =
     Mirage_key.(if_ is_unix)
-      [ package ~min:"1.2.0" ~max:"3.0.0" "mirage-clock-unix" ]
-      [ package ~min:"1.2.0" ~max:"3.0.0" "mirage-clock-freestanding" ]
+      [ package ~min:"2.0.0" ~max:"3.0.0" "mirage-clock-unix" ]
+      [ package ~min:"2.0.0" ~max:"3.0.0" "mirage-clock-freestanding" ]
   method! connect _ modname _args = Fmt.strf "%s.connect ()" modname
 end
 

--- a/lib/mirage_impl_qubesdb.ml
+++ b/lib/mirage_impl_qubesdb.ml
@@ -6,7 +6,7 @@ open Rresult
 type qubesdb = QUBES_DB
 let qubesdb = Type QUBES_DB
 
-let pkg = package ~min:"0.4" ~max:"0.7" "mirage-qubes"
+let pkg = package ~min:"0.4" ~max:"0.8" "mirage-qubes"
 
 let qubesdb_conf = object
   inherit base_configurable

--- a/lib/mirage_impl_qubesdb.ml
+++ b/lib/mirage_impl_qubesdb.ml
@@ -6,7 +6,7 @@ open Rresult
 type qubesdb = QUBES_DB
 let qubesdb = Type QUBES_DB
 
-let pkg = package ~min:"0.4" ~max:"0.8" "mirage-qubes"
+let pkg = package ~min:"0.7" ~max:"0.8" "mirage-qubes"
 
 let qubesdb_conf = object
   inherit base_configurable

--- a/lib/mirage_impl_syslog.ml
+++ b/lib/mirage_impl_syslog.ml
@@ -1,7 +1,6 @@
 module Key = Mirage_key
 open Functoria
 open Mirage_impl_console
-open Mirage_impl_kv_ro
 open Mirage_impl_misc
 open Mirage_impl_pclock
 open Mirage_impl_stackv4
@@ -114,7 +113,7 @@ let syslog_tls_conf ?keyname config =
   in
   impl @@ object
     inherit base_configurable
-    method ty = console @-> pclock @-> stackv4 @-> kv_ro @-> syslog
+    method ty = console @-> pclock @-> stackv4 @-> Mirage_impl_kv.ro @-> syslog
     method name = "tls_syslog"
     method module_name = "Logs_syslog_mirage_tls.Tls"
     method! packages = pkg ["mirage" ; "mirage.tls"]

--- a/lib/mirage_impl_syslog.mli
+++ b/lib/mirage_impl_syslog.mli
@@ -31,5 +31,5 @@ val syslog_tls :
   -> ?console:Mirage_impl_console.console Functoria.impl
   -> ?clock:Mirage_impl_pclock.pclock Functoria.impl
   -> Mirage_impl_stackv4.stackv4 Functoria.impl
-  -> Mirage_impl_kv_ro.kv_ro Functoria.impl
+  -> Mirage_impl_kv.ro Functoria.impl
   -> syslog Functoria.impl

--- a/mirage-types-lwt.opam
+++ b/mirage-types-lwt.opam
@@ -30,8 +30,8 @@ depends:   [
   "mirage-console-lwt" {>= "2.3.5"}
   "mirage-block-lwt" {>= "1.1.0"}
   "mirage-net-lwt" {>= "2.0.0"}
-  "mirage-fs-lwt" {>= "1.1.1"}
-  "mirage-kv-lwt" {>= "1.1.0"}
+  "mirage-fs-lwt" {>= "2.0.0"}
+  "mirage-kv-lwt" {>= "2.0.0"}
   "mirage-channel-lwt" {>= "3.1.0"}
 ]
 

--- a/mirage-types.opam
+++ b/mirage-types.opam
@@ -29,8 +29,8 @@ depends: [
   "mirage-stack" {>= "1.3.0"}
   "mirage-block" {>= "1.1.0"}
   "mirage-net" {>= "2.0.0"}
-  "mirage-fs" {>= "1.1.1"}
-  "mirage-kv" {>= "1.1.1"}
+  "mirage-fs" {>= "2.0.0"}
+  "mirage-kv" {>= "2.0.0"}
   "mirage-channel" {>= "3.1.0"}
 ]
 synopsis: "Module type definitions for MirageOS applications"

--- a/mirage.opam
+++ b/mirage.opam
@@ -24,7 +24,7 @@ depends: [
   "bos"
   "astring"
   "logs"
-  "mirage-runtime"     {>= "3.4.0"}
+  "mirage-runtime"     {>= "3.5.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/types/mirage_types.ml
+++ b/types/mirage_types.ml
@@ -115,6 +115,7 @@ module type CHANNEL = Mirage_channel.S
 (** {2 Static Key/value store} *)
 
 module type KV_RO = Mirage_kv.RO
+module type KV_RW = Mirage_kv.RW
 
 (** {2 Filesystem devices} *)
 

--- a/types/mirage_types_lwt.ml
+++ b/types/mirage_types_lwt.ml
@@ -54,8 +54,9 @@ module type TCPV6 = Mirage_protocols_lwt.TCPV6
 (** Buffered TCP channel *)
 module type CHANNEL = Mirage_channel_lwt.S
 
-(** KV RO *)
+(** Key-value stores *)
 module type KV_RO = Mirage_kv_lwt.RO
+module type KV_RW = Mirage_kv_lwt.RW
 
 (** FS *)
 module type FS = Mirage_fs_lwt.S


### PR DESCRIPTION
this is the release engineering branch for 3.5.0. travis is supposed to succeed with the given remote and mirage-skeleton.

changes needed before a release are mainly a functoria Mirage_kv.RW device (plus merges in opam-repository, and a cohttp-mirage release). a **successful** mirage-dev travis job using this branch and the respective mirage-skeleton branch has run at: https://travis-ci.org/mirage/mirage-dev/builds/499798880

also, an entry for changes is necessary, certainly.