### PR TITLE
mirage-entropy functorized

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -54,11 +54,14 @@ type mclock = Mirage_impl_mclock.mclock
 let mclock = Mirage_impl_mclock.mclock
 let default_monotonic_clock = Mirage_impl_mclock.default_monotonic_clock
 
+type entry_points = Mirage_impl_entry_points.entry_points
+let entry_points = Mirage_impl_entry_points.entry_points
+let default_entry_points = Mirage_impl_entry_points.default_entry_points
+
 type random = Mirage_impl_random.random
 let random = Mirage_impl_random.random
 let stdlib_random = Mirage_impl_random.stdlib_random
 let default_random = Mirage_impl_random.default_random
-let nocrypto = Mirage_impl_random.nocrypto
 let nocrypto_random = Mirage_impl_random.nocrypto_random
 
 type console = Mirage_impl_console.console

--- a/lib/mirage_impl_conduit.ml
+++ b/lib/mirage_impl_conduit.ml
@@ -1,6 +1,5 @@
 open Functoria
 open Mirage_impl_conduit_connector
-open Mirage_impl_random
 
 type conduit = Conduit
 let conduit = Type Conduit
@@ -11,11 +10,10 @@ let conduit_with_connectors connectors = impl @@ object
     method name = Functoria_app.Name.create "conduit" ~prefix:"conduit"
     method module_name = "Conduit_mirage"
     method! packages = Mirage_key.pure [ pkg ]
-    method! deps = abstract nocrypto :: List.map abstract connectors
+    method! deps = List.map abstract connectors
 
     method! connect _i _ = function
-      (* There is always at least the nocrypto device *)
-      | _nocrypto :: connectors ->
+      | connectors ->
         let pp_connector = Fmt.fmt "%s >>=@ " in
         let pp_connectors = Fmt.list ~sep:Fmt.nop pp_connector in
         Fmt.strf
@@ -23,7 +21,6 @@ let conduit_with_connectors connectors = impl @@ object
            %a\
            fun t -> Lwt.return t"
           pp_connectors connectors
-      | [] -> failwith "The conduit with connectors expects at least one argument"
   end
 
 let conduit_direct ?(tls=false) s =

--- a/lib/mirage_impl_conduit_connector.ml
+++ b/lib/mirage_impl_conduit_connector.ml
@@ -1,6 +1,5 @@
 open Functoria
 open Mirage_impl_misc
-open Mirage_impl_random
 open Mirage_impl_stackv4
 
 type conduit_connector = Conduit_connector
@@ -29,6 +28,5 @@ let tls_conduit_connector = impl @@ object
         package ~min:"0.10.0" ~max:"0.11.0" ~sublibs:["mirage"] "tls" ;
         pkg
       ]
-    method! deps = [ abstract nocrypto ]
     method! connect _ _ _ = "Lwt.return Conduit_mirage.with_tls"
   end

