### PR TITLE
configure, output opam: use git rev-parse instead of git branch --show-current (the latter requiring git 2.22+)

### DIFF
--- a/lib/mirage_configure.ml
+++ b/lib/mirage_configure.ml
@@ -62,7 +62,7 @@ let find_git () =
   in
   Bos.OS.Dir.current () >>= fun cwd ->
   find cwd None >>= fun subdir ->
-  let git_branch = Bos.Cmd.(v "git" % "branch" % "--show-current") in
+  let git_branch = Bos.Cmd.(v "git" % "rev-parse" % "--abbrev-ref" % "HEAD") in
   Bos.OS.Cmd.(run_out git_branch |> out_string) >>= fun (branch, _) ->
   let git_remote = Bos.Cmd.(v "git" % "remote" % "get-url" % "origin") in
   Bos.OS.Cmd.(run_out git_remote |> out_string) >>| fun (git_url, _) ->


### PR DESCRIPTION
unfortunately I do not know since which git version the `rev-parse` is supported (pretty tricky to figure out). if this PR is fine, I plan to cherry-pick this commit on a 3.7.3 branch and cut a release 3.7.4 to "unbreak" mirage for people with old git installations.

the code in question is guarded - `find_git` is called in `configure_opam`, and if it errors this is handled gracefully, thus installations of 3.7.3 with an old git do _not_ lead to mirage that is not able to configure, just to mirage whose generated opam files are suboptimal and an error is presented on console (but return code of mirage is 0).

discussion how to get the current branch from git is at https://stackoverflow.com/questions/6245570/how-to-get-the-current-branch-name-in-git