### PR TITLE
Functoria: rename Functoria.configurable into Functoria.Device

### DIFF
--- a/functoria/app/functoria_app.ml
+++ b/functoria/app/functoria_app.ml
@@ -522,7 +522,8 @@ module Make (P: S) = struct
     Codegen.append_main "let _ = Printexc.record_backtrace true";
     Codegen.newline_main ();
     Cache.save ~argv (Info.build_dir i) >>= fun () ->
-    Engine.configure_and_connect ~init i jobs >>| fun () ->
+    Engine.configure i jobs >>| fun () ->
+    Engine.connect i ~init jobs;
     Codegen.newline_main ()
 
   let clean_main i jobs =

--- a/functoria/app/functoria_app.mli
+++ b/functoria/app/functoria_app.mli
@@ -75,7 +75,7 @@ module Make (P: S): sig
 
   val register:
     ?packages:package list ->
-    ?keys:key list ->
+    ?keys:abstract_key list ->
     ?init:job impl list ->
     string -> job impl list -> unit
   (** [register name jobs] registers the application named by [name]
@@ -103,10 +103,6 @@ module Name: sig
       characters outside of ['a'-'z''A'-'Z''0''9''_''-'], and
       replacing '-' with '_'.  If the resulting string starts with a
       digit or is empty then it raises [Invalid_argument]. *)
-
-  val create: string -> prefix:string -> string
-  (** [name key ~prefix] is an deterministic name starting by
-      [prefix]. The name is derived from [key].  *)
 
 end
 

--- a/functoria/lib/functoria_engine.mli
+++ b/functoria/lib/functoria_engine.mli
@@ -17,6 +17,8 @@
 
 (** Functoria engine. *)
 
+open Rresult
+
 module Key = Functoria_key
 module Package = Functoria_package
 
@@ -35,33 +37,22 @@ val packages: t -> Package.t list Key.value
 
 (** {2 Triggering Hooks} *)
 
-type modules
-(** The type for the generated module tables. *)
-
-val configure: Functoria.Info.t -> t -> (modules, Rresult.R.msg) result
+val configure: Functoria.Info.t -> t -> (unit, R.msg) result
 (** [configure i t] calls all the configuration hooks for each of the
     implementations appearing in [t], in topological order. Use the
-    build information [i]. Return a module table associating
-    implementations in [t] to concrete module names. *)
+    build information [i]. *)
 
