### PR TITLE
Use `version` instead of hard-coding a non-existing upper-bound.

### DIFF
--- a/mirage.opam
+++ b/mirage.opam
@@ -25,7 +25,7 @@ depends: [
   "astring"
   "logs"
   "stdlib-shims"
-  "mirage-runtime"     {>= "3.7.0" & < "3.8.0"}
+  "mirage-runtime"     {>= "3.7.0" & <= version}
 ]
 synopsis: "The MirageOS library operating system"
 description: """


### PR DESCRIPTION
This makes pinning to a `dev` version possible.

/cc @hannesm 

It's a mix between what we had before and your [fix](https://github.com/mirage/mirage/pull/1019): we have some slack to release mirage and mirage-runtime separately while keeping the upper-bound to a known existing version (the current one!)