### PR TITLE
Implement initial ixy support

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -888,6 +888,7 @@ module Project = struct
         Key.(abstract target);
         Key.(abstract warn_error);
         Key.(abstract target_debug);
+        Key.(abstract ixy);
         Key.(abstract no_depext);
       ]
       method! packages =

--- a/lib/mirage_impl_network.ml
+++ b/lib/mirage_impl_network.ml
@@ -16,15 +16,23 @@ let network_conf (intf : string Key.key) =
     method module_name = "Netif"
     method! keys = [ key ]
     method! packages =
-      Key.match_ Key.(value target) @@ function
-      | `Unix -> [ package ~min:"2.6.0" ~max:"3.0.0" "mirage-net-unix" ]
-      | `MacOSX -> [ package ~min:"1.6.0" ~max:"2.0.0" "mirage-net-macosx" ]
-      | `Xen -> [ package ~min:"1.10.0" ~max:"2.0.0" "mirage-net-xen"]
-      | `Qubes ->
-        [ package ~min:"1.10.0" ~max:"2.0.0" "mirage-net-xen" ;
-          Mirage_impl_qubesdb.pkg ]
-      | `Virtio | `Hvt | `Muen | `Genode ->
-        [ package ~min:"0.4.2" ~max:"0.5.0" "mirage-net-solo5" ]
+      let choose target ixy =
+        match target, ixy with
+        | `Unix, true ->
+          [ package "mirage-net-ixy" ]
+        | `Unix, false ->
+          [ package ~min:"2.6.0" ~max:"3.0.0" "mirage-net-unix" ]
+        | `MacOSX, _ -> [ package ~min:"1.6.0" ~max:"2.0.0" "mirage-net-macosx" ]
+        | `Xen, _ -> [ package ~min:"1.10.0" ~max:"2.0.0" "mirage-net-xen"]
+        | `Qubes, _ ->
+          [ package ~min:"1.10.0" ~max:"2.0.0" "mirage-net-xen" ;
+            Mirage_impl_qubesdb.pkg ]
+        | `Virtio, _ | `Hvt, _ | `Muen, _ | `Genode, _ ->
+          [ package ~min:"0.4.2" ~max:"0.5.0" "mirage-net-solo5" ] in
+      Functoria_key.((pure choose)
+                     $ Key.(value target)
+                     $ Key.(value ixy))
+
     method! connect _ modname _ =
       Fmt.strf "%s.connect %a" modname Key.serialize_call key
     method! configure i =

--- a/lib/mirage_impl_network.ml
+++ b/lib/mirage_impl_network.ml
@@ -22,6 +22,7 @@ let network_conf (intf : string Key.key) =
           [ package "mirage-net-ixy" ]
         | `Unix, false ->
           [ package ~min:"2.6.0" ~max:"3.0.0" "mirage-net-unix" ]
+        | _, true -> failwith "ixy is not available on non-Linux platforms"
         | `MacOSX, _ -> [ package ~min:"1.6.0" ~max:"2.0.0" "mirage-net-macosx" ]
         | `Xen, _ -> [ package ~min:"1.10.0" ~max:"2.0.0" "mirage-net-xen"]
         | `Qubes, _ ->

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -180,6 +180,13 @@ let target_debug =
   let key = Arg.flag ~stage:`Configure doc in
   Key.create "target_debug" key
 
+let ixy =
+  let doc = "Enables target-specific support for ixy. Supported \
+             targets: unix." in
+  let doc = Arg.info ~docs:mirage_section ~docv:"IXY" ~doc ["ixy"] in
+  let key = Arg.flag ~stage:`Configure doc in
+  Key.create "ixy" key
+
 let no_depext =
   let doc = "Disable call to depext when generating Makefile." in
   let doc = Arg.info ~docs:mirage_section ~docv:"BOOL" ~doc ["no-depext"] in

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -54,6 +54,10 @@ val warn_error: bool key
 val target_debug: bool key
 (** [-g]. Enables target-specific support for debugging. *)
 
+val ixy: bool key
+(** [-ixy]. Enables target-specific support for ixy.
+    {{https://github.com/ixy-languages/ixy.ml}} *)
+
 val no_depext: bool key
 (** [--no-depext]. Disables opam depext in depend target of generated Makefile. *)
 


### PR DESCRIPTION
This PR adds initial support for the [ixy.ml](https://github.com/ixy-languages/ixy.ml) network driver as a MirageOS network device (aka `mirage-net-ixy`). It adds a new `--ixy` flag that can be selected with `mirage-unix` and a `direct` network stack.

When running a unikernel with the `mirage-net-ixy` the PCIe address of the NIC needs to be passed via `--interface=<addr>`. Don't forget to mount a `hugetlbfs` at `/mnt/huge` (use the [script](https://github.com/ixy-languages/ixy.ml/blob/master/setup-hugetlbfs.sh)).

@hannesm and I discussed that there should probably be some restructuring to make the interface more friendly.