### PR TITLE
relax mirage-runtime dependency to be in range 3.7.0 .. 3.8.0

### DIFF
--- a/mirage.opam
+++ b/mirage.opam
@@ -25,7 +25,7 @@ depends: [
   "astring"
   "logs"
   "stdlib-shims"
-  "mirage-runtime"     {= version}
+  "mirage-runtime"     {>= "3.7.0" & < "3.8.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """


### PR DESCRIPTION
for #1017 to pass, this has been applied to opam-repository at https://github.com/ocaml/opam-repository/pull/15364