### PR TITLE
Use dune to build unikernels

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
   (public_name mirage)
   (wrapped     false)
-  (libraries ipaddr logs astring functoria functoria.app mirage-runtime bos))
+  (libraries ipaddr logs astring functoria functoria.app mirage-runtime bos sexplib))

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -721,9 +721,10 @@ let config_solo5_default ~name ~binary_location ~target =
   let out = name ^ post in
   let alias = sxp_of_fmt {|
     (alias
-      (name hvt)
+      (name %a)
       (deps %s))
-  |} out
+  |} Key.pp_target target
+     out
   in
   (* Generate unikernel linking rule*)
   ldflags pkg >>= fun ldflags ->

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -711,7 +711,7 @@ let link info name target target_debug =
   | `Xen | `Qubes ->
     static_libs "mirage-xen-ocaml" >>= fun static_libs ->
     let linker =
-      Bos.Cmd.(v "ld" % "-d"
+      Bos.Cmd.(v "ld" % "--unresolved-symbols=ignore-all" % "-d" (*Some bigarray stuff is grabbed..*) 
                % "-static" % "-nostdlib" % binary_location %% of_list static_libs )
     in
     let out = name ^ ".xen" in

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -748,7 +748,7 @@ let link info name target target_debug =
     extra_c_artifacts "xen" libs >>= fun c_artifacts ->
     static_libs "mirage-xen" >>= fun static_libs ->
     let linker =
-      Bos.Cmd.(v "ld" % "-d" % "-static" % "-nostdlib" %
+      Bos.Cmd.(v "ld" % "-z" % "muldefs" % "-d" % "-static" % "-nostdlib" %
                "_build/main.native.o" %%
                of_list c_artifacts %%
                of_list static_libs)

--- a/lib/mirage_impl_ip.ml
+++ b/lib/mirage_impl_ip.ml
@@ -36,11 +36,11 @@ let right_tcpip_library ?ocamlfind ~sublibs pkg =
   let min = "3.7.1" and max = "3.8.0" in
   Key.match_ Key.(value target) @@ function
   |`MacOSX | `Unix ->
-    [ package ~min ~max ?ocamlfind ~sublibs pkg; package ?ocamlfind ~sublibs:["unix"] "tcpip-checksum"  ]
+    [ package ~min ~max ?ocamlfind ~sublibs pkg  ]
   |`Qubes  | `Xen ->
-    [ package ~min ~max ?ocamlfind ~sublibs pkg; package ?ocamlfind ~sublibs:["xen"] "tcpip-checksum"  ]
+    [ package ~min ~max ?ocamlfind ~sublibs pkg ]
   |`Virtio | `Hvt | `Muen | `Genode ->
-    [ package ~min ~max ?ocamlfind ~sublibs pkg; package ?ocamlfind ~sublibs:["ocaml"] "tcpip-checksum"  ]
+    [ package ~min ~max ?ocamlfind ~sublibs pkg ]
 
 let ipv4_keyed_conf ?network ?gateway () = impl @@ object
     inherit base_configurable

--- a/lib/mirage_impl_ip.ml
+++ b/lib/mirage_impl_ip.ml
@@ -36,11 +36,11 @@ let right_tcpip_library ?ocamlfind ~sublibs pkg =
   let min = "3.7.1" and max = "3.8.0" in
   Key.match_ Key.(value target) @@ function
   |`MacOSX | `Unix ->
-    [ package ~min ~max ?ocamlfind ~sublibs:("unix"::sublibs) pkg ]
+    [ package ~min ~max ?ocamlfind ~sublibs pkg; package ?ocamlfind ~sublibs:["unix"] "tcpip-checksum"  ]
   |`Qubes  | `Xen ->
-    [ package ~min ~max ?ocamlfind ~sublibs:("xen"::sublibs) pkg ]
+    [ package ~min ~max ?ocamlfind ~sublibs pkg; package ?ocamlfind ~sublibs:["xen"] "tcpip-checksum"  ]
   |`Virtio | `Hvt | `Muen | `Genode ->
-    [ package ~min ~max ?ocamlfind ~sublibs pkg ]
+    [ package ~min ~max ?ocamlfind ~sublibs pkg; package ?ocamlfind ~sublibs:["ocaml"] "tcpip-checksum"  ]
 
 let ipv4_keyed_conf ?network ?gateway () = impl @@ object
     inherit base_configurable

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -11,14 +11,11 @@ let stdlib_random_conf = object
   method! packages =
       Mirage_key.match_ Mirage_key.(value target) @@ function
       | `Unix | `MacOSX ->
-        [ package ~max:"0.1.0" "mirage-random-stdlib" ;
-          package "mirage-entropy-unix"]
+        [ package ~max:"0.1.0" "mirage-random-stdlib" ]
       | `Hvt | `Virtio | `Muen | `Genode ->
-        [ package ~max:"0.1.0" "mirage-random-stdlib" ;
-          package "mirage-entropy-freestanding" ]
+        [ package ~max:"0.1.0" "mirage-random-stdlib" ]
       | `Xen | `Qubes ->
-        [ package ~max:"0.1.0" "mirage-random-stdlib" ;
-          package "mirage-entropy-xen" ]
+        [ package ~max:"0.1.0" "mirage-random-stdlib" ]
   method! connect _ modname _ = Fmt.strf "%s.initialize ()" modname
 end
 
@@ -40,18 +37,13 @@ let nocrypto = impl @@ object
     method! packages =
       Mirage_key.match_ Mirage_key.(value target) @@ function
       | `Unix | `MacOSX ->
-        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["lwt"] "nocrypto" ;
-          package "zarith"  ]
+        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["lwt"] "nocrypto" ]
       | `Hvt | `Virtio | `Muen | `Genode ->
         [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"; "freestanding"] "nocrypto" ;
-          package ~min:"0.4.1" ~max:"0.5.0" "mirage-entropy"  ;
-          package "mirage-entropy-freestanding" ;
-          package "zarith-freestanding" ]
+          package ~min:"0.4.1" ~max:"0.5.0" "mirage-entropy" ]
       | `Xen | `Qubes ->
         [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"; "xen"] "nocrypto" ;
-          package ~min:"0.4.1" ~max:"0.5.0" "mirage-entropy"  ;
-          package "mirage-entropy-xen"  ;
-          package "zarith-xen" ]
+          package ~min:"0.4.1" ~max:"0.5.0" "mirage-entropy" ]
 
     method! build _ = Rresult.R.ok (enable_entropy ())
     method! connect i _ _ =

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -31,10 +31,18 @@ let nocrypto = impl @@ object
     method! packages =
       Mirage_key.match_ Mirage_key.(value target) @@ function
       | `Unix | `MacOSX ->
