### PR TITLE
revised resolver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
    - PACKAGE=mirage
    - TESTS=false
  matrix:
-   - DISTRO=alpine OCAML_VERSION=4.05 EXTRA_ENV="MODE=unix"
-   - DISTRO=alpine OCAML_VERSION=4.05 EXTRA_ENV="MODE=virtio" TESTS=true
-   - DISTRO=ubuntu OCAML_VERSION=4.06 EXTRA_ENV="MODE=xen"
-   - DISTRO=centos-7 OCAML_VERSION=4.06 EXTRA_ENV="MODE=muen"
-   - DISTRO=debian-stable OCAML_VERSION=4.07 EXTRA_ENV="MODE=hvt"
+   - DISTRO=alpine OCAML_VERSION=4.07 EXTRA_ENV="MODE=unix"
+   - DISTRO=alpine OCAML_VERSION=4.07 EXTRA_ENV="MODE=virtio" TESTS=true
+   - DISTRO=ubuntu OCAML_VERSION=4.08 EXTRA_ENV="MODE=xen"
+   - DISTRO=centos-7 OCAML_VERSION=4.08 EXTRA_ENV="MODE=muen"
+   - DISTRO=debian-stable OCAML_VERSION=4.08 EXTRA_ENV="MODE=hvt"
    - DISTRO=ubuntu-lts OCAML_VERSION=4.07 EXTRA_ENV="MODE=qubes"

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -418,7 +418,7 @@ val generic_stackv4:
 type resolver
 val resolver: resolver typ
 val resolver_dns:
-  ?ns:Ipaddr.V4.t -> ?ns_port:int -> ?time:time impl -> stackv4 impl -> resolver impl
+  ?ns:Ipaddr.V4.t -> ?ns_port:int -> ?random:random impl -> ?time:time impl -> stackv4 impl -> resolver impl
 val resolver_unix_system: resolver impl
 
 (** {2 Syslog configuration} *)

--- a/lib/mirage_impl_conduit_connector.ml
+++ b/lib/mirage_impl_conduit_connector.ml
@@ -6,7 +6,7 @@ open Mirage_impl_stackv4
 type conduit_connector = Conduit_connector
 let conduit_connector = Type Conduit_connector
 
-let pkg = package ~min:"4.0.0" ~max:"5.0.0" "mirage-conduit"
+let pkg = package ~min:"2.0.0" ~max:"3.0.0" "conduit-mirage"
 
 let tcp_conduit_connector = impl @@ object
     inherit base_configurable

--- a/lib/mirage_impl_conduit_connector.ml
+++ b/lib/mirage_impl_conduit_connector.ml
@@ -6,7 +6,7 @@ open Mirage_impl_stackv4
 type conduit_connector = Conduit_connector
 let conduit_connector = Type Conduit_connector
 
-let pkg = package ~min:"3.0.1" ~max:"4.0.0" "mirage-conduit"
+let pkg = package ~min:"4.0.0" ~max:"5.0.0" "mirage-conduit"
 
 let tcp_conduit_connector = impl @@ object
     inherit base_configurable

--- a/lib/mirage_impl_resolver.ml
+++ b/lib/mirage_impl_resolver.ml
@@ -26,9 +26,6 @@ let resolver_unix_system = impl @@ object
     method! connect _ _modname _ = "Lwt.return Resolver_lwt_unix.system"
   end
 
-let meta_ipv4 ppf s =
-  Fmt.pf ppf "(Ipaddr.V4.of_string_exn %S)" (Ipaddr.V4.to_string s)
-
 let resolver_dns_conf ~ns ~ns_port = impl @@ object
     inherit base_configurable
     method ty = random @-> time @-> stackv4 @-> resolver
@@ -36,18 +33,20 @@ let resolver_dns_conf ~ns ~ns_port = impl @@ object
     method module_name = "Resolver_mirage.Make_with_stack"
     method! packages =
       Key.pure [ Mirage_impl_conduit_connector.pkg ]
+    method! keys = [ Key.abstract ns ; Key.abstract ns_port ]
     method! connect _ modname = function
       | [ _r ; _t ; stack ] ->
-        let meta_ns = Fmt.Dump.option meta_ipv4 in
-        let meta_port = Fmt.(Dump.option int) in
         Fmt.strf
           "let ns = %a in@;\
            let ns_port = %a in@;\
-           let res = %s.R.init ?ns ?ns_port ~stack:%s () in@;\
+           let res = %s.R.init ~ns ~ns_port ~stack:%s () in@;\
            Lwt.return res@;"
-          meta_ns ns meta_port ns_port modname stack
+          pp_key ns pp_key ns_port modname stack
       | _ -> failwith (connect_err "resolver" 3)
   end
 
 let resolver_dns ?ns ?ns_port ?(random = default_random) ?(time = default_time) stack =
