### PR TITLE
exit 0 on successful termination

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -920,7 +920,7 @@ module Project = struct
   let prelude =
     "open Lwt.Infix\n\
      let return = Lwt.return\n\
-     let run = OS.Main.run"
+     let run t = OS.Main.run t ; exit 0"
 
   (* The ocamlfind packages to use when compiling config.ml *)
   let packages = [package "mirage"]


### PR DESCRIPTION
while testing and reading #1010 (esp. `at_exit` handlers), I discovered some inconsistencies in respect to unikernel teardown across the backends that I attempt to clean up here.

a) only with mirage-unix the `at_exit` is actually called (due to how binaries work on unix and that if main finishes, exit is called). MirageOS unikernels that terminate successfully (with exit code 0) never execute `at_exit` handlers. This is solved by calling `exit 0` after `OS.Main.run t`.

b) if `start` terminates abnormally, the different backends handle this slightly differently:
- mirage-unix executes the main task `t` in a `Lwt.catch`, where the exception handler `Logs.err` and calls `Lwt.return_unit` -- the exit code is always 0!
- mirage-solo5 and mirage-xen have a `try Lwt.poll () with exn -> ..`, where the exception handler `Logs.err` and calls `exit 1` (which I dislike even more due to recent work on restart-on-failure)

The primary goal of using `Logs` was to report the exceptions and backtraces via custom log reporters (i.e. syslog), but it turns out to not work very reliable (the unikernel will be terminated before the syslog message is put on the wire). The code should just disappear (I'll PR in the various backends before a next release), and then OCaml's default uncaught exception handler (or Lwt's async_exception_hook) prints the backtrace on stdout/stderr.