### PR TITLE
work on the log reporter

### DIFF
--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -98,13 +98,15 @@ val reporter: reporter typ
 (** Implementation of the log {!reporter} type. *)
 
 val default_reporter:
-  ?clock:pclock impl -> ?ring_size:int -> ?level:Logs.level ->
-  unit -> reporter impl
-(** [default_reporter ?clock ?level ()] is the log reporter that
-    prints log messages to the console, timestampted with [clock]. If
-    not provided, the default clock is {!default_posix_clock}. [level] is
-    the default log threshold. It is [Logs.Info] if not
-    specified. *)
+  ?timestamp:bool -> ?clock:pclock impl -> ?ring_size:int -> ?level:Logs.level ->
+  ?style:Fmt.style_renderer -> ?channel:out_channel -> unit -> reporter impl
+(** [default_reporter ~timestamp ~clock ~ring_size ~level ~style ~channel ()]
+    is the log reporter that prints log messages to the console, timestampted
+    with [clock] (if [timestamp] is provided and [true]). By default, the clock
+    is {!default_posix_clock}. [level] is the default log threshold. It is
+    [Logs.Info] unless specified. The [channel] is by default [Fmt.stderr].
+    The [style] defaults to [Fmt.setup_std_outputs ()] for Unix targets, and
+    none for other targets. *)
 
 val no_reporter: reporter impl
 (** [no_reporter] disable log reporting. *)

--- a/lib/mirage_impl_reporter.ml
+++ b/lib/mirage_impl_reporter.ml
@@ -13,8 +13,98 @@ let pp_level ppf = function
   | Logs.Debug    -> Fmt.string ppf "Logs.Debug"
   | Logs.App      -> Fmt.string ppf "Logs.App"
 
-let mirage_log ?ring_size ~default =
+let setup_log default style =
   let logs = Key.logs in
+  impl @@ object
+    inherit base_configurable
+    method ty = job
+    method name = "mirage_set_log"
+    method module_name = "Mirage_runtime"
+    method! keys = [ Key.abstract logs ]
+    method! deps = [abstract style]
+    method! connect _ modname _ =
+      Fmt.strf
+        "@[<v 2>\
+         %s.set_level ~default:%a %a;@ \
+         Lwt.return_unit@]"
+        modname pp_level default pp_key logs
+  end
+
+let pp_style ppf = function
+  | `Ansi_tty -> Fmt.string ppf "`Ansi_tty"
+  | `None -> Fmt.string ppf "`None"
+
+let channel x =
+  if x == Pervasives.stdout then "Fmt.stdout" else "Fmt.stderr"
+
+let setup_style chan style = impl @@ object
+    inherit base_configurable
+    method ty = job
+    method name = "mirage_setup_style"
+    method module_name = "Mirage_runtime"
+    method! connect _ _modname _ =
+      let ppf = channel chan in
+      Fmt.strf
+        "@[<v 2>\
+         Fmt.set_style_renderer %s %a;@ \
+         Lwt.return_unit@]"
+        ppf pp_style style
+  end
+
+let unix_setup_style = impl @@ object
+    inherit base_configurable
+    method ty = job
+    method name = "mirage_setup_style"
+    method module_name = "Fmt_tty"
+    method! packages = Key.pure [ package ~sublibs:["tty"] "fmt" ]
+    method! connect _ modname _ =
+      Fmt.strf
+        "@[<v 2>\
+         %s.setup_std_outputs ();@ \
+         Lwt.return_unit@]"
+        modname
+  end
+
+let basic_reporter chan setup =
+  impl @@ object
+    inherit base_configurable
+    method ty = reporter
+    method name = "mirage_basic_reporter"
+    method module_name = "Logs_fmt"
+    method! packages =
+      Key.pure [ package ~sublibs:["fmt"] "logs" ]
+    method! deps = [abstract setup]
+    method! connect _ modname _ =
+      Fmt.strf
+        "@[<v 2>\
+         let pp_header = Fmt.(suffix (unit \" \") %s.pp_header) in@ \
+         let dst = %s in@ \
+         let reporter = %s.reporter ~pp_header ~dst ~app:dst () in@ \
+         Logs.set_reporter reporter;@ \
+         Lwt.return_unit@]"
+        modname (channel chan) modname
+  end
+
+let timestamp_reporter chan setup =
+  impl @@ object
+    inherit base_configurable
+    method ty = pclock @-> reporter
+    method name = "mirage_timestamp_reporter"
+    method module_name = "Mirage_timestamp_reporter.Make"
+    method! packages =
+      Key.pure [ package "mirage-timestamp-reporter" ]
+    method! deps = [abstract setup]
+    method! connect _ modname _ =
+        Fmt.strf
+          "@[<v 2>\
+           let dst = %s in@ \
+           let reporter = %s.create ~dst () in@ \
+           Logs.set_reporter reporter;@ \
+           Lwt.return_unit@]"
+          (channel chan) modname
+  end
+
+let trace_ring_reporter ring_size setup =
   impl @@ object
     inherit base_configurable
     method ty = pclock @-> reporter