+  let ns = Key.resolver ?default:ns ()
+  and ns_port = Key.resolver_port ?default:ns_port ()
+  in
   resolver_dns_conf ~ns ~ns_port $ random $ time $ stack

--- a/lib/mirage_impl_resolver.ml
+++ b/lib/mirage_impl_resolver.ml
@@ -17,7 +17,7 @@ let resolver_unix_system = impl @@ object
     method! packages =
       Key.(if_ is_unix)
         [ Mirage_impl_conduit_connector.pkg ;
-          package ~min:"1.0.0" ~max:"2.0.0" "conduit-lwt-unix"; ]
+          package ~min:"1.0.0" ~max:"3.0.0" "conduit-lwt-unix"; ]
         []
     method! configure i =
       match get_target i with

--- a/lib/mirage_impl_resolver.ml
+++ b/lib/mirage_impl_resolver.ml
@@ -3,6 +3,7 @@ module Key = Mirage_key
 open Mirage_impl_misc
 open Mirage_impl_time
 open Mirage_impl_stackv4
+open Mirage_impl_random
 open Rresult
 
 type resolver = Resolver
@@ -30,13 +31,13 @@ let meta_ipv4 ppf s =
 
 let resolver_dns_conf ~ns ~ns_port = impl @@ object
     inherit base_configurable
-    method ty = time @-> stackv4 @-> resolver
+    method ty = random @-> time @-> stackv4 @-> resolver
     method name = "resolver"
     method module_name = "Resolver_mirage.Make_with_stack"
     method! packages =
       Key.pure [ Mirage_impl_conduit_connector.pkg ]
     method! connect _ modname = function
-      | [ _t ; stack ] ->
+      | [ _r ; _t ; stack ] ->
         let meta_ns = Fmt.Dump.option meta_ipv4 in
         let meta_port = Fmt.(Dump.option int) in
         Fmt.strf
@@ -45,8 +46,8 @@ let resolver_dns_conf ~ns ~ns_port = impl @@ object
            let res = %s.R.init ?ns ?ns_port ~stack:%s () in@;\
            Lwt.return res@;"
           meta_ns ns meta_port ns_port modname stack
-      | _ -> failwith (connect_err "resolver" 2)
+      | _ -> failwith (connect_err "resolver" 3)
   end
 
-let resolver_dns ?ns ?ns_port ?(time = default_time) stack =
-  resolver_dns_conf ~ns ~ns_port $ time $ stack
+let resolver_dns ?ns ?ns_port ?(random = default_random) ?(time = default_time) stack =
+  resolver_dns_conf ~ns ~ns_port $ random $ time $ stack

--- a/lib/mirage_impl_resolver.mli
+++ b/lib/mirage_impl_resolver.mli
@@ -5,6 +5,7 @@ val resolver : resolver Functoria.typ
 val resolver_dns :
      ?ns:Ipaddr.V4.t
   -> ?ns_port:int
+  -> ?random:Mirage_impl_random.random Functoria.impl
   -> ?time:Mirage_impl_time.time Functoria.impl
   -> Mirage_impl_stackv4.stackv4 Functoria.impl
   -> resolver Functoria.impl

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -343,6 +343,14 @@ module V6 = struct
 
 end
 
+let resolver ?(default = Ipaddr.V4.of_string_exn "91.239.100.100") () =
+  let doc = Fmt.strf "DNS resolver (default to anycast.censurfridns.dk)" in
+  create_simple ~doc ~default Arg.ipv4_address "resolver"
+
+let resolver_port ?(default = 53) () =
+  let doc = Fmt.strf "DNS resolver port" in
+  create_simple ~doc ~default Arg.int "resolver-port"
+
 let syslog default =
   let doc = Fmt.strf "syslog server" in
   create_simple ~doc ~default Arg.(some ipv4_address) "syslog"

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -133,6 +133,12 @@ module V6 : sig
 
 end
 
+val resolver: ?default:Ipaddr.V4.t -> unit -> Ipaddr.V4.t key
+(** The address of the DNS resolver to use. *)
+
+val resolver_port: ?default:int -> unit -> int key
+(** The port of the DNS resolver. *)
+
 val syslog: Ipaddr.V4.t option -> Ipaddr.V4.t option key
 (** The address to send syslog frames to. *)
 


### PR DESCRIPTION
this requires https://github.com/mirage/ocaml-conduit/pull/290 (which in turn requires a release of ocaml-dns, which will happen soon).

what this PR does:
- the Resolver_mirage.With_stack functor now requires a random device (to generate the identifier of the DNS packet) -- as usual, the `default_random` device is used (configurable via `--prng` configuration time parameter)
- two new command-line keywords are provided (both stages, configuration and runtime): `resolver` and `resolver-port` for configuring the resolver to use