-val connect:
-  ?init:'a Functoria.impl list -> modules:modules ->
-  Functoria.Info.t -> t -> unit
-(** [connect ?init ~modules i t] generates the [connect] functions in
+val connect: ?init:'a Functoria.impl list ->  Functoria.Info.t -> t -> unit
+(** [connect ?init i t] generates the [connect] functions in
     [main.ml], for each of the implementations appearing [t], in
     topological order. Use build information [i]. *)
 
-val configure_and_connect:
-  ?init:'a Functoria.impl list ->
-  Functoria.Info.t -> t -> (unit, Rresult.R.msg) result
-(** [configure_and_connect] is [configure |> connect]. *)
-
-val build: Functoria.Info.t -> t -> (unit, Rresult.R.msg) result
+val build: Functoria.Info.t -> t -> (unit, R.msg) result
 (** [build i t] calls the build hooks for each of the implementations
     appearing in [t], in topological order. Use the build information
     [i]. *)
 
-val clean: Functoria.Info.t -> t -> (unit, Rresult.R.msg) result
+val clean: Functoria.Info.t -> t -> (unit, R.msg) result
 (** [clean i t] calls the clean hooks for each of the implementations
     appearing in [t], in topological order. Use the build information
     [i]. *)

--- a/functoria/lib/functoria_misc.ml
+++ b/functoria/lib/functoria_misc.ml
@@ -37,34 +37,13 @@ module Name = struct
     String.iter begin function
       | 'a'..'z' | 'A'..'Z'
       | '0'..'9' | '_' as c -> Buffer.add_char b c
-      | '-' -> Buffer.add_char b '_'
+      | '-' | '.' -> Buffer.add_char b '_'
       | _ -> ()
     end s;
     let s' = Buffer.contents b in
     if String.length s' = 0 || ('0' <= s'.[0] && s'.[0] <= '9') then
       raise (Invalid_argument s);
     s'
-
-  let ids = Hashtbl.create 1024
-
-  let names = Hashtbl.create 1024
-
-  let create name =
-    let n =
-      try 1 + Hashtbl.find ids name
-      with Not_found -> 1 in
-    Hashtbl.replace ids name n;
-    Format.sprintf "%s%d" name n
-
-  let find_or_create tbl key create_value =
-    try Hashtbl.find tbl key
-    with Not_found ->
-      let value = create_value () in
-      Hashtbl.add tbl key value;
-      value
-
-  let create key ~prefix =
-    find_or_create names key (fun () -> create prefix)
 
 end
 

--- a/functoria/lib/functoria_misc.mli
+++ b/functoria/lib/functoria_misc.mli
@@ -29,10 +29,8 @@ module type Monoid = sig
   val union: t -> t -> t
 end
 
-(** Generation of fresh names *)
 module Name: sig
   val ocamlify: string -> string
-  val create: string -> prefix:string -> string
 end
 
 module Codegen: sig

--- a/functoria/lib/functoria_s.ml
+++ b/functoria/lib/functoria_s.ml
@@ -1,0 +1,52 @@
+(*
+ * Copyright (c) 2015 Gabriel Radanne <drupyog@zoho.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Rresult
+
+type 'a key = 'a Functoria_key.key
+type 'a value = 'a Functoria_key.value
+type keys = Functoria_key.t
+type info = Functoria_info.t
+type package = Functoria_package.t
+
+type _ typ =
+  | Type: 'a -> 'a typ (* module type *)
+  | Function: 'a typ * 'b typ -> ('a -> 'b) typ (* functor *)
+
+type _ impl =
+  | Dev: 'ty device -> 'ty impl (* base devices *)
+  | App: ('a, 'b) app -> 'b impl   (* functor application *)
+  | If: bool value * 'a impl * 'a impl -> 'a impl
+
+and ('a, 'b) app = {
+  f: ('a -> 'b) impl;  (* functor *)
+  x: 'a impl;          (* parameter *)
+}
+
+and abstract_impl = Abstract: _ impl -> abstract_impl
+
+and 'a device = {
+  id: int;
+  module_name: string;
+  module_type: 'a typ;
+  keys: keys list;
+  packages: package list value;
+  connect: info -> string -> string list -> string;
+  configure: info -> (unit, R.msg) result;
+  build: info -> (unit, R.msg) result;
+  clean: info -> (unit, R.msg) result;
+  extra_deps: abstract_impl list;
+}

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -377,7 +377,6 @@ val direct_stackv4:
   ?clock:mclock impl ->
   ?random:random impl ->
   ?time:time impl ->
-  ?group:string ->
   network impl -> ethernet impl -> arpv4 impl -> ipv4 impl -> stackv4 impl
 
 (** Network stack with sockets. Exposes the key {!Key.V4.interfaces}. *)
@@ -386,11 +385,11 @@ val socket_stackv4:
 
 (** Build a stackv4 by looking up configuration information via QubesDB,
  *  building an ipv4, then building a stack on top of that. *)
-val qubes_ipv4_stack: ?group:string -> ?qubesdb:qubesdb impl -> ?arp:(ethernet impl -> arpv4 impl) -> network impl -> stackv4 impl
+val qubes_ipv4_stack: ?qubesdb:qubesdb impl -> ?arp:(ethernet impl -> arpv4 impl) -> network impl -> stackv4 impl
 
 (** Build a stackv4 by obtaining a DHCP lease, using the lease to
  *  build an ipv4, then building a stack on top of that. *)
-val dhcp_ipv4_stack: ?group:string -> ?random:random impl -> ?time:time impl -> ?arp:(ethernet impl -> arpv4 impl) -> network impl -> stackv4 impl
+val dhcp_ipv4_stack: ?random:random impl -> ?time:time impl -> ?arp:(ethernet impl -> arpv4 impl) -> network impl -> stackv4 impl
 
 (** Build a stackv4 by checking the {!Key.V4.network}, and {!Key.V4.gateway} keys
  *  for ipv4 configuration information, filling in unspecified information from [?config],

--- a/lib/mirage_impl_argv.ml
+++ b/lib/mirage_impl_argv.ml
@@ -1,48 +1,33 @@
 open Functoria
 module Key = Mirage_key
 
-let argv_unix = impl @@ object
-    inherit base_configurable
-    method ty = Functoria.argv
-    method name = "argv_unix"
-    method module_name = "Bootvar"
-    method! packages =
-      Key.pure [ package ~min:"0.1.0" ~max:"0.2.0" "mirage-bootvar-unix" ]
-    method! connect _ _ _ = "Bootvar.argv ()"
-  end
+let ty = Functoria.argv
 
-let argv_solo5 = impl @@ object
-    inherit base_configurable
-    method ty = Functoria.argv
-    method name = "argv_solo5"
-    method module_name = "Bootvar"
-    method! packages =
-      Key.pure [ package ~min:"0.6.0" ~max:"0.7.0" "mirage-bootvar-solo5" ]
-    method! connect _ _ _ = "Bootvar.argv ()"
-  end
+let argv_unix =
+  let packages = [ package ~min:"0.1.0" ~max:"0.2.0" "mirage-bootvar-unix" ] in
+  let connect _ _ _ = "Bootvar.argv ()" in
+  impl ~packages ~connect "Bootvar" ty
 
-let no_argv = impl @@ object
-    inherit base_configurable
-    method ty = Functoria.argv
-    method name = "argv_empty"
-    method module_name = "Mirage_runtime"
-    method! connect _ _ _ = "Lwt.return [|\"\"|]"
-  end
+let argv_solo5 =
+  let packages = [ package ~min:"0.6.0" ~max:"0.7.0" "mirage-bootvar-solo5" ] in
+  let connect _ _ _ = "Bootvar.argv ()" in
+  impl ~packages ~connect "Bootvar" ty
 
-let argv_xen = impl @@ object
-    inherit base_configurable
-    method ty = Functoria.argv
-    method name = "argv_xen"
-    method module_name = "Bootvar"
-    method! packages =
-      Key.pure [ package ~min:"0.7.0" ~max:"0.8.0" "mirage-bootvar-xen" ]
-    method! connect _ _ _ = Fmt.strf
+let no_argv =
+  let connect _ _ _ = "return [|\"\"|]" in
+  impl ~connect "Mirage_runtime" ty
+
+let argv_xen =
+  let packages = [ package ~min:"0.7.0" ~max:"0.8.0" "mirage-bootvar-xen" ] in
+  let connect _ _ _ =
+    Fmt.strf
       (* Some hypervisor configurations try to pass some extra arguments.
        * They means well, but we can't do much with them,
        * and they cause Functoria to abort. *)
       "let filter (key, _) = List.mem key (List.map snd Key_gen.runtime_keys) in@ \
        Bootvar.argv ~filter ()"
-  end
+  in
+  impl ~packages ~connect  "Bootvar" ty
 
 let default_argv =
   match_impl Key.(value target) [

--- a/lib/mirage_impl_arpv4.ml
+++ b/lib/mirage_impl_arpv4.ml
@@ -7,20 +7,15 @@ open Mirage_impl_misc
 type arpv4 = Arpv4
 let arpv4 = Type Arpv4
 
-let arp_conf = object
-  inherit base_configurable
-  method ty = ethernet @-> time @-> arpv4
-  method name = "arp"
-  method module_name = "Arp.Make"
-  method! packages =
-    Key.pure [ package ~min:"2.2.0" ~max:"3.0.0" "arp-mirage" ]
-  method! connect _ modname = function
+let arp_conf =
+  let packages = [ package ~min:"2.2.0" ~max:"3.0.0" "arp-mirage" ] in
+  let connect _ modname = function
     | [ eth ; _time ] -> Fmt.strf "%s.connect %s" modname eth
     | _ -> failwith (connect_err "arp" 3)
-end
+  in
+  impl ~packages ~connect "Arp.Make" (ethernet @-> time @-> arpv4)
 
-let arp_func = impl arp_conf
 let arp
     ?(time = default_time)
     (eth : ethernet impl) =
-  arp_func $ eth $ time
+  arp_conf $ eth $ time

--- a/lib/mirage_impl_block.mli
+++ b/lib/mirage_impl_block.mli
@@ -19,17 +19,7 @@ val block_of_xenstore_id : string -> block Functoria.impl
 
 val block_of_file : string -> block Functoria.impl
 
-class block_conf :
-  string
-  -> object
-       inherit Functoria.base_configurable
-
-       method module_name : string
-
-       method name : string
-
-       method ty : block Functoria.typ
-     end
+val block_conf : string -> block Functoria.Device.t
 
 type block_t = {filename: string; number: int}
 

--- a/lib/mirage_impl_conduit.ml
+++ b/lib/mirage_impl_conduit.ml
@@ -5,26 +5,22 @@ open Mirage_impl_random
 type conduit = Conduit
 let conduit = Type Conduit
 
-let conduit_with_connectors connectors = impl @@ object
-    inherit base_configurable
-    method ty = conduit
-    method name = Functoria_app.Name.create "conduit" ~prefix:"conduit"
-    method module_name = "Conduit_mirage"
-    method! packages = Mirage_key.pure [ pkg ]
-    method! deps = abstract nocrypto :: List.map abstract connectors
-
-    method! connect _i _ = function
-      (* There is always at least the nocrypto device *)
-      | _nocrypto :: connectors ->
-        let pp_connector = Fmt.fmt "%s >>=@ " in
-        let pp_connectors = Fmt.list ~sep:Fmt.nop pp_connector in
-        Fmt.strf
-          "Lwt.return Conduit_mirage.empty >>=@ \
-           %a\
-           fun t -> Lwt.return t"
-          pp_connectors connectors
-      | [] -> failwith "The conduit with connectors expects at least one argument"
-  end
+let conduit_with_connectors connectors =
+  let packages = [ pkg ] in
+  let extra_deps = abstract nocrypto :: List.map abstract connectors in
+  let connect _ _ = function
+    (* There is always at least the nocrypto device *)
+    | _nocrypto :: connectors ->
+      let pp_connector = Fmt.fmt "%s >>=@ " in
+      let pp_connectors = Fmt.list ~sep:Fmt.nop pp_connector in
+      Fmt.strf
+        "Lwt.return Conduit_mirage.empty >>=@ \
+         %a\
+         fun t -> Lwt.return t"
+        pp_connectors connectors
+    | [] -> failwith "The conduit with connectors expects at least one argument"
+  in
+  impl ~packages ~extra_deps ~connect "Conduit_mirage" conduit
 
 let conduit_direct ?(tls=false) s =
   (* TCP must be before tls in the list. *)

--- a/lib/mirage_impl_console.ml
+++ b/lib/mirage_impl_console.ml
@@ -5,38 +5,19 @@ module Key = Mirage_key
 type console = CONSOLE
 let console = Type CONSOLE
 
-let console_unix str = impl @@ object
-    inherit base_configurable
-    method ty = console
-    val name = Name.ocamlify @@ "console_unix_" ^ str
-    method name = name
-    method module_name = "Console_unix"
-    method! packages =
-      Key.pure [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-console-unix" ]
-    method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
-  end
+let connect str = fun _ m _ -> Fmt.strf "%s.connect %S" m str
 
-let console_xen str = impl @@ object
-    inherit base_configurable
-    method ty = console
-    val name = Name.ocamlify @@ "console_xen_" ^ str
-    method name = name
-    method module_name = "Console_xen"
-    method! packages =
-      Key.pure [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-console-xen" ]
-    method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
-  end
+let console_unix str =
+  let packages = [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-console-unix" ] in
+  impl ~packages ~connect:(connect str) "Console_unix" console
 
-let console_solo5 str = impl @@ object
-    inherit base_configurable
-    method ty = console
-    val name = Name.ocamlify @@ "console_solo5_" ^ str
-    method name = name
-    method module_name = "Console_solo5"
-    method! packages =
-      Key.pure [ package ~min:"0.6.1" ~max:"0.7.0" "mirage-console-solo5" ]
-    method! connect _ modname _args = Fmt.strf "%s.connect %S" modname str
-  end
+let console_xen str =
+  let packages = [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-console-xen" ] in
+  impl ~packages ~connect:(connect str) "Console_xen" console
+
+let console_solo5 str =
+  let packages = [ package ~min:"0.6.1" ~max:"0.7.0" "mirage-console-solo5" ] in
+  impl ~packages ~connect:(connect str) "Console_solo5" console
 
 let custom_console str =
   match_impl Key.(value target) [

--- a/lib/mirage_impl_ethernet.ml
+++ b/lib/mirage_impl_ethernet.ml
@@ -6,17 +6,12 @@ open Mirage_impl_network
 type ethernet = ETHERNET
 let ethernet = Type ETHERNET
 
-let ethernet_conf = object
-  inherit base_configurable
-  method ty = network @-> ethernet
-  method name = "ethernet"
-  method module_name = "Ethernet.Make"
-  method! packages =
-    Key.pure [ package ~min:"2.2.0" ~max:"3.0.0" "ethernet" ]
-  method! connect _ modname = function
-    | [ eth ] -> Fmt.strf "%s.connect %s" modname eth
+let etif_conf =
+  let packages = [ package ~min:"2.2.0" ~max:"3.0.0" "ethernet" ] in
+  let connect _ m = function
+    | [ eth ] -> Fmt.strf "%s.connect %s" m eth
     | _ -> failwith (connect_err "ethernet" 1)
-end
+  in
+  impl ~packages ~connect "Ethernet.Make" (network @-> ethernet)
 
-let etif_func = impl ethernet_conf
-let etif network = etif_func $ network
+let etif network = etif_conf $ network

--- a/lib/mirage_impl_http.ml
+++ b/lib/mirage_impl_http.ml
@@ -4,28 +4,18 @@ open Mirage_impl_misc
 type http = HTTP
 let http = Type HTTP
 
-let cohttp_server conduit = impl @@ object
-    inherit base_configurable
-    method ty = http
-    method name = "http"
-    method module_name = "Cohttp_mirage.Server_with_conduit"
-    method! packages =
-      Mirage_key.pure [ package ~min:"2.1.0" ~max:"3.0.0" "cohttp-mirage" ]
-    method! deps = [ abstract conduit ]
-    method! connect _i modname = function
-      | [ conduit ] -> Fmt.strf "%s.connect %s" modname conduit
-      | _ -> failwith (connect_err "http" 1)
-  end
+let connect err _i modname = function
+  | [ conduit ] -> Fmt.strf "%s.connect %s" modname conduit
+  | _ -> failwith (connect_err err 1)
 
-let httpaf_server conduit = impl @@ object
-    inherit base_configurable
-    method ty = http
-    method name = "httpaf"
-    method module_name = "Httpaf_mirage.Server_with_conduit"
-    method! packages =
-      Mirage_key.pure [ package "httpaf-mirage" ]
-    method! deps = [ abstract conduit ]
-    method! connect _i modname = function
-      | [ conduit ] -> Fmt.strf "%s.connect %s" modname conduit
-      | _ -> failwith (connect_err "httpaf" 1)
-  end
+let cohttp_server conduit =
+  let packages = [ package ~min:"2.1.0" ~max:"3.0.0" "cohttp-mirage" ] in
+  let extra_deps = [ abstract conduit ] in
+  impl ~packages ~connect:(connect "http") ~extra_deps
+    "Cohttp_mirage.Server_with_conduit" http
+
+let httpaf_server conduit =
+  let packages = [ package "httpaf-mirage" ] in
+  let extra_deps = [ abstract conduit ] in
+  impl ~packages ~connect:(connect "httapf") ~extra_deps
+    "Httpaf_mirage.Server_with_conduit" http

--- a/lib/mirage_impl_icmp.ml
+++ b/lib/mirage_impl_icmp.ml
@@ -8,16 +8,12 @@ type icmpv4 = v4 icmp
 let icmp = Type ICMP
 let icmpv4: icmpv4 typ = icmp
 
-let icmpv4_direct_conf () = object
-  inherit base_configurable
-  method ty : ('a ip -> 'a icmp) typ = ip @-> icmp
-  method name = "icmpv4"
-  method module_name = "Icmpv4.Make"
-  method! packages = right_tcpip_library ~sublibs:["icmpv4"] "tcpip"
-  method! connect _ modname = function
+let icmpv4_direct () =
+  let packages_v = right_tcpip_library ~sublibs:["icmpv4"] "tcpip" in
+  let connect _ modname = function
     | [ ip ] -> Fmt.strf "%s.connect %s" modname ip
     | _  -> failwith (connect_err "icmpv4" 1)
-end
+  in
+  impl ~packages_v ~connect "Icmpv4.Make" (ip @-> icmp)
 
-let icmpv4_direct_func () = impl (icmpv4_direct_conf ())
-let direct_icmpv4 ip = icmpv4_direct_func () $ ip
+let direct_icmpv4 ip = icmpv4_direct () $ ip

--- a/lib/mirage_impl_kv.ml
+++ b/lib/mirage_impl_kv.ml
@@ -7,44 +7,36 @@ open Astring
 type ro = RO
 let ro = Type RO
 
-let crunch dirname = impl @@ object
-    inherit base_configurable
-    method ty = ro
-    val name = Name.create ("static" ^ dirname) ~prefix:"static"
-    method name = name
-    method module_name = String.Ascii.capitalize name
-    method! packages =
-      Key.pure [
-        package ~min:"3.0.0" ~max:"4.0.0" "mirage-kv-mem";
-        package ~min:"3.1.0" ~max:"4.0.0" ~build:true "crunch"
-      ]
-    method! connect _ modname _ = Fmt.strf "%s.connect ()" modname
-    method! build _i =
-      let dir = Fpath.(v dirname) in
-      let file = Fpath.(v name + "ml") in
-      Bos.OS.Path.exists dir >>= function
-      | true ->
-        Mirage_impl_misc.Log.info (fun m -> m "Generating: %a" Fpath.pp file);
-        Bos.OS.Cmd.run Bos.Cmd.(v "ocaml-crunch" % "-o" % p file % p dir)
-      | false ->
-        R.error_msg (Fmt.strf "The directory %s does not exist." dirname)
-    method! clean _i =
-      Bos.OS.File.delete Fpath.(v name + "ml") >>= fun () ->
-      Bos.OS.File.delete Fpath.(v name + "mli")
-  end
+let crunch dirname =
+  let name = "Static" in
+  let packages = [
+    package ~min:"3.0.0" ~max:"4.0.0" "mirage-kv-mem";
+    package ~min:"3.1.0" ~max:"4.0.0" ~build:true "crunch"
+  ] in
+  let connect _ modname _ = Fmt.strf "%s.connect ()" modname in
+  let build _i =
+    let dir = Fpath.(v dirname) in
+    let file = Fpath.(v (String.Ascii.lowercase name) + "ml") in
+    Bos.OS.Path.exists dir >>= function
+    | true ->
+      Mirage_impl_misc.Log.info (fun m -> m "Generating: %a" Fpath.pp file);
+      Bos.OS.Cmd.run Bos.Cmd.(v "ocaml-crunch" % "-o" % p file % p dir)
+    | false ->
+      R.error_msg (Fmt.strf "The directory %s does not exist." dirname)
+  in
+  let clean _i =
+    Bos.OS.File.delete Fpath.(v name + "ml") >>= fun () ->
+    Bos.OS.File.delete Fpath.(v name + "mli")
+  in
+  impl ~packages ~connect ~build ~clean name ro
 
-let direct_kv_ro dirname = impl @@ object
-    inherit base_configurable
-    method ty = ro
-    val name = Name.create ("direct-kv-ro-" ^ dirname) ~prefix:"direct"
-    method name = name
-    method module_name = "Mirage_kv_unix"
-    method! packages =
-      Key.pure [ package ~min:"2.1.0" ~max:"3.0.0" "mirage-kv-unix" ]
-    method! connect i modname _names =
+let direct_kv_ro dirname =
+  let packages = [ package ~min:"2.1.0" ~max:"3.0.0" "mirage-kv-unix" ] in
+  let connect i modname _names =
       let path = Fpath.(Info.build_dir i / dirname) in
       Fmt.strf "%s.connect \"%a\"" modname Fpath.pp path
-  end
+  in
+  impl ~packages ~connect "Mirage_kv_unix" ro
 
 let direct_kv_ro dirname =
   match_impl Key.(value target) [
@@ -60,29 +52,19 @@ let direct_kv_ro dirname =
 type rw = RW
 let rw = Type RW
 
-let direct_kv_rw dirname = impl @@ object
-    inherit base_configurable
-    method ty = rw
-    val name = Name.create ("direct-kv-rw-" ^ dirname) ~prefix:"direct"
-    method name = name
-    method module_name = "Mirage_kv_unix"
-    method! packages =
-      Key.pure [ package ~min:"2.1.0" ~max:"3.0.0" "mirage-kv-unix" ]
-    method! connect i modname _names =
-      let path = Fpath.(Info.build_dir i / dirname) in
-      Fmt.strf "%s.connect \"%a\"" modname Fpath.pp path
-  end
+let direct_kv_rw dirname =
+  let packages = [ package ~min:"2.1.0" ~max:"3.0.0" "mirage-kv-unix" ] in
+  let connect i modname _names =
+    let path = Fpath.(Info.build_dir i / dirname) in
+    Fmt.strf "%s.connect \"%a\"" modname Fpath.pp path
+  in
+  impl ~packages ~connect "Mirage_kv_unix" rw
 
-let mem_kv_rw_config = impl @@ object
-    inherit base_configurable
-    method ty = Mirage_impl_pclock.pclock @-> rw
-    method name = "mirage-kv-mem"
-    method module_name = "Mirage_kv_mem.Make"
-    method! packages =
-      Key.pure [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-kv-mem" ]
-    method! connect _i modname _names =
-      Fmt.strf "%s.connect ()" modname
-  end
+let mem_kv_rw_config =
+  let packages = [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-kv-mem" ] in
+  let connect _ modname _names = Fmt.strf "%s.connect ()" modname in
+  impl ~packages ~connect "Mirage_kv_mem.Make"
+    (Mirage_impl_pclock.pclock @-> rw)
 
 let mem_kv_rw ?(clock = Mirage_impl_pclock.default_posix_clock) () =
   mem_kv_rw_config $ clock

--- a/lib/mirage_impl_mclock.ml
+++ b/lib/mirage_impl_mclock.ml
@@ -3,15 +3,10 @@ open Functoria
 type mclock = MCLOCK
 let mclock = Type MCLOCK
 
-let monotonic_clock_conf = object
-  inherit base_configurable
-  method ty = mclock
-  method name = "mclock"
-  method module_name = "Mclock"
-  method! packages =
+let default_monotonic_clock =
+  let packages_v =
     Mirage_key.(if_ is_unix)
       [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-clock-unix" ]
       [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-clock-freestanding" ]
-end
-
-let default_monotonic_clock = impl monotonic_clock_conf
+  in
+  impl ~packages_v "Mclock" mclock

--- a/lib/mirage_impl_pclock.ml
+++ b/lib/mirage_impl_pclock.ml
@@ -3,15 +3,10 @@ open Functoria
 type pclock = PCLOCK
 let pclock = Type PCLOCK
 
-let posix_clock_conf = object
-  inherit base_configurable
-  method ty = pclock
-  method name = "pclock"
-  method module_name = "Pclock"
-  method! packages =
-    Mirage_key.(if_ is_unix)
+let default_posix_clock =
+  let packages_v =
+        Mirage_key.(if_ is_unix)
       [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-clock-unix" ]
       [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-clock-freestanding" ]
-end
-
-let default_posix_clock = impl posix_clock_conf
+  in
+  impl ~packages_v "Pclock" pclock

--- a/lib/mirage_impl_qubesdb.ml
+++ b/lib/mirage_impl_qubesdb.ml
@@ -1,24 +1,18 @@
 open Functoria
 module Key = Mirage_key
 open Mirage_impl_misc
-open Rresult
 
 type qubesdb = QUBES_DB
 let qubesdb = Type QUBES_DB
 
 let pkg = package ~min:"0.8.0" ~max:"0.9.0" "mirage-qubes"
 
-let qubesdb_conf = object
-  inherit base_configurable
-  method ty = qubesdb
-  method name = "qubesdb"
-  method module_name = "Qubes.DB"
-  method! packages = Key.pure [ pkg ]
-  method! configure i =
-    match get_target i with
-    | `Qubes | `Xen -> R.ok ()
-    | _ -> R.error_msg "Qubes DB invoked for an unsupported target; qubes and xen are supported"
-  method! connect _ modname _args = Fmt.strf "%s.connect ~domid:0 ()" modname
-end
-
-let default_qubesdb = impl qubesdb_conf
+let default_qubesdb =
+  let packages = [pkg] in
+  let configure i = match get_target i with
+    | `Qubes | `Xen -> Ok ()
+    | _ -> failwith "Qubes DB invoked for an unsupported target; qubes and \
+                     xen are supported"
+  in
+  let connect _ modname _args = Fmt.strf "%s.connect ~domid:0 ()" modname in
+  impl ~packages ~configure ~connect "Qubes.DB" qubesdb

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -3,17 +3,10 @@ open Functoria
 type random = RANDOM
 let random = Type RANDOM
 
-let stdlib_random_conf = object
-  inherit base_configurable
-  method ty = random
-  method name = "random"
-  method module_name = "Mirage_random_stdlib"
-  method! packages =
-    Mirage_key.pure [ package ~min:"0.1.0" ~max:"1.0.0" "mirage-random-stdlib" ]
-  method! connect _ modname _ = Fmt.strf "%s.initialize ()" modname
-end
-
-let stdlib_random = impl stdlib_random_conf
+let stdlib_random =
+  let packages = [ package ~min:"0.1.0" ~max:"1.0.0" "mirage-random-stdlib" ] in
+  let connect _ modname _ = Fmt.strf "%s.initialize ()" modname in
+  impl ~packages ~connect "Mirage_random_stdlib" random
 
 (* This is to check that entropy is a dependency if "tls" is in
    the package array. *)
@@ -23,31 +16,19 @@ let enable_entropy, is_entropy_enabled =
   let g () = !r in
   (f, g)
 
-let nocrypto = impl @@ object
-    inherit base_configurable
-    method ty = job
-    method name = "nocrypto"
-    method module_name = "Nocrypto_entropy"
-    method! packages =
-      Mirage_key.pure
-        [ package ~min:"0.5.4-2" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto" ;
-          package ~min:"0.5.0" ~max:"0.6.0" "mirage-entropy" ]
+let nocrypto =
+  let packages = [
+    package ~min:"0.5.4-2" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto" ;
+    package ~min:"0.5.0" ~max:"0.6.0" "mirage-entropy"
+  ] in
+  let build _ = Ok (enable_entropy ()) in
+  let connect _ _ _ = "Nocrypto_entropy_mirage.initialize ()" in
+  impl ~packages ~build ~connect "Nocrypto_entropy" job
 
-    method! build _ = Rresult.R.ok (enable_entropy ())
-    method! connect _ _ _ = "Nocrypto_entropy_mirage.initialize ()"
-  end
-
-let nocrypto_random_conf = object
-  inherit base_configurable
-  method ty = random
-  method name = "random"
-  method module_name = "Nocrypto.Rng"
-  method! packages =
-    Mirage_key.pure [ package ~min:"0.5.4-2" ~max:"0.6.0" "nocrypto" ]
-  method! deps = [abstract nocrypto]
-end
-
-let nocrypto_random = impl nocrypto_random_conf
+let nocrypto_random =
+  let packages = [ package ~min:"0.5.4-2" ~max:"0.6.0" "nocrypto" ] in
+  let extra_deps = [abstract nocrypto] in
+  impl ~packages ~extra_deps "Nocrypto.Rng" random
 
 let default_random =
   match_impl (Mirage_key.value Mirage_key.prng) [

--- a/lib/mirage_impl_resolver.ml
+++ b/lib/mirage_impl_resolver.ml
@@ -4,49 +4,43 @@ open Mirage_impl_misc
 open Mirage_impl_mclock
 open Mirage_impl_stackv4
 open Mirage_impl_random
-open Rresult
 
 type resolver = Resolver
 let resolver = Type Resolver
 
-let resolver_unix_system = impl @@ object
-    inherit base_configurable
-    method ty = resolver
-    method name = "resolver_unix"
-    method module_name = "Resolver_lwt"
-    method! packages =
-      Key.(if_ is_unix)
-        [ Mirage_impl_conduit_connector.pkg ;
-          package ~min:"2.0.2" ~max:"3.0.0" "conduit-lwt-unix"; ]
-        []
-    method! configure i =
-      match get_target i with
-      | `Unix | `MacOSX -> R.ok ()
-      | _ -> R.error_msg "Unix resolver not supported on non-UNIX targets."
-    method! connect _ _modname _ = "Lwt.return Resolver_lwt_unix.system"
-  end
+let resolver_unix_system =
+  let packages_v =
+    Key.(if_ is_unix)
+      [ Mirage_impl_conduit_connector.pkg ;
+        package ~min:"2.0.2" ~max:"3.0.0" "conduit-lwt-unix"; ]
+      []
+  in
+  let configure i =
+    match get_target i with
+    | `Unix | `MacOSX -> Ok ()
+    | _ -> failwith "Unix resolver not supported on non-UNIX targets."
+  in
+  let connect _ _modname _ = "Lwt.return Resolver_lwt_unix.system" in
+  impl ~packages_v ~configure ~connect "Resolver_lwt" resolver
 
-let resolver_dns_conf ~ns ~ns_port = impl @@ object
-    inherit base_configurable
-    method ty = random @-> mclock @-> stackv4 @-> resolver
-    method name = "resolver"
-    method module_name = "Resolver_mirage.Make_with_stack"
-    method! packages =
-      Key.pure [ Mirage_impl_conduit_connector.pkg ]
-    method! keys = [ Key.abstract ns ; Key.abstract ns_port ]
-    method! connect _ modname = function
-      | [ _r ; _t ; stack ] ->
-        Fmt.strf
-          "let ns = %a in@;\
-           let ns_port = %a in@;\
-           let res = %s.R.init ~ns ~ns_port ~stack:%s () in@;\
-           Lwt.return res@;"
-          pp_key ns pp_key ns_port modname stack
-      | _ -> failwith (connect_err "resolver" 3)
-  end
+let resolver_dns_conf ~ns ~ns_port =
+  let packages = [ Mirage_impl_conduit_connector.pkg ] in
+  let keys = Key.[ abstract ns ; abstract ns_port ] in
+  let connect _ modname = function
+    | [ _r ; _t ; stack ] ->
+      Fmt.strf
+        "let ns = %a in@;\
+         let ns_port = %a in@;\
+         let res = %s.R.init ~ns ~ns_port ~stack:%s () in@;\
+         Lwt.return res@;"
+        pp_key ns pp_key ns_port modname stack
+    | _ -> failwith (connect_err "resolver" 3)
+  in
+  impl ~packages ~keys ~connect
+    "Resolver_mirage.Make_with_stack"
+    (random @-> mclock @-> stackv4 @-> resolver)
 
 let resolver_dns ?ns ?ns_port ?(random = default_random) ?(mclock = default_monotonic_clock) stack =
   let ns = Key.resolver ?default:ns ()
-  and ns_port = Key.resolver_port ?default:ns_port ()
-  in
+  and ns_port = Key.resolver_port ?default:ns_port () in
   resolver_dns_conf ~ns ~ns_port $ random $ mclock $ stack

--- a/lib/mirage_impl_stackv4.ml
+++ b/lib/mirage_impl_stackv4.ml
@@ -15,77 +15,70 @@ open Mirage_impl_udp
 type stackv4 = STACKV4
 let stackv4 = Type STACKV4
 
-let add_suffix s ~suffix = if suffix = "" then s else s^"_"^suffix
-
-let stackv4_direct_conf ?(group="") () = impl @@ object
-    inherit base_configurable
-    method ty =
-      time @-> random @-> network @->
-      ethernet @-> arpv4 @-> ipv4 @-> Mirage_impl_icmp.icmpv4 @-> udpv4 @-> tcpv4 @->
-      stackv4
-    val name = add_suffix "stackv4_" ~suffix:group
-    method name = name
-    method module_name = "Tcpip_stack_direct.Make"
-    method! packages = right_tcpip_library ~sublibs:["stack-direct"] "tcpip"
-    method! connect _i modname = function
-      | [ _t; _r; interface; ethif; arp; ip; icmp; udp; tcp ] ->
-        Fmt.strf
-          "%s.connect %s %s %s %s %s %s %s"
-          modname interface ethif arp ip icmp udp tcp
-      | _ -> failwith (connect_err "direct stackv4" 9)
-  end
+let stackv4_direct_conf () =
+  let packages_v = right_tcpip_library ~sublibs:["stack-direct"] "tcpip" in
+  let connect _i modname = function
+    | [ _t; _r; interface; ethif; arp; ip; icmp; udp; tcp ] ->
+      Fmt.strf
+        "%s.connect %s %s %s %s %s %s %s"
+        modname interface ethif arp ip icmp udp tcp
+    | _ -> failwith (connect_err "direct stackv4" 9)
+  in
+  impl ~packages_v ~connect
+    "Tcpip_stack_direct.Make"
+    (time @-> random @-> network @->
+     ethernet @-> arpv4 @-> ipv4 @-> Mirage_impl_icmp.icmpv4 @-> udpv4 @-> tcpv4 @->
+     stackv4)
 
 let direct_stackv4
     ?(clock=default_monotonic_clock)
     ?(random=default_random)
     ?(time=default_time)
-    ?group
     network eth arp ip =
-  stackv4_direct_conf ?group ()
+  stackv4_direct_conf ()
   $ time $ random $ network
   $ eth $ arp $ ip
   $ Mirage_impl_icmp.direct_icmpv4 ip
   $ direct_udp ~random ip
   $ direct_tcp ~clock ~random ~time ip
 
-let dhcp_ipv4_stack ?group ?(random = default_random) ?(time = default_time) ?(arp = arp ?time:None) tap =
+let dhcp_ipv4_stack ?(random = default_random) ?(time = default_time) ?(arp = arp ?time:None) tap =
   let config = dhcp random time tap in
   let e = etif tap in
   let a = arp e in
   let i = ipv4_of_dhcp config e a in
-  direct_stackv4 ?group tap e a i
+  direct_stackv4 tap e a i
 
 let static_ipv4_stack ?group ?config ?(arp = arp ?time:None) tap =
   let e = etif tap in
   let a = arp e in
   let i = create_ipv4 ?group ?config e a in
-  direct_stackv4 ?group tap e a i
+  direct_stackv4 tap e a i
 
-let qubes_ipv4_stack ?group ?(qubesdb = default_qubesdb) ?(arp = arp ?time:None) tap =
+let qubes_ipv4_stack ?(qubesdb = default_qubesdb) ?(arp = arp ?time:None) tap =
   let e = etif tap in
   let a = arp e in
   let i = ipv4_qubes qubesdb e a in
-  direct_stackv4 ?group tap e a i
+  direct_stackv4 tap e a i
 
-let stackv4_socket_conf ?(group="") ips = impl @@ object
-    inherit base_configurable
-    method ty = stackv4
-    val name = add_suffix "stackv4_socket" ~suffix:group
-    method name = name
-    method module_name = "Tcpip_stack_socket"
-    method! keys = [ Key.abstract ips ]
-    method! packages = right_tcpip_library ~sublibs:["stack-socket"] "tcpip"
-    method! deps = [abstract (socket_udpv4 None); abstract (socket_tcpv4 None)]
-    method! connect _i modname = function
-      | [ udpv4 ; tcpv4 ] ->
-        Fmt.strf
-          "%s.connect %a %s %s"
-          modname pp_key ips udpv4 tcpv4
-      | _ -> failwith (connect_err "socket stack" 2)
-  end
+let stackv4_socket_conf ips =
+  let keys = [ Key.abstract ips ] in
+  let packages_v = right_tcpip_library ~sublibs:["stack-socket"] "tcpip" in
+  let extra_deps = [
+    abstract (socket_udpv4 None);
+    abstract (socket_tcpv4 None);
+  ] in
+  let connect _i modname = function
+    | [ udpv4 ; tcpv4 ] ->
+      Fmt.strf "%s.connect %a %s %s" modname pp_key ips udpv4 tcpv4
+    | _ -> failwith (connect_err "socket stack" 2)
+  in
+  impl ~keys ~packages_v ~extra_deps ~connect
+    "Tcpip_stack_socket"
+    stackv4
 
 let socket_stackv4 ?group ipv4s =
-  stackv4_socket_conf ?group (Key.V4.ips ?group ipv4s)
+  stackv4_socket_conf (Key.V4.ips ?group ipv4s)
 
 (** Generic stack *)
 
@@ -107,7 +100,7 @@ let generic_stackv4
           $ net_key
           $ dhcp_key) in
   match_impl p [
-    `Dhcp, dhcp_ipv4_stack ?group tap;
+    `Dhcp, dhcp_ipv4_stack tap;
     `Socket, socket_stackv4 ?group [Ipaddr.V4.any];
-    `Qubes, qubes_ipv4_stack ?group tap;
+    `Qubes, qubes_ipv4_stack tap;
   ] ~default:(static_ipv4_stack ?config ?group tap)

--- a/lib/mirage_impl_stackv4.mli
+++ b/lib/mirage_impl_stackv4.mli
@@ -6,7 +6,6 @@ val direct_stackv4 :
      ?clock:Mirage_impl_mclock.mclock Functoria.impl
   -> ?random:Mirage_impl_random.random Functoria.impl
   -> ?time:Mirage_impl_time.time Functoria.impl
-  -> ?group:string
   -> Mirage_impl_network.network Functoria.impl
   -> Mirage_impl_ethernet.ethernet Functoria.impl
   -> Mirage_impl_arpv4.arpv4 Functoria.impl
@@ -17,16 +16,14 @@ val socket_stackv4 :
   ?group:string -> Ipaddr.V4.t list -> stackv4 Functoria.impl
 
 val qubes_ipv4_stack :
-     ?group:string
-  -> ?qubesdb:Mirage_impl_qubesdb.qubesdb Functoria.impl
+  ?qubesdb:Mirage_impl_qubesdb.qubesdb Functoria.impl
   -> ?arp:(   Mirage_impl_ethernet.ethernet Functoria.impl
            -> Mirage_impl_arpv4.arpv4 Functoria.impl)
   -> Mirage_impl_network.network Functoria.impl
   -> stackv4 Functoria.impl
 
 val dhcp_ipv4_stack :
-     ?group:string
-  -> ?random:Mirage_impl_random.random Functoria.impl
+    ?random:Mirage_impl_random.random Functoria.impl
   -> ?time:Mirage_impl_time.time Functoria.impl
   -> ?arp:(   Mirage_impl_ethernet.ethernet Functoria.impl
            -> Mirage_impl_arpv4.arpv4 Functoria.impl)

--- a/lib/mirage_impl_syslog.ml
+++ b/lib/mirage_impl_syslog.ml
@@ -31,94 +31,83 @@ let opt p s = Fmt.(option @@ prefix (unit ("~"^^s^^":")) p)
 let opt_int = opt Fmt.int
 let opt_string = opt (fun pp v -> Format.fprintf pp "%S" v)
 
-let pkg sublibs =
-  Key.pure [ package ~min:"0.2.2" ~max:"0.3.0" ~sublibs "logs-syslog" ]
+let pkg sublibs = [ package ~min:"0.2.2" ~max:"0.3.0" ~sublibs "logs-syslog" ]
 
 let syslog_udp_conf config =
-  let endpoint = Key.syslog config.server
-  and port = Key.syslog_port config.port
-  and hostname = Key.syslog_hostname config.hostname
+  let endpoint = Key.syslog config.server in
+  let port = Key.syslog_port config.port in
+  let hostname = Key.syslog_hostname config.hostname in
+  let packages = pkg ["mirage"] in
+  let keys = Key.[abstract endpoint; abstract hostname; abstract port] in
+  let connect _i modname = function
+    | [ console ; pclock ; stack ] ->
+      Fmt.strf
+        "@[<v 2>\
+         match %a with@ \
+         | None -> Lwt.return_unit@ \
+         | Some server ->@ \
+         let port = %a in@ \
+         let reporter =@ \
+         %s.create %s %s %s ~hostname:%a ?port server %a ()@ \
+         in@ \
+         Logs.set_reporter reporter;@ \
+         Lwt.return_unit@]"
+        pp_key endpoint
+        pp_key port
+        modname console pclock stack
+        pp_key hostname
+        (opt_int "truncate") config.truncate
+    | _ -> failwith (connect_err "syslog udp" 3)
   in
-  impl @@ object
-    inherit base_configurable
-    method ty = console @-> pclock @-> stackv4 @-> syslog
-    method name = "udp_syslog"
-    method module_name = "Logs_syslog_mirage.Udp"
-    method! packages = pkg ["mirage"]
-    method! keys =
-      [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
-    method! connect _i modname = function
-      | [ console ; pclock ; stack ] ->
-        Fmt.strf
-          "@[<v 2>\
-           match %a with@ \
-           | None -> Lwt.return_unit@ \
-           | Some server ->@ \
-             let port = %a in@ \
-             let reporter =@ \
-               %s.create %s %s %s ~hostname:%a ?port server %a ()@ \
-             in@ \
-             Logs.set_reporter reporter;@ \
-             Lwt.return_unit@]"
-          pp_key endpoint
-          pp_key port
-          modname console pclock stack
-          pp_key hostname
-          (opt_int "truncate") config.truncate
-      | _ -> failwith (connect_err "syslog udp" 3)
-  end
+  impl ~packages ~keys ~connect
+    "Logs_syslog_mirage.Udp"
+    (console @-> pclock @-> stackv4 @-> syslog)
 
-let syslog_udp ?(config = default_syslog_config) ?(console = default_console) ?(clock = default_posix_clock) stack =
+let syslog_udp
+    ?(config = default_syslog_config)
+    ?(console = default_console)
+    ?(clock = default_posix_clock)
+    stack =
   syslog_udp_conf config $ console $ clock $ stack
 
 let syslog_tcp_conf config =
-  let endpoint = Key.syslog config.server
-  and port = Key.syslog_port config.port
-  and hostname = Key.syslog_hostname config.hostname
-  in
-  impl @@ object
-    inherit base_configurable
-    method ty = console @-> pclock @-> stackv4 @-> syslog
-    method name = "tcp_syslog"
-    method module_name = "Logs_syslog_mirage.Tcp"
-    method! packages = pkg ["mirage"]
-    method! keys =
-      [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
-    method! connect _i modname = function
-      | [ console ; pclock ; stack ] ->
-        Fmt.strf
-          "@[<v 2>\
-           match %a with@ \
-           | None -> Lwt.return_unit@ \
-           | Some server ->@ \
-             let port = %a in@ \
-             %s.create %s %s %s ~hostname:%a ?port server %a () >>= function@ \
-             | Ok reporter -> Logs.set_reporter reporter; Lwt.return_unit@ \
+  let endpoint = Key.syslog config.server in
+  let port = Key.syslog_port config.port in
+  let hostname = Key.syslog_hostname config.hostname in
+  let packages = pkg ["mirage"] in
+  let keys = Key.[abstract endpoint; abstract hostname; abstract port] in
+  let connect _i modname = function
+    | [ console ; pclock ; stack ] ->
+      Fmt.strf
+        "@[<v 2>\
+         match %a with@ \
+         | None -> Lwt.return_unit@ \
+         | Some server ->@ \
+         let port = %a in@ \
+         %s.create %s %s %s ~hostname:%a ?port server %a () >>= function@ \
+         | Ok reporter -> Logs.set_reporter reporter; Lwt.return_unit@ \
              | Error e -> invalid_arg e@]"
-          pp_key endpoint
-          pp_key port
-          modname console pclock stack
-          pp_key hostname
-          (opt_int "truncate") config.truncate
-      | _ -> failwith (connect_err "syslog tcp" 3)
-  end
+        pp_key endpoint
+        pp_key port
+        modname console pclock stack
+        pp_key hostname
+        (opt_int "truncate") config.truncate
+    | _ -> failwith (connect_err "syslog tcp" 3)
+  in
+  impl ~packages ~keys ~connect
+    "Logs_syslog_mirage.Tcp"
+    (console @-> pclock @-> stackv4 @-> syslog)
 
 let syslog_tcp ?(config = default_syslog_config) ?(console = default_console) ?(clock = default_posix_clock) stack =
   syslog_tcp_conf config $ console $ clock $ stack
 
 let syslog_tls_conf ?keyname config =
-  let endpoint = Key.syslog config.server
-  and port = Key.syslog_port config.port
-  and hostname = Key.syslog_hostname config.hostname
-  in
-  impl @@ object
-    inherit base_configurable
-    method ty = console @-> pclock @-> stackv4 @-> Mirage_impl_kv.ro @-> syslog
-    method name = "tls_syslog"
-    method module_name = "Logs_syslog_mirage_tls.Tls"
-    method! packages = pkg ["mirage" ; "mirage.tls"]
-    method! keys = [ Key.abstract endpoint ; Key.abstract hostname ; Key.abstract port ]
-    method! connect _i modname = function
+  let endpoint = Key.syslog config.server in
+  let port = Key.syslog_port config.port in
+  let hostname = Key.syslog_hostname config.hostname in
+  let packages = pkg ["mirage" ; "mirage.tls"] in
+  let keys = Key.[abstract endpoint; abstract hostname; abstract port ] in
+  let connect _i modname = function
       | [ console ; pclock ; stack ; kv ] ->
         Fmt.strf
           "@[<v 2>\
@@ -136,7 +125,15 @@ let syslog_tls_conf ?keyname config =
           (opt_int "truncate") config.truncate
           (opt_string "keyname") keyname
       | _ -> failwith (connect_err "syslog tls" 4)
-  end
+  in
+  impl ~packages ~keys ~connect
+    "Logs_syslog_mirage_tls.Tls"
+    (console @-> pclock @-> stackv4 @-> Mirage_impl_kv.ro @-> syslog)
 
-let syslog_tls ?(config = default_syslog_config) ?keyname ?(console = default_console) ?(clock = default_posix_clock) stack kv =
+let syslog_tls
+    ?(config = default_syslog_config)
+    ?keyname
+    ?(console = default_console)
+    ?(clock = default_posix_clock)
+    stack kv =
   syslog_tls_conf ?keyname config $ console $ clock $ stack $ kv

--- a/lib/mirage_impl_tcp.ml
+++ b/lib/mirage_impl_tcp.ml
@@ -6,7 +6,6 @@ open Mirage_impl_mclock
 open Mirage_impl_misc
 open Mirage_impl_random
 open Mirage_impl_time
-open Rresult
 
 type 'a tcp = TCP
 type tcpv4 = v4 tcp
@@ -16,20 +15,16 @@ let tcp = Type TCP
 let tcpv4 : tcpv4 typ = tcp
 let tcpv6 : tcpv6 typ = tcp
 
-(* Value restriction ... *)
-let tcp_direct_conf () = object
-  inherit base_configurable
-  method ty = (ip: 'a ip typ) @-> time @-> mclock @-> random @-> (tcp: 'a tcp typ)
-  method name = "tcp"
-  method module_name = "Tcp.Flow.Make"
-  method! packages = right_tcpip_library ~sublibs:["tcp"] "tcpip"
-  method! connect _ modname = function
+(* this needs to be a function due to the value restriction. *)
+let tcp_direct_func () =
+  let packages_v = right_tcpip_library ~sublibs:["tcp"] "tcpip" in
+  let connect _ modname = function
     | [ip; _time; _clock; _random] -> Fmt.strf "%s.connect %s" modname ip
     | _ -> failwith (connect_err "direct tcp" 4)
-end
-
-(* Value restriction ... *)
-let tcp_direct_func () = impl (tcp_direct_conf ())
+  in
+  impl ~packages_v ~connect
+    "Tcp.Flow.Make"
+    (ip @-> time @-> mclock @-> random @-> tcp)
 
 let direct_tcp
     ?(clock=default_monotonic_clock)
@@ -37,19 +32,15 @@ let direct_tcp
     ?(time=default_time) ip =
   tcp_direct_func () $ ip $ time $ clock $ random
 
-let tcpv4_socket_conf ipv4_key = object
-  inherit base_configurable
-  method ty = tcpv4
-  val name = Name.create "tcpv4_socket" ~prefix:"tcpv4_socket"
-  method name = name
-  method module_name = "Tcpv4_socket"
-  method! keys = [ Key.abstract ipv4_key ]
-  method! packages = right_tcpip_library ~sublibs:["tcpv4-socket"] "tcpip"
-  method! configure i =
+let tcpv4_socket_conf ipv4_key =
+  let keys = [ Key.abstract ipv4_key ] in
+  let packages_v = right_tcpip_library ~sublibs:["tcpv4-socket"] "tcpip" in
+  let configure i =
     match get_target i with
-    | `Unix | `MacOSX -> R.ok ()
-    | _  -> R.error_msg "TCPv4 socket not supported on non-UNIX targets."
-  method! connect _ modname _ = Fmt.strf "%s.connect %a" modname pp_key ipv4_key
-end
+    | `Unix | `MacOSX -> Ok ()
+    | _  -> failwith "TCPv4 socket not supported on non-UNIX targets."
+  in
+  let connect _ modname _ = Fmt.strf "%s.connect %a" modname pp_key ipv4_key in
+  impl ~packages_v ~configure ~keys ~connect "Tcpv4_socket" tcpv4
 
-let socket_tcpv4 ?group ip = impl (tcpv4_socket_conf @@ Key.V4.socket ?group ip)
+let socket_tcpv4 ?group ip = tcpv4_socket_conf @@ Key.V4.socket ?group ip

--- a/lib/mirage_impl_time.ml
+++ b/lib/mirage_impl_time.ml
@@ -3,11 +3,4 @@ open Functoria
 type time = TIME
 let time = Type TIME
 
-let time_conf = object
-  inherit base_configurable
-  method ty = time
-  method name = "time"
-  method module_name = "OS.Time"
-end
-
-let default_time = impl time_conf
+let default_time = impl "OS.Time" time

--- a/lib/mirage_impl_tracing.ml
+++ b/lib/mirage_impl_tracing.ml
@@ -9,48 +9,46 @@ let tracing = job
 let mprof_trace ~size () =
   let unix_trace_file = "trace.ctf" in
   let key = Key.tracing_size size in
-  impl @@ object
-    inherit base_configurable
-    method ty = job
-    method name = "mprof_trace"
-    method module_name = "MProf"
-    method! keys = [ Key.abstract key ]
-    method! packages =
-      Key.match_ Key.(value target) @@ function
-      | #Mirage_key.mode_xen ->
-        [ package ~max:"1.0.0" "mirage-profile";
-          package ~max:"1.0.0" ~min:"0.9.0" "mirage-profile-xen" ]
-      | #Mirage_key.mode_solo5 -> []
-      | #Mirage_key.mode_unix ->
-        [ package ~max:"1.0.0" "mirage-profile";
-          package ~max:"1.0.0" "mirage-profile-unix" ]
-    method! build _ =
-      match query_ocamlfind ["lwt.tracing"] with
-      | Error _ | Ok [] ->
-        R.error_msg "lwt.tracing module not found. Hint:\
-                     opam pin add lwt https://github.com/mirage/lwt.git#tracing"
-      | Ok _ -> Ok ()
-    method! connect i _ _ = match get_target i with
-      | #Mirage_key.mode_solo5 ->
-        failwith  "tracing is not currently implemented for solo5 targets"
-      | #Mirage_key.mode_unix ->
-        Fmt.strf
-          "Lwt.return ())@.\
-           let () = (@ \
-           @[<v 2> let buffer = MProf_unix.mmap_buffer ~size:%a %S in@ \
-           let trace_config = MProf.Trace.Control.make buffer MProf_unix.timestamper in@ \
-           MProf.Trace.Control.start trace_config@]"
-          Key.serialize_call (Key.abstract key)
-          unix_trace_file;
-      | #Mirage_key.mode_xen ->
-        Fmt.strf
-          "Lwt.return ())@.\
-           let () = (@ \
-           @[<v 2> let trace_pages = MProf_xen.make_shared_buffer ~size:%a in@ \
-           let buffer = trace_pages |> Io_page.to_cstruct |> Cstruct.to_bigarray in@ \
-           let trace_config = MProf.Trace.Control.make buffer MProf_xen.timestamper in@ \
-           MProf.Trace.Control.start trace_config;@ \
-           MProf_xen.share_with ~domid:0 trace_pages@ \
-           |> OS.Main.run@]"
-          Key.serialize_call (Key.abstract key)
-  end
+  let keys = [ Key.abstract key ] in
+  let packages_v =
+    Key.match_ Key.(value target) @@ function
+    | #Mirage_key.mode_xen ->
+      [ package ~max:"1.0.0" "mirage-profile";
+        package ~max:"1.0.0" ~min:"0.9.0" "mirage-profile-xen" ]
+    | #Mirage_key.mode_solo5 -> []
+    | #Mirage_key.mode_unix ->
+      [ package ~max:"1.0.0" "mirage-profile";
+        package ~max:"1.0.0" "mirage-profile-unix" ]
+  in
+  let build _ =
+    match query_ocamlfind ["lwt.tracing"] with
+    | Error _ | Ok [] ->
+      R.error_msg  "lwt.tracing module not found. Hint:\
+                    opam pin add lwt https://github.com/mirage/lwt.git#tracing"
+    | Ok _ -> R.ok ()
+  in
+  let connect i _ _ = match get_target i with
+    | #Mirage_key.mode_solo5 ->
+      failwith  "tracing is not currently implemented for solo5 targets"
+    | #Mirage_key.mode_unix ->
+      Fmt.strf
+        "Lwt.return ())@.\
+         let () = (@ \
+         @[<v 2> let buffer = MProf_unix.mmap_buffer ~size:%a %S in@ \
+         let trace_config = MProf.Trace.Control.make buffer MProf_unix.timestamper in@ \
+         MProf.Trace.Control.start trace_config@]"
+        Key.serialize_call (Key.abstract key)
+        unix_trace_file;
+    | #Mirage_key.mode_xen ->
+      Fmt.strf
+        "Lwt.return ())@.\
+         let () = (@ \
+         @[<v 2> let trace_pages = MProf_xen.make_shared_buffer ~size:%a in@ \
+         let buffer = trace_pages |> Io_page.to_cstruct |> Cstruct.to_bigarray in@ \
+         let trace_config = MProf.Trace.Control.make buffer MProf_xen.timestamper in@ \
+         MProf.Trace.Control.start trace_config;@ \
+         MProf_xen.share_with ~domid:0 trace_pages@ \
+         |> OS.Main.run@]"
+        Key.serialize_call (Key.abstract key)
+  in
+  impl ~keys ~packages_v ~build ~connect  "MProf" job

--- a/lib/mirage_impl_udp.ml
+++ b/lib/mirage_impl_udp.ml
@@ -1,10 +1,11 @@
 module Key = Mirage_key
 module Name = Functoria_app.Name
+
+open Rresult
 open Functoria
 open Mirage_impl_ip
 open Mirage_impl_misc
 open Mirage_impl_random
-open Rresult
 
 type 'a udp = UDP
 type udpv4 = v4 udp
@@ -15,35 +16,25 @@ let udpv4: udpv4 typ = udp
 let udpv6: udpv6 typ = udp
 
 (* Value restriction ... *)
-let udp_direct_conf () = object
-  inherit base_configurable
-  method ty = (ip: 'a ip typ) @-> random @-> (udp: 'a udp typ)
-  method name = "udp"
-  method module_name = "Udp.Make"
-  method! packages = right_tcpip_library ~sublibs:["udp"] "tcpip"
-  method! connect _ modname = function
+let udp_direct_func () =
+  let packages_v = right_tcpip_library ~sublibs:["udp"] "tcpip" in
+  let connect _ modname = function
     | [ ip; _random ] -> Fmt.strf "%s.connect %s" modname ip
     | _  -> failwith (connect_err "udp" 2)
-end
+  in
+  impl ~packages_v ~connect "Udp.Make" (ip @-> random @-> udp)
 
-(* Value restriction ... *)
-let udp_direct_func () = impl (udp_direct_conf ())
 let direct_udp ?(random=default_random) ip = udp_direct_func () $ ip $ random
 
-let udpv4_socket_conf ipv4_key = object
-  inherit base_configurable
-  method ty = udpv4
-  val name = Name.create "udpv4_socket" ~prefix:"udpv4_socket"
-  method name = name
-  method module_name = "Udpv4_socket"
-  method! keys = [ Key.abstract ipv4_key ]
-  method! packages =
-    right_tcpip_library ~sublibs:["udpv4-socket"] "tcpip"
-  method! configure i =
+let udpv4_socket_conf ipv4_key =
+  let keys = [ Key.abstract ipv4_key ] in
+  let packages_v = right_tcpip_library ~sublibs:["udpv4-socket"] "tcpip" in
+  let configure i =
     match get_target i with
     | `Unix | `MacOSX -> R.ok ()
     | _ -> R.error_msg "UDPv4 socket not supported on non-UNIX targets."
-  method! connect _ modname _ = Fmt.strf "%s.connect %a" modname pp_key ipv4_key
-end
+  in
+  let connect _ modname _ = Fmt.strf "%s.connect %a" modname pp_key ipv4_key in
+  impl ~keys ~packages_v ~configure ~connect "Udpv4_socket" udpv4
 
-let socket_udpv4 ?group ip = impl (udpv4_socket_conf @@ Key.V4.socket ?group ip)
+let socket_udpv4 ?group ip = udpv4_socket_conf @@ Key.V4.socket ?group ip

--- a/test/functoria-e2e/app/config.ml
+++ b/test/functoria-e2e/app/config.ml
@@ -1,7 +1,7 @@
 open F0
 module Key = Functoria_key
 
-let main = Functoria.(foreign "App" job)
+let main = Functoria.(main "App" job)
 
 let key =
   let doc = Key.Arg.info ~doc:"How to say hello." ["hello"] in

--- a/test/functoria/gen-1/main.ml.expected
+++ b/test/functoria/gen-1/main.ml.expected
@@ -2,31 +2,31 @@ let (>>=) x f = f x
 let return x = x
 let run x = x
 
-module App1 = App.Make(Key_gen)(Info_gen)
+module App_make__8 = App.Make(Key_gen)(Info_gen)
 
-let argv1 = lazy (
+let sys__2 = lazy (
   return Sys.argv
   )
 
-let key1 = lazy (
-  let __argv1 = Lazy.force argv1 in
-  __argv1 >>= fun _argv1 ->
-  return (Functoria_runtime.with_argv (List.map fst Key_gen.runtime_keys) "foo" _argv1)
+let key_gen__3 = lazy (
+  let __sys__2 = Lazy.force sys__2 in
+  __sys__2 >>= fun _sys__2 ->
+  return (Functoria_runtime.with_argv (List.map fst Key_gen.runtime_keys) "foo" _sys__2)
   )
 
-let info1 = lazy (
+let info_gen__5 = lazy (
   return Info_gen.info
   )
 
-let f11 = lazy (
-  let __key1 = Lazy.force key1 in
-  let __info1 = Lazy.force info1 in
-  __key1 >>= fun _key1 ->
-  __info1 >>= fun _info1 ->
-  App1.start _key1 _info1
+let app_make__8 = lazy (
+  let __key_gen__3 = Lazy.force key_gen__3 in
+  let __info_gen__5 = Lazy.force info_gen__5 in
+  __key_gen__3 >>= fun _key_gen__3 ->
+  __info_gen__5 >>= fun _info_gen__5 ->
+  App_make__8.start _key_gen__3 _info_gen__5
   )
 
 let () =
   let t =
-  Lazy.force f11
+  Lazy.force app_make__8
   in run t

--- a/test/functoria/test.ml
+++ b/test/functoria/test.ml
@@ -1,4 +1,5 @@
 let () = Alcotest.run "functoria" [
     "cli"    , Test_cli.suite;
     "package", Test_package.suite;
+    "graph"  , Test_graph.suite;
   ]

--- a/test/functoria/test_graph.ml
+++ b/test/functoria/test_graph.ml
@@ -1,0 +1,109 @@
+open Functoria
+module Graph = Functoria_graph
+
+let zero = Device.v "z" Functoria.job
+
+let x = Device.v "Foo.Bar" Functoria.job
+let y = Device.v "X.Y" Functoria.(job @-> job)
+let z = Device.v "Bar" job
+
+let apply f d =
+  let id = Device.id d in
+  let g = Graph.create (of_device d) in
+  let v =
+    match Graph.find_all g (function
+        | Graph.Dev d -> Device.id d = id
+        | _ -> false)
+    with [x] -> x | _ -> assert false
+  in
+  f v
+
+let var_name x = apply Graph.var_name x
+let impl_name x = apply Graph.impl_name x
+
+let id () = Scanf.sscanf (var_name zero) "z__%d" (fun i -> i)
+let ident s i x = Fmt.strf "%s__%d" s (i+x)
+
+let test_var_name () =
+  let id = id () in
+  Alcotest.(check string) "x" (ident "foo_bar" id 1) (var_name x);
+  Alcotest.(check string) "y" (ident "x_y" id 2) (var_name y);
+  Alcotest.(check string) "z" (ident "bar" id 3) (var_name z)
+
+let test_impl_name () =
+  let id = id () in
+  Alcotest.(check string) "x" "Foo.Bar" (impl_name x);
+  Alcotest.(check string) "y" (ident "X_y" id 2) (impl_name y);
+  Alcotest.(check string) "z" "Bar" (impl_name z)
+
+let d1 = Device.v ~packages:[package "a"] "Foo.Bar" job
+let d2 = Device.v ~packages:[package "b"] "Foo.Bar" job
+
+let i1 = of_device d1
+let i2 = of_device d2
+
+let if1 = if_impl (Functoria_key.pure true) i1 i2
+let if2 = if_impl (Functoria_key.pure true) i2 i1
+
+let normalise_lines str =
+  let open Astring in
+  let lines = String.cuts ~empty:true ~sep:"\n" str in
+  let lines =
+    List.map (fun line ->
+        if String.for_all Char.Ascii.is_blank line then "" else line
+      ) lines
+  in
+  String.concat ~sep:"\n" lines
+
+let graph_str g = normalise_lines (Fmt.to_to_string Functoria_graph.pp_dot g)
+
+let digraph i =
+  let j = i+1 and k = i+2 in
+  Fmt.str {|digraph G {
+  ordering=out;
+  %d [shape=box, label="foo_bar__%d
+Foo.Bar
+", ];
+  %d [shape=box, label="foo_bar__%d
+Foo.Bar
+", ];
+  %d [label="If
+", ];
+
+
+  %d -> %d [headport=n, style="dotted,bold", ];
+  %d -> %d [headport=n, style="dotted", ];
+
+  }|} i i j j k k i k j
+
+let test_graph () =
+  let id = id () in
+  let t1 = Functoria_graph.create if1 in
+  Alcotest.(check string) "t1.dot" (digraph (id+1)) (graph_str t1);
+  let t2 = Functoria_graph.create if2 in
+  Alcotest.(check string) "t2.dot" (digraph (id+4)) (graph_str t2);
+  let module M = struct
+    type t = (string * string list) list
+    let empty = []
+    let union = List.append
+  end in
+  let packages t =
+    let ctx = Functoria_key.empty_context in
+    Functoria_graph.collect (module M) (function
+      | If _ | App -> []
+      | Functoria_graph.Dev d ->
+        let pkgs = Functoria_key.(eval ctx (Device.packages d)) in
+        List.map (fun pkg ->
+            Functoria_package.name pkg, Functoria_package.libraries pkg
+          ) pkgs
+      ) (Graph.eval ~context:ctx t)
+  in
+  let label = Alcotest.(list (pair string (list string))) in
+  Alcotest.(check label) "t1" ["a", ["a"]] (packages t1);
+  Alcotest.(check label) "t2" ["b", ["b"]] (packages t2)
+
+let suite = [
+  "var_name"  , `Quick, test_var_name;
+  "impl_name" , `Quick, test_impl_name;
+  "test_graph", `Quick, test_graph;
+]

--- a/test/functoria/test_graph.mli
+++ b/test/functoria/test_graph.mli
@@ -1,0 +1,1 @@
+val suite: unit Alcotest.test_case list


### PR DESCRIPTION
Remove objects and classes and clean-up few related things.

This is not ready to be merged yet but `functoria` and `functoria-runtime` seems to compile and their tests pass.