### PR TITLE
Qrexec expose

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -42,6 +42,10 @@ type qubesdb = Mirage_impl_qubesdb.qubesdb
 let qubesdb = Mirage_impl_qubesdb.qubesdb
 let default_qubesdb = Mirage_impl_qubesdb.default_qubesdb
 
+type qrexec = Mirage_impl_qrexec.qrexec
+let qrexec = Mirage_impl_qrexec.qrexec
+let default_qrexec = Mirage_impl_qrexec.default_qrexec
+
 type time = Mirage_impl_time.time
 let time = Mirage_impl_time.time
 let default_time = Mirage_impl_time.default_time

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -935,21 +935,11 @@ let (++) acc x = match acc, x with
   | None, Some x -> Some [x]
   | Some acc, Some x -> Some (acc @ [x])
 
-(* TODO: ideally we'd combine these *)
-let qrexec_init = match_impl Key.(value target) [
-  `Qubes, Mirage_impl_qrexec.qrexec_qubes;
-] ~default:Functoria_app.noop
-
-let gui_init = match_impl Key.(value target) [
-  `Qubes, Mirage_impl_gui.gui_qubes;
-] ~default:Functoria_app.noop
-
 let register
     ?(argv=default_argv) ?tracing ?(reporter=default_reporter ())
     ?keys ?packages
     name jobs =
-  let argv = Some (Functoria_app.keys argv) in
+  let argv = Some [(Functoria_app.keys argv)] in
   let reporter = if reporter == no_reporter then None else Some reporter in
-  let qubes_init = Some [qrexec_init; gui_init] in
-  let init = qubes_init ++ argv ++ reporter ++ tracing in
+  let init = argv ++ reporter ++ tracing in
   register ?keys ?packages ?init name jobs

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -53,6 +53,9 @@ val qubesdb: qubesdb typ
 val default_qubesdb: qubesdb impl
 (** A default qubes database, guessed from the usual valid configurations. *)
 
+type qrexec
+val qrexec: qrexec typ
+val default_qrexec: qrexec impl
 
 (** {2 Time} *)
 

--- a/lib/mirage_impl_qrexec.ml
+++ b/lib/mirage_impl_qrexec.ml
@@ -24,6 +24,6 @@ let default_qrexec = impl @@ object
        Lwt.async (fun () ->@ \
        OS.Lifecycle.await_shutdown_request () >>= fun _ ->@ \
        %s.disconnect qrexec);@ \
-       Lwt.return (`Ok qrexec)@]"
+       Lwt.return qrexec@]"
       modname modname
 end

--- a/lib/mirage_impl_qrexec.ml
+++ b/lib/mirage_impl_qrexec.ml
@@ -3,9 +3,10 @@ module Name = Functoria_app.Name
 module Key = Mirage_key
 open Rresult
 
-let qrexec = job
+type qrexec = QREXEC
+let qrexec = Type QREXEC
 
-let qrexec_qubes = impl @@ object
+let default_qrexec = impl @@ object
   inherit base_configurable
   method ty = qrexec
   val name = Name.ocamlify @@ "qrexec_"

--- a/lib/mirage_impl_qrexec.mli
+++ b/lib/mirage_impl_qrexec.mli
@@ -1,2 +1,3 @@
-val qrexec_qubes : Functoria.job Functoria.impl
-val qrexec : Functoria.job Functoria.typ
+type qrexec
+val default_qrexec : qrexec Functoria.impl
+val qrexec : qrexec Functoria.typ

--- a/lib/mirage_impl_qrexec.mli
+++ b/lib/mirage_impl_qrexec.mli
@@ -1,1 +1,2 @@
 val qrexec_qubes : Functoria.job Functoria.impl
+val qrexec : Functoria.job Functoria.typ


### PR DESCRIPTION
We don't automatically invoke gui and qrexec for -t qubes anymore.
In QubesOS 3.2 it was necessary to start default handlers for all VMs,
otherwise QubesOS would assume the VM was not working properly and kill it
after 60 seconds.  This is configurable in QubesOS 4, so now that
QubesOS 3.2 is past end-of-life, don't do it by default.
/cc @yomimono 