### PR TITLE
require ocaml 4.05.0 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ locally or use the Docker image.
 
 You will need the following:
 
-* a working [OCaml](https://ocaml.org) compiler (4.04.2 or higher).
+* a working [OCaml](https://ocaml.org) compiler (4.05.0 or higher).
 * the [OPAM](https://opam.ocaml.org) source package manager (2.0.0 or higher).
 * an x86\_64 or armel Linux host to compile Xen kernels, or FreeBSD, OpenBSD or
   MacOS X for the solo5 and userlevel versions.

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -894,7 +894,7 @@ module Project = struct
         (* XXX: use %%VERSION_NUM%% here instead of hardcoding a version? *)
         let min = "3.5.0" and max = "3.6.0" in
         let common = [
-          package ~build:true ~min:"4.04.2" "ocaml";
+          package ~build:true ~min:"4.05.0" "ocaml";
           package "lwt";
           package ~min ~max "mirage-types-lwt";
           package ~min ~max "mirage-types";

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -17,7 +17,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.05.0"}
   "dune" {build & >= "1.1.0"}
   "ipaddr"             {>= "3.0.0"}
   "functoria-runtime"  {>= "2.2.2"}

--- a/mirage-types-lwt.opam
+++ b/mirage-types-lwt.opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends:   [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.05.0"}
   "dune" {build & >= "1.1.0"}
   "lwt"
   "cstruct" {>="3.2.1"}

--- a/mirage-types.opam
+++ b/mirage-types.opam
@@ -17,7 +17,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.05.0"}
   "dune" {build & >= "1.1.0"}
   "mirage-device" {>= "1.1.0"}
   "mirage-time" {>= "1.1.0"}

--- a/mirage.opam
+++ b/mirage.opam
@@ -17,7 +17,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.05.0"}
   "dune" {build & >= "1.1.0"}
   "ipaddr"             {>= "3.0.0"}
   "functoria"          {>= "2.2.3"}


### PR DESCRIPTION
see https://github.com/mirage/mirage-kv/commit/3df5b30f240f675d8d95c94440825e013b7cfc2f for further information

with ocaml 4.04.2, mirage itself could be compiled, but any generated configured unikernel (opam file) would require 4.05.0 due to the mirage-kv >= 2.0.0 dependency of mirage-types, where mirage-kv requires 4.05.0.