@@ -22,32 +112,39 @@ let mirage_log ?ring_size ~default =
     method module_name = "Mirage_logs.Make"
     method! packages =
       Key.pure [ package ~min:"0.3.0" ~max:"0.4.0" "mirage-logs" ]
-    method! keys = [ Key.abstract logs ]
+    method! deps = [abstract setup]
     method! connect _ modname = function
-      | [ pclock ] ->
+      | [ pclock ; _ ] ->
         Fmt.strf
           "@[<v 2>\
            let ring_size = %a in@ \
            let reporter = %s.create ?ring_size %s in@ \
-           Mirage_runtime.set_level ~default:%a %a;@ \
            %s.set_reporter reporter;@ \
-           Lwt.return reporter"
+           Lwt.return_unit@]"
           Fmt.(Dump.option int) ring_size
           modname pclock
-          pp_level default
-          pp_key logs
           modname
-    | _ -> failwith (connect_err "log" 1)
+    | _ -> failwith (connect_err "trace_ring_reporter" 1)
   end
 
-let default_reporter
-    ?(clock=default_posix_clock) ?ring_size ?(level=Logs.Info) () =
-  mirage_log ?ring_size ~default:level $ clock
+let default_setup channel ?(level = Logs.Info) ?style () =
+  let style =
+    match style with
+    | None ->
+      match_impl Key.(value target) [
+        `Unix, unix_setup_style;
+        `MacOSX, unix_setup_style
+      ] ~default:Functoria_app.noop
+    | Some x -> setup_style channel x
+  in
+  setup_log level style
 
-let no_reporter = impl @@ object
-    inherit base_configurable
-    method ty = reporter
-    method name = "no_reporter"
-    method module_name = "Mirage_runtime"
-    method! connect _ _ _ = "assert false"
-  end
+let default_reporter ?(timestamp = true) ?(clock=default_posix_clock)
+    ?ring_size ?level ?style ?(channel = stdout) () =
+  let setup = default_setup channel ?level ?style () in
+  match timestamp, ring_size with
+  | false, None -> basic_reporter channel setup
+  | true, None -> timestamp_reporter channel setup $ clock
+  | _ -> trace_ring_reporter ring_size setup $ clock
+
+let no_reporter = Functoria_app.noop

--- a/lib/mirage_impl_reporter.mli
+++ b/lib/mirage_impl_reporter.mli
@@ -3,9 +3,12 @@ type reporter = Functoria.job
 val reporter : reporter Functoria.typ
 
 val default_reporter :
-     ?clock:Mirage_impl_pclock.pclock Functoria.impl
+  ?timestamp:bool
+  -> ?clock:Mirage_impl_pclock.pclock Functoria.impl
   -> ?ring_size:int
   -> ?level:Logs.level
+  -> ?style:Fmt.style_renderer
+  -> ?channel:out_channel
   -> unit
   -> reporter Functoria.impl
 


### PR DESCRIPTION
how it used to be in any case:
![current](https://user-images.githubusercontent.com/228456/55753662-2f0dee80-5a4b-11e9-8873-b4531dee9446.png)

now, what I wanted to have are colours... on Unix to check whether the output terminal is a usual one, or redirected to a log file, or a dumb terminal.

now, the same unikernel with this patchset on unix:
![new-default-unix](https://user-images.githubusercontent.com/228456/55754075-236ef780-5a4c-11e9-9cfc-d12c43f3cab6.png)

when redirected to a file:
![new-default-unix-redirect](https://user-images.githubusercontent.com/228456/55754170-4bf6f180-5a4c-11e9-9169-92d46e9720fb.png)

solo5 target:
![new-default-solo5](https://user-images.githubusercontent.com/228456/55754177-51543c00-5a4c-11e9-9981-bdf58e8dd239.png)

now, modifying `config.ml` to include in the `register` call: `~reporter:(default_reporter ~timestamp:false ())` leads to (on unix):
![new-timestamp-false](https://user-images.githubusercontent.com/228456/55753815-857b2d00-5a4b-11e9-96ff-e84d828b98d0.png)

and ``~reporter:(default_reporter ~timestamp:false ~style:`Ansi_tty ())`` compiled for solo5:
![new-timestamp-false-style-ansi-tty-solo5](https://user-images.githubusercontent.com/228456/55753860-a6438280-5a4b-11e9-9596-3e7a75299d6f.png)

advantages:
- the user experience changes: unix unikernels reporting to standard output have colors now
- when the output is redirected to a file, there aren't color escape sequences
- you can explicitly enable colours for freestanding targets
- you can disable the timestamp ;)
- the mirage-logs library and its ring buffer is only used as dependency if the `ring_buffer` argument is passed to `default_reporter`

downsides are:
- tags are not printed atm
- log source name is not printed
- we should pass `style` as boot parameter (maybe `timestamp_prefix` as well?)

I guess to remove redundancy, the reporters should be part of mirage-logs..