-        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["lwt"] "nocrypto" ]
-      | _ ->
-        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto" ;
-          package ~min:"0.4.1" ~max:"0.5.0" "mirage-entropy" ]
+        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["lwt"] "nocrypto" ;
+          package "zarith"  ]
+      | `Hvt | `Virtio | `Muen | `Genode ->
+        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"; "freestanding"] "nocrypto" ;
+          package ~min:"0.4.1" ~max:"0.5.0" "mirage-entropy"  ;
+          package "mirage-entropy-freestanding" ;
+          package "zarith-freestanding" ]
+      | `Xen | `Qubes ->
+        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"; "xen"] "nocrypto" ;
+          package ~min:"0.4.1" ~max:"0.5.0" "mirage-entropy"  ;
+          package "mirage-entropy-xen"  ;
+          package "zarith-xen" ]
 
     method! build _ = Rresult.R.ok (enable_entropy ())
     method! connect i _ _ =

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -39,10 +39,10 @@ let nocrypto = impl @@ object
       | `Unix | `MacOSX ->
         [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["lwt"] "nocrypto" ]
       | `Hvt | `Virtio | `Muen | `Genode ->
-        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"; "freestanding"] "nocrypto" ;
+        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto" ;
           package ~min:"0.4.1" ~max:"0.5.0" "mirage-entropy" ]
       | `Xen | `Qubes ->
-        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"; "xen"] "nocrypto" ;
+        [ package ~min:"0.5.4" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto" ;
           package ~min:"0.4.1" ~max:"0.5.0" "mirage-entropy" ]
 
     method! build _ = Rresult.R.ok (enable_entropy ())

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -9,7 +9,16 @@ let stdlib_random_conf = object
   method name = "random"
   method module_name = "Mirage_random_stdlib"
   method! packages =
-    Mirage_key.pure [ package ~max:"0.1.0" "mirage-random-stdlib" ]
+      Mirage_key.match_ Mirage_key.(value target) @@ function
+      | `Unix | `MacOSX ->
+        [ package ~max:"0.1.0" "mirage-random-stdlib" ;
+          package "mirage-entropy-unix"]
+      | `Hvt | `Virtio | `Muen | `Genode ->
+        [ package ~max:"0.1.0" "mirage-random-stdlib" ;
+          package "mirage-entropy-freestanding" ]
+      | `Xen | `Qubes ->
+        [ package ~max:"0.1.0" "mirage-random-stdlib" ;
+          package "mirage-entropy-xen" ]
   method! connect _ modname _ = Fmt.strf "%s.initialize ()" modname
 end
 

--- a/lib/mirage_impl_reporter.ml
+++ b/lib/mirage_impl_reporter.ml
@@ -21,7 +21,7 @@ let mirage_log ?ring_size ~default =
     method name = "mirage_logs"
     method module_name = "Mirage_logs.Make"
     method! packages =
-      Key.pure [ package ~min:"0.3.0" ~max:"0.4.0" "mirage-logs" ]
+      Key.pure [ package ~min:"1.0.0" ~max:"2.0.0" "mirage-logs" ]
     method! keys = [ Key.abstract logs ]
     method! connect _ modname = function
       | [ pclock ] ->


### PR DESCRIPTION
I'm creating this PR in order to track the modifications of the mirage CLI I've made for mirage/mirage#969.

`mirage config -t <target>` creates a `dune` file with all the rules needed to build the end user unikernel. This allows `mirage build` to be very simple (equal to `dune build @target`) and take full advantage of dune incremental builds.
 
Using variants, less packages will need (unix-freestanding-xen) specialization but this requires an update of packages that have C stubs.

One good indicator of this working fine is the `mirage/mirage-dev#dune` CI on mirage-skeleton. It doesn't pass yet but it should improve as we dufiny packages.