--- a/lib/mirage_impl_entry_points.ml
+++ b/lib/mirage_impl_entry_points.ml
@@ -1,0 +1,48 @@
+open Functoria
+
+type entry_points = ENTRY_POINTS
+let entry_points = Type ENTRY_POINTS
+
+let entry_points_unix = impl @@ object
+  inherit base_configurable
+  method ty = entry_points
+  val name = "entry-points-unix"
+  method name = name
+  method module_name = "Mirage_unix_main"
+  method! packages =
+    Mirage_key.pure
+      [ package ~sublibs:[ "main" ] "mirage-unix" ]
+end
+
+let entry_points_solo5 = impl @@ object
+  inherit base_configurable
+  method ty = entry_points
+  val name = "entry-points-solo5"
+  method name = name
+  method module_name = "Mirage_solo5_main"
+  method! packages =
+    Mirage_key.pure
+      [ package ~sublibs:[ "main" ] "mirage-solo5" ]
+end
+
+let entry_points_xen = impl @@ object
+  inherit base_configurable
+  method ty = entry_points
+  val name = "entry-points-xen"
+  method name = name
+  method module_name = "Mirage_xen_main"
+  method! packages =
+    Mirage_key.pure
+      [ package ~sublibs:[ "main" ] "mirage-xen" ]
+end
+
+let default_entry_points =
+  match_impl Mirage_key.(value target)
+    [ `Xen,    entry_points_xen
+    ; `Qubes,  entry_points_xen
+    ; `Virtio, entry_points_solo5
+    ; `Hvt,    entry_points_solo5
+    ; `Spt,    entry_points_solo5
+    ; `Muen,   entry_points_solo5
+    ; `Genode, entry_points_solo5 ]
+  ~default:entry_points_unix

--- a/lib/mirage_impl_entry_points.mli
+++ b/lib/mirage_impl_entry_points.mli
@@ -1,0 +1,11 @@
+open Functoria
+
+type entry_points
+
+val entry_points : entry_points typ
+
+val entry_points_unix : entry_points impl
+val entry_points_solo5 : entry_points impl
+val entry_points_xen : entry_points impl
+
+val default_entry_points : entry_points impl

--- a/lib/mirage_impl_ip.ml
+++ b/lib/mirage_impl_ip.ml
@@ -7,6 +7,7 @@ open Mirage_impl_mclock
 open Mirage_impl_misc
 open Mirage_impl_network
 open Mirage_impl_qubesdb
+open Mirage_impl_entry_points
 open Mirage_impl_random
 open Mirage_impl_time
 
@@ -91,12 +92,15 @@ let ipv4_dhcp_conf = impl @@ object
 
 let dhcp random time net = dhcp_conf $ random $ time $ net
 let ipv4_of_dhcp
-    ?(random = default_random)
+    ?(entry_points= default_entry_points)
+    ?(random = default_random ~entry_points ())
     ?(clock = default_monotonic_clock) dhcp ethif arp =
   ipv4_dhcp_conf $ dhcp $ random $ clock $ ethif $ arp
 
 let create_ipv4 ?group ?config
-    ?(random = default_random) ?(clock = default_monotonic_clock) etif arp =
+    ?(entry_points= default_entry_points)
+    ?(random = default_random ~entry_points ())
+    ?(clock = default_monotonic_clock) etif arp =
   let config = match config with
   | None ->
     let network = Ipaddr.V4.Prefix.of_address_string_exn "10.0.0.2/24"
@@ -131,7 +135,8 @@ let ipv4_qubes_conf = impl @@ object
   end
 
 let ipv4_qubes
-    ?(random = default_random)
+    ?(entry_points = default_entry_points)
+    ?(random = default_random ~entry_points ())
     ?(clock = default_monotonic_clock) db ethernet arp =
   ipv4_qubes_conf $ db $ random $ clock $ ethernet $ arp
 
@@ -154,7 +159,8 @@ let ipv6_conf ?addresses ?netmasks ?gateways () = impl @@ object
   end
 
 let create_ipv6
-    ?(random = default_random)
+    ?(entry_points = default_entry_points)
+    ?(random = default_random ~entry_points ())
     ?(time = default_time)
     ?(clock = default_monotonic_clock)
     ?group etif { addresses ; netmasks ; gateways } =

--- a/lib/mirage_impl_ip.mli
+++ b/lib/mirage_impl_ip.mli
@@ -4,6 +4,7 @@ open Mirage_impl_ethernet
 open Mirage_impl_mclock
 open Mirage_impl_network
 open Mirage_impl_qubesdb
+open Mirage_impl_entry_points
 open Mirage_impl_random
 
 type v4
@@ -33,6 +34,7 @@ type ipv6_config =
 val create_ipv4 :
      ?group:string
   -> ?config:ipv4_config
+  -> ?entry_points:entry_points impl
   -> ?random:random impl
   -> ?clock:mclock impl
   -> ethernet impl
@@ -40,7 +42,8 @@ val create_ipv4 :
   -> ipv4 impl
 
 val create_ipv6 :
-     ?random:random impl
+     ?entry_points:entry_points impl
+  -> ?random:random impl
   -> ?time:Mirage_impl_time.time impl
   -> ?clock:mclock impl
   -> ?group:string
@@ -55,7 +58,8 @@ val dhcp :
   -> Mirage_impl_dhcp.dhcp impl
 
 val ipv4_of_dhcp :
-     ?random:random impl
+     ?entry_points:entry_points impl
+  -> ?random:random impl
   -> ?clock:mclock impl
   -> Mirage_impl_dhcp.dhcp impl
   -> ethernet impl
@@ -63,7 +67,8 @@ val ipv4_of_dhcp :
   -> ipv4 impl
 
 val ipv4_qubes :
-     ?random:random impl
+     ?entry_points:entry_points impl
+  -> ?random:random impl
   -> ?clock:mclock impl
   -> qubesdb impl
   -> ethernet impl

--- a/lib/mirage_impl_random.mli
+++ b/lib/mirage_impl_random.mli
@@ -1,13 +1,14 @@
+open Functoria
+open Mirage_impl_entry_points
+
 type random
 
-val random : random Functoria.typ
+val random : random typ
 
-val stdlib_random : random Functoria.impl
+val stdlib_random : entry_points impl -> random impl
 
-val default_random : random Functoria.impl
+val default_random : ?entry_points:entry_points impl -> unit -> random impl
 
-val nocrypto : Functoria.job Functoria.impl
-
-val nocrypto_random : random Functoria.impl
+val nocrypto_random : entry_points impl -> random impl
 
 val is_entropy_enabled : unit -> bool

--- a/lib/mirage_impl_resolver.ml
+++ b/lib/mirage_impl_resolver.ml
@@ -3,6 +3,7 @@ module Key = Mirage_key
 open Mirage_impl_misc
 open Mirage_impl_time
 open Mirage_impl_stackv4
+open Mirage_impl_entry_points
 open Mirage_impl_random
 open Rresult
 
@@ -45,7 +46,10 @@ let resolver_dns_conf ~ns ~ns_port = impl @@ object
       | _ -> failwith (connect_err "resolver" 3)
   end
 
-let resolver_dns ?ns ?ns_port ?(random = default_random) ?(time = default_time) stack =
+let resolver_dns ?ns ?ns_port
+    ?(entry_points = default_entry_points)
+    ?(random = default_random ~entry_points ())
+    ?(time = default_time) stack =
   let ns = Key.resolver ?default:ns ()
   and ns_port = Key.resolver_port ?default:ns_port ()
   in

--- a/lib/mirage_impl_resolver.mli
+++ b/lib/mirage_impl_resolver.mli
@@ -5,6 +5,7 @@ val resolver : resolver Functoria.typ
 val resolver_dns :
      ?ns:Ipaddr.V4.t
   -> ?ns_port:int
+  -> ?entry_points:Mirage_impl_entry_points.entry_points Functoria.impl
   -> ?random:Mirage_impl_random.random Functoria.impl
   -> ?time:Mirage_impl_time.time Functoria.impl
   -> Mirage_impl_stackv4.stackv4 Functoria.impl

--- a/lib/mirage_impl_stackv4.ml
+++ b/lib/mirage_impl_stackv4.ml
@@ -7,6 +7,7 @@ open Mirage_impl_mclock
 open Mirage_impl_misc
 open Mirage_impl_network
 open Mirage_impl_qubesdb
+open Mirage_impl_entry_points
 open Mirage_impl_random
 open Mirage_impl_tcp
 open Mirage_impl_time
@@ -37,7 +38,8 @@ let stackv4_direct_conf ?(group="") () = impl @@ object
 
 let direct_stackv4
     ?(clock=default_monotonic_clock)
-    ?(random=default_random)
+    ?(entry_points=default_entry_points)
+    ?(random=default_random ~entry_points ())
     ?(time=default_time)
     ?group
     network eth arp ip =
@@ -48,7 +50,10 @@ let direct_stackv4
   $ direct_udp ~random ip
   $ direct_tcp ~clock ~random ~time ip
 
-let dhcp_ipv4_stack ?group ?(random = default_random) ?(time = default_time) ?(arp = arp ?time:None) tap =
+let dhcp_ipv4_stack ?group
+    ?(entry_points = default_entry_points)
+    ?(random = default_random ~entry_points ())
+    ?(time = default_time) ?(arp = arp ?time:None) tap =
   let config = dhcp random time tap in
   let e = etif tap in
   let a = arp e in

--- a/lib/mirage_impl_stackv4.mli
+++ b/lib/mirage_impl_stackv4.mli
@@ -4,6 +4,7 @@ val stackv4 : stackv4 Functoria.typ
 
 val direct_stackv4 :
      ?clock:Mirage_impl_mclock.mclock Functoria.impl
+  -> ?entry_points:Mirage_impl_entry_points.entry_points Functoria.impl
   -> ?random:Mirage_impl_random.random Functoria.impl
   -> ?time:Mirage_impl_time.time Functoria.impl
   -> ?group:string
@@ -26,6 +27,7 @@ val qubes_ipv4_stack :
 
 val dhcp_ipv4_stack :
      ?group:string
+  -> ?entry_points:Mirage_impl_entry_points.entry_points Functoria.impl
   -> ?random:Mirage_impl_random.random Functoria.impl
   -> ?time:Mirage_impl_time.time Functoria.impl
   -> ?arp:(   Mirage_impl_ethernet.ethernet Functoria.impl

--- a/lib/mirage_impl_tcp.ml
+++ b/lib/mirage_impl_tcp.ml
@@ -4,6 +4,7 @@ open Functoria
 open Mirage_impl_ip
 open Mirage_impl_mclock
 open Mirage_impl_misc
+open Mirage_impl_entry_points
 open Mirage_impl_random
 open Mirage_impl_time
 open Rresult
@@ -33,7 +34,8 @@ let tcp_direct_func () = impl (tcp_direct_conf ())
 
 let direct_tcp
     ?(clock=default_monotonic_clock)
-    ?(random=default_random)
+    ?(entry_points= default_entry_points)
+    ?(random=default_random ~entry_points ())
     ?(time=default_time) ip =
   tcp_direct_func () $ ip $ time $ clock $ random
 

--- a/lib/mirage_impl_tcp.mli
+++ b/lib/mirage_impl_tcp.mli
@@ -12,6 +12,7 @@ val tcpv6 : tcpv6 Functoria.typ
 
 val direct_tcp :
      ?clock:Mirage_impl_mclock.mclock Functoria.impl
+  -> ?entry_points:Mirage_impl_entry_points.entry_points Functoria.impl
   -> ?random:Mirage_impl_random.random Functoria.impl
   -> ?time:Mirage_impl_time.time Functoria.impl
   -> 'a Mirage_impl_ip.ip Functoria.impl

--- a/lib/mirage_impl_udp.ml
+++ b/lib/mirage_impl_udp.ml
@@ -3,6 +3,7 @@ module Name = Functoria_app.Name
 open Functoria
 open Mirage_impl_ip
 open Mirage_impl_misc
+open Mirage_impl_entry_points
 open Mirage_impl_random
 open Rresult
 
@@ -28,7 +29,10 @@ end
 
 (* Value restriction ... *)
 let udp_direct_func () = impl (udp_direct_conf ())
-let direct_udp ?(random=default_random) ip = udp_direct_func () $ ip $ random
+let direct_udp
+  ?(entry_points=default_entry_points)
+  ?(random=default_random ~entry_points ())
+  ip = udp_direct_func () $ ip $ random
 
 let udpv4_socket_conf ipv4_key = object
   inherit base_configurable

--- a/lib/mirage_impl_udp.mli
+++ b/lib/mirage_impl_udp.mli
@@ -9,6 +9,7 @@ val udpv4 : udpv4 Functoria.typ
 val udpv6 : udpv6 Functoria.typ
 
 val direct_udp :
+?entry_points:Mirage_impl_entry_points.entry_points Functoria.impl ->
 ?random:Mirage_impl_random.random Functoria.impl -> 'a Mirage_impl_ip.ip
 Functoria.impl -> 'a udp Functoria.impl
 


### PR DESCRIPTION
Hi @mirage/core!

This PR is one patch to paving the way for the _dunification_ of MirageOS. But, at least, it rollbacks the MirageOS eco-system to something more homogeneous. Indeed, the choice of MirageOS is to take the advantage of _functors_ to be able to choose an implementations of an abstraction - like choose `irmin` or `crunch` as a read-only KV-store.

`functoria` serves this purpose and orchestrates application of _functors_ according definitions.

### The black duck

However, a part of the MirageOS decided to choose an other way to specialize an implementation from another by a non-conventional way: `mirage-entropy` with `mirage-os-shim`. These packages use the _linking-trick_:
- `mirage-entropy` expects __at the link time__ a CMX which follows CMI provided by `mirage-os-shim`
- `nocrypto.mirage` and `mirage-stdlib-random` are done on top of that
- a _dummy implementation_ exists to ensure that this CMX is not missed when we configure an _unikernel_ - to avoid any struggle at the build-time

According discussion on mirage/mirage-os-shim#8, the goal of this PR is to delete this non-explicit dependency path of the MirageOS eco-system and provide a new way to have a _random generator_ implementation.

### The solution

This new way is, of course, the _functor_ way. Random generator must initializes an entropy engine at the beginning of the process - so, just before `start`. `mirage-entropy` trusts on a CMI to have an access to `at_enter_iter` and fill a state used by the entropy engine.

However, as I said, implementation of this CMI provided by `mirage-os-shim` does not exist - not yet. Then, `mirage-os-shim` provided a specialization of implementations of targets (eg. `mirage-solo5`, `mirage-xen` & `mirage-unix`) under the same CMI.

At the end, `mirage-entropy` will be linked with the right specialization/implementation of `mirage-os-shim` (with an help of `META` file/`ocamlfind` - **hint** _dunification_) and will be have an access to `at_enter_iter`. However, `functoria` is not able to follow this kind of dependency - or precisely not conventionally.

The choice was made to provide a new interface `Mirage_main.S` (see mirage/mirage-os-shim#9) into the `mirage-os-shim` package and only an interface - so specialization of targets under this interface should not exist anymore.

Then, by this way, we are able to reverse the dependency graph between targets and `mirage-os-shim`. targets must depend on `mirage-os-shim` and implement this interface - the choice was made to provide a new sub-package `main`:
- mirage/mirage-solo5#53
- mirage/mirage-unix#13

`mirage-entropy` will be _functorized_ over this interface (mirage/mirage-entropy#44) and, by cascading, `mirage-random-stdlib` will be _functorized_ too (mirage/mirage-random-stdlib#2). `nocrypto.mirage` is not needed anymore when a new package [`mirage-entropy-nocrypto`](https://github.com/dinosaure/mirage-entropy-nocrypto.git) follows the same implementation but, again, in a _functorized_ way.

Random generators expect now an implementation which provides entry-points of the target - see `Mirage_impl_entry_points`. Of course, any random occurrence must be updated to, at least, choose the default random implementation (eg. `mirage-random-stdlib`) with the right _default_ target.

Finally, to ensure the existence of the CMX at the link time when we currently compile an _unikernel_, a _dummy implementation_ was made to track this dependency globally and ensure that CMX of the target to provide `at_enter_iter` exists at the link time.

Because we follow in this PR an usual pattern (with `functoria` and dependencies with `package`), this _dummy implementation_ is not needed anymore - I think. But I don't know real implication of this deletion.

### Status of this PR

At first, this PR wants to show what is going on currently and what we will do to start proper discussion of all of that when, even if it concerns few packages, update seems deep enough to avoid to click with blinded eyes.

Secondly, it breaks compatibility specially about `random`, so we need to take care across several others packages and still have a consistent eco-system. `pins` was not done, `versions` should be cleaned and we should start a release plan.

Third, `entry_points`/`mirage-os-shim`/`*.main` use bad names or non-explicit purposes names and we should find a consensus to be clear about all of that to avoid any mis-conception/mis-comprehension.

### _functor_ design, _linking-trick_ and _virtual-library_

As I said into mirage/mirage-os-shim#8, `virtual_libraries` provided by `dune` is interesting for us when `mirage` should be only an _interface provider_. However, the goal, at this time, is to _dunify_ MirageOS - so I prefer to post-pone this goal.

Design of `mirage-entropy`/`mirage-os-shim` is not bad and is an example of how to use `virtual_libraries` outside the scope of `dune` - and mirage/mirage-os-shim#8 provides a compatible way across packages of this idea independently of the build-system. However, this patch highlight how _linking-trick_ (at the end, or more generally we can talk about the _linking-trick_) is fragile specially with `functoria` (which was not developed with pattern in our mind).

It shows that, even if we can find good aspects of it, it's hard to follow what is really going on when I spend finally 2 weeks to really understand the dependency graph of all with one of my smallest _unikernel_ [`entropieur`](https://github.com/dinosaure/mirage-os-shinimy).

I think, we should stay far from all of that at the beginning and start a full documentation of all and may be a migration to this kind of design then, but I consider it as orthogonal to the _dunification_ of MirageOS first.