### PR TITLE
ocamlbuild: Respect verbosity, quiet by default

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -627,8 +627,13 @@ let compile ignore_dirs libs warn_error target =
     | [] -> Bos.Cmd.empty
     | dirs  -> Bos.Cmd.(v "-Xs" % concat dirs)
   in
+  let want_quiet_build = match Logs.level () with
+  | Some Info | Some Debug -> false
+  | _ -> true
+  in
   let cmd = Bos.Cmd.(v "ocamlbuild" % "-use-ocamlfind" %
-                     "-classic-display" %
+                     "-classic-display" %%
+                     on want_quiet_build (v "-quiet") %
                      "-tags" % concat tags %
                      "-pkgs" % concat libs %
                      "-cflags" % concat cflags %


### PR DESCRIPTION
Make the ocamlbuild invocation respect the mirage tool's verbosity
setting. As the default log level is Warning, this will result in quiet
builds by default; mirage build --verbose can be used to get an
equivalent of the old behaviour.

/cc @mirage/core