### PR TITLE
dunification of MirageOS

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
   (public_name mirage)
   (wrapped     false)
-  (libraries stdlib-shims ipaddr logs astring functoria functoria.app mirage-runtime bos))
+  (libraries stdlib-shims ipaddr logs astring functoria functoria.app mirage-runtime bos sexplib))

--- a/lib/mirage_build.mli
+++ b/lib/mirage_build.mli
@@ -1,5 +1,4 @@
 open Rresult
 
 val ignore_dirs : string list
-val compile : string list -> string list -> bool -> Mirage_key.mode -> (unit, [> R.msg ]) result
 val build : Functoria.Info.t -> (unit, [> R.msg ]) result

--- a/lib/mirage_cc_to_opt.ml
+++ b/lib/mirage_cc_to_opt.ml
@@ -1,0 +1,167 @@
+open Rresult
+
+module Log = Mirage_impl_misc.Log
+
+let search directories library =
+  let rec go = function
+    | [] -> R.error_msgf "Library <%a> does not exist." Fpath.pp library
+    | x :: r ->
+      let path = Fpath.(x // library) in
+      Bos.OS.File.exists path >>= function
+      | true -> Ok path
+      | false -> go r in
+  go directories
+
+let resolve directories libraries =
+  Log.debug (fun m -> m "Start to resolve static libraries into: %a" Fmt.(Dump.list Fpath.pp) directories) ;
+  let rec go resolved = function
+    | [] -> R.ok (List.rev resolved)
+    | `Name library :: r ->
+      Log.debug (fun m -> m "Search -l%s into library directories" library) ;
+      let path = Fpath.(v ("lib" ^ library) + "a") in
+      search directories path >>= fun x -> go (x :: resolved) r
+    | `Filename path :: r ->
+      if Fpath.is_rel path
+      then ( Log.debug (fun m -> m "Search -l:%a into library directories" Fpath.pp path)
+           ; search directories path >>= fun x -> go (x :: resolved) r )
+      else
+        ( Log.debug (fun m -> m "Search -l%a into library directories" Fpath.pp path)
+        ; Bos.OS.File.exists path >>= function
+          | true -> go (path :: resolved) r
+          | false -> R.error_msgf "Library <%a> does not exist" Fpath.pp path ) in
+  go [] libraries >>= fun _ ->
+  Ok (directories, libraries)
+
+let is_opt s = String.length s > 1 && s.[0] = '-'
+
+let parse_opt_arg s =
+  let l = String.length s in
+  if s.[1] <> '-'
+  then
+    if l = 2 then s, None
+    else String.sub s 0 2, Some (String.sub s 2 (l - 2))
+  else
+    try
+      let i = String.index s '=' in
+      String.sub s 0 i, Some (String.sub s (i + 1) (l - i - 1))
+    with Not_found -> s, None
+
+let parse_lL_args args =
+  let rec go lL_args other_args = function
+    | [] -> R.ok (List.rev lL_args, List.rev other_args)
+    | "--" :: args -> R.ok (List.rev lL_args, List.rev_append other_args args)
+    | x :: args ->
+      if not (is_opt x)
+      then go lL_args (x :: other_args) args
+      else
+        let name, value = parse_opt_arg x in
+        match name with
+        | "-L" | "--library-directory" | "--library-path" | "-l" | "--library" ->
+          ( match value with
+            | Some value -> go ((name, value) :: lL_args) other_args args
+            | None -> match args with
+              | [] -> R.error_msgf "%s must have a value." name
+              | value :: args ->
+                if is_opt value
+                then R.error_msgf "%s must have a value." name
+                else go ((name, value) :: lL_args) other_args args )
+        | _ -> go lL_args (x :: other_args) args in
+  go [] [] args
+
+let to_cmdliner ~binary lL_args =
+  let res = Array.make (1 + List.length lL_args) "" in
+  res.(0) <- binary ;
+  List.iteri (fun i (k, v) -> res.(i + 1) <- Fmt.strf "%s%s" k v) lL_args ;
+  res
+
+let resolve directories libraries =
+  resolve directories libraries |> function
+  | Ok v -> `Ok (Ok v)
+  | Error (`Msg err) -> `Ok (Error (`Msg err))
+
+open Cmdliner
+
+let existing_directory =
+  let parser x = match Fpath.of_string x with
+    | Ok v when Fpath.is_dir_path v && Sys.is_directory x -> Ok v
+    | Ok v when Sys.is_directory x -> Ok (Fpath.to_dir_path v)
+    | Ok v -> R.error_msgf "Directory <%a> does not exist" Fpath.pp v
+    | Error err -> Error err in
+  let pp = Fpath.pp in
+  Arg.conv ~docv:"<directory>" (parser, pp)
+
+let library =
+  let parser x = match Astring.String.cut ~sep:":" x with
+    | Some ("", path) ->
+      ( match Fpath.of_string path with
+        | Ok v when Fpath.is_abs v && Sys.file_exists path -> Ok (`Filename v)
+        | Ok v when Fpath.is_rel v -> Ok (`Filename v)
+        | Ok v -> R.error_msgf "Library <%a> does not exist" Fpath.pp v
+        | Error err -> Error err )
+    | Some (_, _) -> R.error_msgf "Invalid <namespec> %S" x
+    | None ->
+      ( match Fpath.of_string x with
+        | Ok v when Fpath.is_file_path v && Fpath.filename v = x -> Ok (`Name x)
+        | Ok v -> R.error_msgf "Invalid library name <%a>" Fpath.pp v
+        | Error err -> Error err ) in
+  let pp ppf = function
+    | `Filename path -> Fmt.pf ppf ":%a" Fpath.pp path
+    | `Name x -> Fmt.string ppf x in
+  Arg.conv ~docv:"<library>" (parser, pp)
+
+let path_of_libraries =
+  let doc = "Add directory $(i,dir) to the list of directories to be searched for $(b,-l)." in
+  let docv = "dir" in
+  Arg.(value & opt_all existing_directory [] & info [ "L"; "library-directory"; "library-path" ] ~doc ~docv)
+
+let libraries =
+  let doc = "Add the archive of object file specified by $(i,namespec) to the list of files to link. \
+             This option may be used any number of times. \
+             If $(i,namespec) is of the form $(i,:filename), $(b,ld) will search the library path for a file called $(i,filename), \
+             otherwise it will search the library path of a file called $(i,libnamespec.a)." in
+  let docv = "namespec" in
+  Arg.(value & opt_all library [] & info [ "l"; "library" ] ~doc ~docv)
+
+let cmd =
+  let doc = "cctoopt" in
+  let exits = Term.default_exits in
+  let man = 
+    [ `S Manpage.s_description
+    ; `P "Transform a $(i,ld)/$(i,cc) command-line to an $(i,ocamlopt) command-line." ] in
+  Term.(ret (const resolve $ path_of_libraries $ libraries)),
+  Term.info "cctoopt" ~doc ~exits ~man
+
+let null_buffer = Buffer.create 0x100
+let null = Format.formatter_of_buffer null_buffer
+
+let process_argv argv =
+  parse_lL_args (List.tl (Array.to_list argv)) >>= fun (lL_args, other_args) ->
+  let argv = to_cmdliner ~binary:argv.(0) lL_args in
+  ( let res = Cmdliner.Term.eval ~help:null ~err:null ~catch:false ~argv cmd in
+    Buffer.clear null_buffer ; match res with
+    | `Error (`Exn | `Term | `Parse) ->
+      R.error_msgf "Error to process command-line: %a." Fmt.(Dump.array string) argv
+    | `Ok (Ok v) -> Ok (`Do (v, other_args))
+    | `Ok (Error (`Msg err)) -> R.error_msg err
+    | `Version | `Help -> assert false (* XXX(dinosaure): TODO! *) )
+
+let with_I path =
+  [ "-I"; Fpath.to_string path ]
+
+let with_cclib_l = function
+  | `Filename path -> [ "-cclib"; "-l:" ^ Fpath.to_string path ]
+  | `Name name -> [ "-cclib"; "-l" ^ name ]
+
+let run_with_binary argv =
+  if Array.length argv = 0 then Fmt.invalid_arg "run_with_binary: must have, at least, one argument" ;
+  Log.debug (fun m -> m "Start to ocamlify: %a" Fmt.(Dump.array string) argv) ;
+  process_argv argv |> function
+  | Ok (`Do ((directories, libraries), other_args)) ->
+    let a = List.(concat (map with_I directories)) in
+    let b = List.(concat (map with_cclib_l libraries)) in
+    let c = other_args in
+    Ok (a @ b @ c)
+  | Error err -> Error err
+
+let run ?(binary= "a.out") argv =
+  run_with_binary (Array.concat [ [| binary |]; argv ])

--- a/lib/mirage_cc_to_opt.mli
+++ b/lib/mirage_cc_to_opt.mli
@@ -1,0 +1,24 @@
+(** [cc to opt] modules is an {i ocamlifier} of a {i cc}/{i ld} command-line.
+
+    The goal of this module is to do a predictible translation from a {i cc}/{i ld}
+    command-line to an {i ocamlopt} command-line. It converts:
+    {ul
+    {- [-l] option to [-cclib -l] option}
+    {- [-L] option to [-I] option}}
+
+    Due to the pervasive and versatile context of the linker, it could be hard to
+    follow which static libraries will be linked with our {i unikernel}. This module,
+    while it formats options, resolves absolute path of static libraries - and checks
+    if they exist. Then, it re-order options to ensure absolute path of libraries
+    (when -L takes the precedences over -l).
+
+    Into details, this module eats [pkg-config] outputs to give a well-formed
+    command-line to {i ocamlopt} and link the {i unikernel} with right static
+    libraries according the target.
+
+    Format of [-l] follows description given by {i ld} (which differs, a bit,
+    from {i gcc}). Any [-I] option given to {i ocamlopt} is automaticaly translated
+    to [-L] by {i ocamlopt} itself. *)
+
+val run_with_binary : string array -> (string list, [> `Msg of string ]) result
+val run : ?binary:string -> string array -> (string list, [> `Msg of string ]) result

--- a/lib/mirage_clean.ml
+++ b/lib/mirage_clean.ml
@@ -13,6 +13,9 @@ let clean i =
   Mirage_configure_xen.clean_main_xe ~name >>= fun () ->
   Mirage_configure_virtio.clean_main_libvirt_xml ~name >>= fun () ->
   Mirage_configure.clean_myocamlbuild () >>= fun () ->
+  Mirage_configure.clean_dune () >>= fun () ->
+  Mirage_configure.clean_dune_workspace () >>= fun () ->
+  Mirage_configure.clean_dune_project () >>= fun () ->
   Mirage_configure_solo5.clean_manifest () >>= fun () ->
   Bos.OS.File.delete Fpath.(v "Makefile") >>= fun () ->
   rr_iter (Mirage_configure.clean_opam ~name)

--- a/lib/mirage_configure.ml
+++ b/lib/mirage_configure.ml
@@ -212,10 +212,11 @@ let configure i =
   let target_debug = Key.(get ctx target_debug) in
   if target_debug && target <> `Hvt then
     Log.warn (fun m -> m "-g not supported for target: %a" Key.pp_target target);
-  configure_myocamlbuild () >>= fun () ->
+  configure_dune i >>= fun () ->
   rr_iter (clean_opam ~name)
     [`Unix; `MacOSX; `Xen; `Qubes; `Hvt; `Spt; `Virtio; `Muen; `Genode]
   >>= fun () ->
+  configure_dune_workspace i >>= fun () ->
   configure_opam ~name:opam_name i >>= fun () ->
   let no_depext = Key.(get ctx no_depext) in
   configure_makefile ~no_depext ~opam_name >>= fun () ->

--- a/lib/mirage_configure.ml
+++ b/lib/mirage_configure.ml
@@ -148,24 +148,29 @@ let configure_dune i =
   let s_lflags = String.concat ~sep:" " lflags in
   let s_cflags = String.concat ~sep:" " cflags in
   let s_variants = variant_of_target target in
+  let s_forbidden = match target with
+    | #Mirage_key.mode_xen | #Mirage_key.mode_solo5 -> "(forbidden_libraries unix)"
+    | #Mirage_key.mode_unix -> "" in
   let s_exclude_modules = String.concat ~sep:" " (exclude_modules_of_target target) in
   let res =
     Fmt.strf
-      {sexp|
-        (executable
-          (name main)
-          (modes %s)
-          (libraries %s)
-          (link_flags %s)
-          (modules (:standard \ %s))
-          (flags %s)
-          (variants %s))
-        |sexp}
+{sexp|
+  (executable
+    (name main)
+    (modes %s)
+    (libraries %s)
+    (link_flags %s)
+    (modules (:standard \ %s))
+    (flags %s)
+    %s
+    (variants %s))
+  |sexp}
         s_output_mode
         s_libraries
         s_lflags
         s_exclude_modules
         s_cflags
+        s_forbidden
         s_variants in
   configure_post_build_rules i ~name ~binary_location ~target >>= fun rules ->
   let res = res ^ "\n" in

--- a/lib/mirage_configure.mli
+++ b/lib/mirage_configure.mli
@@ -14,3 +14,7 @@ val clean_opam : name:string -> Mirage_key.mode -> (unit, [> R.msg ]) result
 val configure_makefile : no_depext:bool -> opam_name:string -> (unit, [> R.msg ]) result
 
 val configure : Functoria.Info.t -> (unit, [> R.msg ]) result
+
+val clean_dune : unit -> (unit, [> R.msg ]) result
+val clean_dune_project : unit -> (unit, [> R.msg ]) result
+val clean_dune_workspace : unit -> (unit, [> R.msg ]) result

--- a/lib/mirage_configure_solo5.ml
+++ b/lib/mirage_configure_solo5.ml
@@ -2,8 +2,10 @@ open Rresult
 open Astring
 open Mirage_impl_misc
 
+module Info = Functoria.Info
 module Codegen = Functoria_app.Codegen
 module Log = Mirage_impl_misc.Log
+module Key = Mirage_key
 
 let solo5_manifest_path = Fpath.v "manifest.json"
 

--- a/lib/mirage_configure_solo5.ml
+++ b/lib/mirage_configure_solo5.ml
@@ -5,7 +5,7 @@ open Mirage_impl_misc
 module Codegen = Functoria_app.Codegen
 module Log = Mirage_impl_misc.Log
 
-let solo5_manifest_path = Fpath.v "_build/manifest.json"
+let solo5_manifest_path = Fpath.v "manifest.json"
 
 let clean_manifest () =
   Bos.OS.File.delete solo5_manifest_path
@@ -65,3 +65,121 @@ let compile_manifest target =
   in
   Log.info (fun m -> m "executing %a" Bos.Cmd.pp cmd);
   Bos.OS.Cmd.run cmd
+
+(* Process to get & save into files flags. *)
+
+open Sexplib
+
+let cflags_sexp_path = Fpath.((v ".mirage" + "solo5") / "cflags.sexp")
+let lflags_path = Fpath.((v ".mirage" + "solo5") / "lflags")
+let libs_sexp_path = Fpath.((v ".mirage" + "solo5") / "libs.sexp")
+let libdir_path = Fpath.((v ".mirage" + "solo5") / "libdir")
+
+let cflags ~target =
+  let pkg, _ = solo5_pkg target in
+  pkg_config pkg [ "--cflags" ] >>= fun cflags ->
+  let sexp =
+    sexp_of_fmt
+      {sexp|(%a)|sexp}
+      Fmt.(list ~sep:(always " ") string) cflags in
+  Bos.OS.File.write_lines
+    cflags_sexp_path
+    (List.map (fun x -> Sexp.to_string_hum x ^ "\n") [ sexp ])
+
+let lflags ~target =
+  let pkg, _ = solo5_pkg target in
+  pkg_config pkg [ "--variable=ldflags" ] >>= fun lflags ->
+  Bos.OS.File.write_lines
+    lflags_path lflags
+
+let libs ~target =
+  let pkg, _ = solo5_pkg target in
+  pkg_config pkg [ "--libs" ] >>= fun libs ->
+  let sexp =
+    sexp_of_fmt
+      {sexp|(%a)|sexp}
+      Fmt.(list ~sep:(always " ") string) libs in
+  Bos.OS.File.write_lines
+    libs_sexp_path
+    (List.map (fun x -> Sexp.to_string_hum x ^ "\n") [ sexp ])
+
+let libdir ~target =
+  let pkg, _ = solo5_pkg target in
+  pkg_config pkg [ "--variable=libdir" ] >>= fun libdir ->
+  Bos.OS.File.write_lines
+    libdir_path libdir
+
+(* Generate configure part of Solo5 target. *)
+
+let hijack_dune () =
+  let lines =
+    [ "(include dune.config)"
+    ; "(dirs .mirage.solo5)"
+    ; "(include dune.build)" ] in
+  Bos.OS.File.write_lines (Fpath.v "dune") lines
+
+let configure_solo5 ~name ~binary_location ~target =
+  hijack_dune () >>= fun () ->
+  Bos.OS.Dir.create ~path:true Fpath.(v ".mirage" + "solo5") >>= fun _ ->
+  cflags ~target >>= fun () ->
+  lflags ~target >>= fun () ->
+  libs ~target >>= fun () ->
+  libdir ~target >>= fun () ->
+  generate_manifest_json () >>= fun () ->
+
+  let _, post = solo5_pkg target in
+  let out = name ^ post in
+  let alias =
+    sexp_of_fmt
+      {sexp|
+      (alias
+        (name %a)
+         (enabled_if (= %%{context_name} "mirage-freestanding"))
+         (deps %s))
+      |sexp} Key.pp_target target out in
+  let rule_unikernel =
+    sexp_of_fmt
+      {sexp|
+      (rule
+        (targets %s)
+        (mode promote)
+        (deps %s manifest.o)
+        (action (run ld %%{read-lines:lflags} manifest.o %s -o %s)))
+      |sexp} out binary_location binary_location out in
+  let rule_libs =
+    sexp_of_fmt
+      {sexp|(rule (copy %a libs.sexp))|sexp}
+      Fpath.pp libs_sexp_path in
+  let rule_lflags =
+    sexp_of_fmt
+      {sexp|(rule (copy %a lflags))|sexp}
+      Fpath.pp lflags_path in
+  let rule_cflags =
+    sexp_of_fmt
+      {sexp|(rule (copy %a cflags.sexp))|sexp}
+      Fpath.pp cflags_sexp_path in
+  let rule_libdir =
+    sexp_of_fmt
+      {sexp|(rule (copy %a libdir))|sexp}
+      Fpath.pp libdir_path in
+  let rule_manifest_c =
+    sexp_of_fmt
+      {sexp|
+      (rule
+        (targets manifest.c)
+        (deps manifest.json)
+        (action (run solo5-elftool gen-manifest manifest.json manifest.c)))
+      |sexp} in
+  let rule_manifest_o =
+    sexp_of_fmt
+      {sexp|
+      (library
+        (name manifest)
+        (modules manifest)
+        (foreign_stubs (language c) (names manifest)
+          (flags (:include cflags.sexp))))
+      |sexp} in
+  Bos.OS.File.write (Fpath.v "manifest.ml") "" >>= fun () ->
+  Ok ( rule_lflags :: rule_cflags :: rule_libs :: rule_libdir
+       :: rule_manifest_c :: rule_manifest_o
+       :: alias :: rule_unikernel :: [] )

--- a/lib/mirage_configure_solo5.mli
+++ b/lib/mirage_configure_solo5.mli
@@ -8,3 +8,5 @@ val solo5_pkg : [> Mirage_key.mode_solo5 ] -> string * string
 val generate_manifest_json : unit -> (unit, [> R.msg ]) result
 val generate_manifest_c : unit -> (unit, [> R.msg ]) result
 val compile_manifest : [> Mirage_key.mode_solo5 ] -> (unit, [> R.msg ]) result
+
+val configure_solo5 : name:string -> binary_location:string -> target:Mirage_key.mode -> (Sexplib.Sexp.t list, [> R.msg ]) result

--- a/lib/mirage_configure_unix.ml
+++ b/lib/mirage_configure_unix.ml
@@ -1,0 +1,24 @@
+open Mirage_impl_misc
+
+module Key = Mirage_key
+
+let configure_unix ~name ~binary_location ~target =
+  let target_name = Fmt.strf "%a" Key.pp_target target in
+  let alias =
+    sexp_of_fmt
+      {sexp|
+      (alias
+        (name %s)
+        (enabled_if (= %%{context_name} "default"))
+        (deps %s))
+      |sexp} target_name name in
+  let rule =
+    sexp_of_fmt
+      {sexp|
+      (rule
+        (target %s)
+        (deps %s)
+        (mode promote)
+        (action (run ln -nfs %s %s)))
+      |sexp} name binary_location binary_location name in
+  Ok [ alias; rule; ]

--- a/lib/mirage_configure_xen.ml
+++ b/lib/mirage_configure_xen.ml
@@ -186,3 +186,64 @@ let configure_main_xe ~root ~name =
     "xe file"
 
 let clean_main_xe ~name = Bos.OS.File.delete Fpath.(v name + "xe")
+
+let configure_xen_arm ~out ~linker_command ~binary_location =
+  let elf = out ^ ".elf" in
+  let libgcc_cmd = Bos.Cmd.(v "gcc" % "-print-libgcc-file-name") in
+  Bos.OS.Cmd.(run_out libgcc_cmd |> out_string) >>= fun (libgcc, _) ->
+  let rule_link =
+    sexp_of_fmt
+      {sexp|
+      (rule
+        (targets %s)
+        (deps %s)
+        (action (run %s %s -o %s)))
+      |sexp} elf binary_location linker_command libgcc elf in
+  let rule_obj_copy =
+    sexp_of_fmt
+      {sexp|
+      (rule
+        (mode promote)
+        (targets %s)
+        (deps %s)
+        (action (run objcopy -O binary %s %s)))
+      |sexp} out elf elf out in
+  Ok [ rule_link; rule_obj_copy; ]
+
+let configure_xen_default ~out ~linker_command ~binary_location =
+  let rule =
+    sexp_of_fmt
+      {sexp|
+      (rule
+        (mode promote)
+        (targets %s)
+        (deps %s)
+        (action (run %s -o %s)))
+      |sexp} out binary_location linker_command out in
+  Ok [ rule ]
+
+let configure_xen ~name ~binary_location ~target =
+  let target_name = Fmt.strf "%a" Key.pp_target target in
+  let out = name ^ ".xen" in
+  let alias =
+    sexp_of_fmt
+      {sexp|
+      (alias
+        (name %s)
+        (enabled_if (= %%{context_name} "mirage-xen"))
+        (deps %s))
+      |sexp} target_name out in
+  let linker_command = "ld -d -static -nostdlib " ^ binary_location in
+  let uname_cmd = Bos.Cmd.(v "uname" %  "-m") in
+  Bos.OS.Cmd.(run_out uname_cmd |> out_string) >>= fun (machine, _) ->
+  ( match String.is_prefix ~affix:"arm" machine with
+  | true -> configure_xen_arm ~out ~linker_command ~binary_location
+  | false -> configure_xen_default ~out ~linker_command ~binary_location )
+  >>= fun rules ->
+  let rule_libs =
+    sexp_of_fmt
+      {sexp|(rule (copy %%{lib:mirage-xen-ocaml:libs.sexp} libs.sexp))|sexp} in
+  let rule_cflags =
+    sexp_of_fmt
+      {sexp|(rule (copy %%{lib:mirage-xen-ocaml:cflags.sexp} cflags.sexp))|sexp} in
+  Ok ( rule_cflags :: rule_libs :: alias :: rules )

--- a/lib/mirage_configure_xen.ml
+++ b/lib/mirage_configure_xen.ml
@@ -2,6 +2,7 @@ open Rresult
 open Astring
 open Mirage_impl_misc
 
+module Key = Mirage_key
 module Info = Functoria.Info
 module Codegen = Functoria_app.Codegen
 module Log = Mirage_impl_misc.Log

--- a/lib/mirage_configure_xen.mli
+++ b/lib/mirage_configure_xen.mli
@@ -19,3 +19,4 @@ val clean_main_xl : name:string -> ext:string -> (unit, [> R.msg ]) result
 
 val configure_main_xe : root:string -> name:string -> (unit, [> R.msg ]) result
 val clean_main_xe : name:string -> (unit, [> R.msg ]) result
+val configure_xen : name:string -> binary_location:string -> target:Mirage_key.mode -> (Sexplib.Sexp.t list, [> R.msg ]) result

--- a/lib/mirage_impl_misc.ml
+++ b/lib/mirage_impl_misc.ml
@@ -94,6 +94,9 @@ let extra_c_artifacts target pkgs =
   in
   R.ok r
 
+let static_libs pkg_config_deps =
+  pkg_config pkg_config_deps [ "--static"; "--libs" ]
+
 let terminal () =
   let dumb = try Sys.getenv "TERM" = "dumb" with Not_found -> true in
   let isatty = try Unix.(isatty (descr_of_out_channel Stdlib.stdout)) with

--- a/lib/mirage_impl_misc.ml
+++ b/lib/mirage_impl_misc.ml
@@ -105,3 +105,5 @@ let rec rr_iter f l =
   match l with
   | [] -> R.ok ()
   | x :: l -> f x >>= fun () -> rr_iter f l
+
+let sexp_of_fmt fmt = Fmt.kstrf Sexplib.Sexp.of_string fmt

--- a/lib/mirage_impl_misc.mli
+++ b/lib/mirage_impl_misc.mli
@@ -30,3 +30,5 @@ val extra_c_artifacts : string -> string list -> (string list, [> R.msg ]) resul
 val terminal : unit -> bool
 
 val rr_iter : ('a -> (unit, 'e) result) -> 'a list -> (unit, 'e) result
+
+val sexp_of_fmt : ('a, Format.formatter, unit, Sexplib.Sexp.t) format4 -> 'a

--- a/lib/mirage_impl_misc.mli
+++ b/lib/mirage_impl_misc.mli
@@ -26,6 +26,7 @@ val query_ocamlfind :
 val opam_prefix : (string, [> R.msg ]) result Lazy.t
 val pkg_config : string -> string list -> (string list, [> R.msg ]) result
 val extra_c_artifacts : string -> string list -> (string list, [> R.msg ]) result
+val static_libs : string -> (string list, [> R.msg ]) result
 
 val terminal : unit -> bool
 

--- a/lib/mirage_link.ml
+++ b/lib/mirage_link.ml
@@ -5,6 +5,8 @@ open Mirage_impl_misc
 module Key = Mirage_key
 module Info = Functoria.Info
 
+[@@@warning "-32"]
+
 let static_libs pkg_config_deps =
   pkg_config pkg_config_deps [ "--static" ; "--libs" ]
 
@@ -84,4 +86,4 @@ let link info name target _target_debug =
     Bos.OS.Cmd.run linker >>= fun () ->
     Ok out
 
-
+let link _info _name _target _target_debug = Ok ()

--- a/lib/mirage_link.mli
+++ b/lib/mirage_link.mli
@@ -6,4 +6,4 @@ val ldpostflags : string -> (string list, [> R.msg ]) result
 
 val find_ld : string -> string
 
-val link : Functoria.Info.t -> string -> Mirage_key.mode -> bool -> (string, [> R.msg ]) result
+val link : Functoria.Info.t -> string -> Mirage_key.mode -> bool -> (unit, [> R.msg ]) result

--- a/mirage.opam
+++ b/mirage.opam
@@ -25,6 +25,7 @@ depends: [
   "astring"
   "logs"
   "stdlib-shims"
+  "sexplib"
   "mirage-runtime"     {>= "3.7.0" & < "3.8.0"}
 ]
 synopsis: "The MirageOS library operating system"


### PR DESCRIPTION
/cc @mirage/core and @TheLortex 

Hi all, this is the first **draft** of a _not-completely_ tested _dunification_ of MirageOS. First, this PR does not work but I think, I reached a step where we need to start to talk technically about the _dunification_ of MirageOS and when we should track minor updates.

### The Pull-Request

The PR is the smallest of what I can do (and #1017 helps me a lot). Each commit has a description about the goal and update only one file per one file the project to avoid a misleading of patches.

This PR **does not** have deletion - not yet. Some warnings (eg. 32) was added. The goal is to propose a smooth view about the _dunification_ of MirageOS.

This PR is **only** about the _dunification_. Behind this word, we can imagine a lot (`duniverse`, `variants` and so on) but the only goal is to use `dune` to compile an _unikernel_.

This PR is not yet fully tested. Currently, only [pasteur](https://github.com/dinosaure/pasteur) was tested - `pasteur` includes a large stack when it use `irmin.2.0.0`, `git` and `digestif` and `conduit` with `httpaf` (including `tls` and `nocrypto` even if we don't support HTTPS, shame on me). Only UNIX and Solo5 target are tested - I don't have a deployment process for Xen. Despite all this, `pasteur` still is a good PoC to test/improve _dunification_ of MirageOS.

This PR trusts on `dune.2.0.0`. Several features are used but not so really required. Small patches on some libraries needed by `pasteur` are needed because:
- they don't compile on `dune.2.0.0`
- they have the UNIX module

This PR should not expect anything else from `dune.2.0.0`

### Issues on the eco-system

MirageOS has a large eco-system where we can find some unusual packaging politics. When we are the ownership on these packages, it's fine to update them according the _dunification_ of MirageOS. However, it's not totally the case where some MirageOS _unikernels_ depend on some libraries outside the scope of the MirageOS organization.

According all of that, and even if we have this PR, we still have some issues on our eco-system. The goal of this PR and the _dunification_ in general is not to fix all of these issues. At least, we highlighted them. But, please, keep in your mind that the only goal of this PR is to tap `dune build` in his keyboard.

One of the biggest issue on the eco-system was fixed with #1010. I don't want to re-explain all the story about `mirage-os-shim`, however, as I said, this issue highlighted a weak about a documentation of: how to be MirageOS compatible? And we just discovered that we have many ways.

But an other issue still exists on this PR and was explained/discussed into #1018 about `pkg-config`. `dune` can provides some others ways to do some tricks at the link time (eg. variants) but __it's not the purpose of this PR__. However, we should start then to talk about all of that.

The last issue is about GMP and we will go a bit into details.

#### Zarith and GMP

The `zarith.cmxa` has an information used by `ocamlopt` then: `-lgmp`. If you want to compile an executable or an object with `zarith` and without `-noautolink`, `ocamlopt` will emit to `gcc` (at the link time) `-lgmp` (and then, `gcc` will take `libgmp.a` available into your `LD_LIBRARY_PATH`).

Of course, considering targets like Solo5 or Xen, `libgmp.a` available on your system does not fit into constraints expected by Xen or Solo5. GMP must be compiled with specific C flags.

This is the purpose of the package `gmp-freestanding` and `gmp-xen`. My only concern about this way is to rename `libgmp_freestanding.a` and `libgmp_xen.a` to `libgmp.a` and let the compiler to choose these implementations according the target. Considering flags, Solo5 and Xen can provide in some ways `-L$(opam config var lib)/gmp-{freestanding,xen}` as a dependency.

**NOTE**: that means for any compilation of any _unikernels_, `-L` shoud always be emitted by `mirage-os-xen` or `ocaml-freestanding` even if the _unikernel_ does not depend on `gmp`. However, `-lgmp` will be emitted only if we want to link with `zarith.cmxa`.

#### Versatility of the linking

The linking step is done by `gcc` currently in our OCaml world, the linking step is super versatile where static libraries are chosen depending of which path is available on the command-line (and the environment). The predictability of which library will be statically linked to our _unikernel_ is hard to follow/track.

A new tool was added into `mirage`: `cc-to-opt` or `cc-to-ocamlopt` which will takes C flags and do a translation of `-L` to `-I` and `-l` to `-cclib -l`. It wants to resolve static libraries and say that they exists according all given path by `-L`. Then, it re-order _options_ due to the precedence of `-L` over `-l` (`-LA -la -LB` and `-LA -LB -la` don't have the same behavior if `liba.a` is available into `A` and `B` - this behavior is pretty-close to the GMP case where `libgmp.a` is available into several directories).

At the end, the choice was made to let `ocamlopt` to __link__ the object file (for Xen/Solo5/Unix). Then, and `ld` command will be done according the target:
- `unix`: nothing to do, at least, an `ln -sfn`
- `solo5`: `ld` with Solo5 link script
- `xen`: `ld` with some options

#### Correctness of C stubs linked

The previous point want to serve an other issue about the expected flags used to compile C sources (like GMP or `digestif`). An _unikernel_ for Solo5 which links with `digestif.c` (compiled to be used by an UNIX executable) __can work__. That means that silently, we can link with the wrong `libdigestif.a` and the _unikernel_ still works.

The only way to verify that we link with the right C stubs is to check (from what I know) assembly code between your _unikernel_ and expected static library.

At this stage, no solution exists so. But, again, this PR highlighted this issue.

#### UNIX module and `-dontlink`

On the currant status of MirageOS, `ocamlbuild` is used with `-dontlink` to avoid any link with `unix.cmxa`. However, we lost this option if we want to use `dune`.

About that, the deletion of this option/feature highlighted several packages which are linked with `unix.cmxa` mostly because they want to be linked with `bigarray.cmxa` which contains `map_file` (an UNIX _syscall_). Again, some packages have this dependency again (like `sexplib`).

This is the purpose of [`bigarray-compat`](https://github.com/mirage/bigarray-compat.git) and we should use it at any of our projects, at least.

### Issue on `dune`

`dune` unlocks several features to improve the way to compile an _unikernel_. Some of them are not used now but they exist. The notably feature is, may be, the variant where `dune` can orchestrate the choice of which OCaml library we should use according the target (`freestanding` or `xen`).

At this stage, it's possible to use it when the generated `dune` file describe which variant it will use (with the `variant` field).

A proposition on Zarith was made by @TheLortex in this way. We can talk about that on an other issue/PR but the idea is to have a Zarith library which provides `freestanding` and `xen` which the right link with GMP.

Another feature is about the `forbidden_libraries` which is not yet used - but it can be. The purpose of it is to follow who want to link with a specific library and, in our case, `unix.cmxa`. This `dune`'s field can help us a lot to track the compatibility with MirageOS of our libraries.

The compilation of an _unikernel_ with `dune` unlocks an other way to develop an our MirageOS where we can start to use `duniverse` and have a self-contained workspace of all of what we need. In this way, `mirage` still continues to emit an OPAM file used by `duniverse` then to download all libraries needed by our _unikernel_.

And from that, `dune` can provide a well-defined workspace with right C flags according the target to let the user to use C stubs without the _hard_ plumbing needed when we want to package that to OPAM.

#### (dirs ...)

The only problem today about `dune` is: we can not use `(dirs ...)` to load some specific underlying directories into the `dune.build` file. I don't know why. The current trick is that `mirage configure` rewrite not-only `dune.build` but `dune` too to load correctly files needed to compile _unikernel_.

#### flags needed by the target

Currently, a proper way to get flags needed by the target (C flags for C stubs and linking flags for `ld`) is not well-defined. The current way chosen by Solo5 is to use `pkg-config`. The other way chosen by Xen is to provide into the distribution of `mirage-os-xen` some files needed by `dune` then.

An explanation is available here: mirage/ocaml-freestanding#66

This question is pretty-close to what we want to do with `pkg-config` (if we want to use it or remove it). Currently, we don't have an homogeneous way to get these information and we should start to discuss/document that.

### Conclusion

Let start to talk about the _dunification_ of MirageOS. Please, I really would like to stay focus on the real _dunification_ of MirageOS. I know that this PR can unlock several possibilities but keep in your mind that as long as this PR will not be merged, all other discussions/issues will be vain - because the predicate is to use `dune` first.

Next week, I will try to provide a CI with this PR to show that this PR works! But we can start to talk about details of the way to _dunify_ a MirageOS.

PS: thanks for reading all!