### PR TITLE
Revise random

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,5 +1,5 @@
 eval `opam config env`
 opam depext -uiy mirage
 cd ~
-git clone https://github.com/mirage/mirage-skeleton.git
+git clone -b random https://github.com/hannesm/mirage-skeleton.git
 make -C mirage-skeleton && rm -rf mirage-skeleton

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,5 +1,5 @@
 eval `opam config env`
 opam depext -uiy mirage
 cd ~
-git clone -b easy https://github.com/hannesm/mirage-skeleton.git
+git clone https://github.com/mirage/mirage-skeleton.git
 make -C mirage-skeleton && rm -rf mirage-skeleton

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -46,10 +46,10 @@ let default_monotonic_clock = Mirage_impl_mclock.default_monotonic_clock
 
 type random = Mirage_impl_random.random
 let random = Mirage_impl_random.random
-let stdlib_random = Mirage_impl_random.stdlib_random
+let stdlib_random = Mirage_impl_random.default_random
 let default_random = Mirage_impl_random.default_random
 let nocrypto = Mirage_impl_random.nocrypto
-let nocrypto_random = Mirage_impl_random.nocrypto_random
+let nocrypto_random = Mirage_impl_random.default_random
 
 type console = Mirage_impl_console.console
 let console = Mirage_impl_console.console

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -120,15 +120,15 @@ val random: random typ
 (** Implementations of the [Mirage_types.RANDOM] signature. *)
 
 val stdlib_random: random impl
+[@@ocaml.deprecated "Mirage will always use a Fortuna PRNG."]
 (** Passthrough to the OCaml Random generator. *)
 
 val nocrypto_random: random impl
+[@@ocaml.deprecated "Mirage will always use a Fortuna PRNG."]
 (** Passthrough to the Fortuna PRNG implemented in nocrypto. *)
 
 val default_random: random impl
-(** Default PRNG device to be used in unikernels.  It defaults to {!stdlib}, but
-    users can override using the {!Key.prng} command line argument.
-*)
+(** Default PRNG device to be used in unikernels. It is a Fortuna PRNG. *)
 
 
 
@@ -458,7 +458,8 @@ val syslog_tls: ?config:syslog_config -> ?keyname:string -> ?console:console imp
 (** {2 Entropy} *)
 
 val nocrypto: job impl
-(** Device that initializes the entropy. *)
+[@@ocaml.deprecated "nocrypto is deprecated and not needed anymore."]
+(** Device that initializes the entropy. Deprecated and unused. *)
 
 (** {2 Conduit configuration} *)
 

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -128,7 +128,8 @@ val nocrypto_random: random impl
 (** Passthrough to the Fortuna PRNG implemented in nocrypto. *)
 
 val default_random: random impl
-(** Default PRNG device to be used in unikernels. It is a Fortuna PRNG. *)
+(** Default PRNG device to be used in unikernels. It uses getrandom/getentropy
+    on Unix, and a Fortuna PRNG on other targets. *)
 
 
 

--- a/lib/mirage_build.ml
+++ b/lib/mirage_build.ml
@@ -6,17 +6,6 @@ open Mirage_link
 module Key = Mirage_key
 module Info = Functoria.Info
 
-let check_entropy libs =
-  query_ocamlfind ~recursive:true libs >>= fun ps ->
-  if List.mem "nocrypto" ps && not (Mirage_impl_random.is_entropy_enabled ()) then
-    R.error_msg
-      {___|The nocrypto library is loaded but entropy is not enabled! \
-       Please enable the entropy by adding a dependency to the nocrypto \
-       device. You can do so by adding ~deps:[abstract nocrypto] \
-       to the arguments of Mirage.foreign.|___}
-  else
-    R.ok ()
-
 let compile ignore_dirs libs warn_error target =
   let tags =
     [ Fmt.strf "predicate(%s)" (backend_predicate target);
@@ -75,7 +64,6 @@ let build i =
   let target = Key.(get ctx target) in
   let libs = Info.libraries i in
   let target_debug = Key.(get ctx target_debug) in
-  check_entropy libs >>= fun () ->
   compile ignore_dirs libs warn_error target >>= fun () ->
   (match target with
     | #Mirage_key.mode_solo5 ->

--- a/lib/mirage_impl_conduit.ml
+++ b/lib/mirage_impl_conduit.ml
@@ -1,6 +1,5 @@
 open Functoria
 open Mirage_impl_conduit_connector
-open Mirage_impl_random
 
 type conduit = Conduit
 let conduit = Type Conduit
@@ -11,7 +10,7 @@ let conduit_with_connectors connectors = impl @@ object
     method name = Functoria_app.Name.create "conduit" ~prefix:"conduit"
     method module_name = "Conduit_mirage"
     method! packages = Mirage_key.pure [ pkg ]
-    method! deps = abstract nocrypto :: List.map abstract connectors
+    method! deps = List.map abstract connectors
 
     method! connect _i _ = function
       (* There is always at least the nocrypto device *)

--- a/lib/mirage_impl_conduit_connector.ml
+++ b/lib/mirage_impl_conduit_connector.ml
@@ -25,7 +25,7 @@ let tls_conduit_connector = impl @@ object
     method module_name = "Conduit_mirage"
     method! packages =
       Mirage_key.pure [
-        package ~min:"0.10.0" ~max:"0.11.0" ~sublibs:["mirage"] "tls" ;
+        package ~min:"0.11.0" ~max:"0.12.0" "tls-mirage" ;
         pkg
       ]
     method! connect _ _ _ = "Lwt.return Conduit_mirage.with_tls"

--- a/lib/mirage_impl_conduit_connector.ml
+++ b/lib/mirage_impl_conduit_connector.ml
@@ -1,6 +1,5 @@
 open Functoria
 open Mirage_impl_misc
-open Mirage_impl_random
 open Mirage_impl_stackv4
 
 type conduit_connector = Conduit_connector
@@ -29,6 +28,5 @@ let tls_conduit_connector = impl @@ object
         package ~min:"0.10.0" ~max:"0.11.0" ~sublibs:["mirage"] "tls" ;
         pkg
       ]
-    method! deps = [ abstract nocrypto ]
     method! connect _ _ _ = "Lwt.return Conduit_mirage.with_tls"
   end

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -3,54 +3,21 @@ open Functoria
 type random = RANDOM
 let random = Type RANDOM
 
-let stdlib_random_conf = object
+let random_conf = object
   inherit base_configurable
   method ty = random
   method name = "random"
-  method module_name = "Mirage_random_stdlib"
+  method module_name = "Mirage_crypto_rng"
   method! packages =
-    Mirage_key.pure [ package ~min:"0.1.0" ~max:"1.0.0" "mirage-random-stdlib" ]
-  method! connect _ modname _ = Fmt.strf "%s.initialize ()" modname
+    Mirage_key.pure [
+      package "mirage-crypto-rng" ;
+      package ~min:"1.0.0" "mirage-entropy" ;
+    ]
+  method! connect _ _ _ =
+    (* here we could use the boot argument to select the RNG! *)
+    "Entropy.connect (module Mirage_crypto_rng.Fortuna)"
 end
 
-let stdlib_random = impl stdlib_random_conf
+let default_random = impl random_conf
 
-(* This is to check that entropy is a dependency if "tls" is in
-   the package array. *)
-let enable_entropy, is_entropy_enabled =
-  let r = ref false in
-  let f () = r := true in
-  let g () = !r in
-  (f, g)
-
-let nocrypto = impl @@ object
-    inherit base_configurable
-    method ty = job
-    method name = "nocrypto"
-    method module_name = "Nocrypto_entropy"
-    method! packages =
-      Mirage_key.pure
-        [ package ~min:"0.5.4-2" ~max:"0.6.0" ~sublibs:["mirage"] "nocrypto" ;
-          package ~min:"0.5.0" ~max:"0.6.0" "mirage-entropy" ]
-
-    method! build _ = Rresult.R.ok (enable_entropy ())
-    method! connect _ _ _ = "Nocrypto_entropy_mirage.initialize ()"
-  end
-
-let nocrypto_random_conf = object
-  inherit base_configurable
-  method ty = random
-  method name = "random"
-  method module_name = "Nocrypto.Rng"
-  method! packages =
-    Mirage_key.pure [ package ~min:"0.5.4-2" ~max:"0.6.0" "nocrypto" ]
-  method! deps = [abstract nocrypto]
-end
-
-let nocrypto_random = impl nocrypto_random_conf
-
-let default_random =
-  match_impl (Mirage_key.value Mirage_key.prng) [
-    `Stdlib  , stdlib_random;
-    `Nocrypto, nocrypto_random;
-  ] ~default:stdlib_random
+let nocrypto = Functoria_app.noop

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -12,15 +12,14 @@ let random_conf = object
   method! packages =
     Mirage_key.(if_ is_unix)
       [ package ~sublibs:["unix"] "mirage-crypto-rng" ]
-      [ package "mirage-crypto-rng" ;
-        package ~min:"1.0.0" "mirage-entropy" ]
+      [ package "mirage-crypto-entropy" ]
   method! connect i _ _ =
     match get_target i with
     | #Mirage_key.mode_unix ->
       "Lwt.return (Mirage_crypto_rng_unix.initialize ())"
     | _ ->
       (* here we could use the boot argument to select the RNG! *)
-      "Entropy.connect (module Mirage_crypto_rng.Fortuna)"
+      "Mirage_crypto_entropy.initialize (module Mirage_crypto_rng.Fortuna)"
 end
 
 let default_random = impl random_conf

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -1,4 +1,5 @@
 open Functoria
+open Mirage_impl_misc
 
 type random = RANDOM
 let random = Type RANDOM
@@ -9,13 +10,17 @@ let random_conf = object
   method name = "random"
   method module_name = "Mirage_crypto_rng"
   method! packages =
-    Mirage_key.pure [
-      package "mirage-crypto-rng" ;
-      package ~min:"1.0.0" "mirage-entropy" ;
-    ]
-  method! connect _ _ _ =
-    (* here we could use the boot argument to select the RNG! *)
-    "Entropy.connect (module Mirage_crypto_rng.Fortuna)"
+    Mirage_key.(if_ is_unix)
+      [ package ~sublibs:["unix"] "mirage-crypto-rng" ]
+      [ package "mirage-crypto-rng" ;
+        package ~min:"1.0.0" "mirage-entropy" ]
+  method! connect i _ _ =
+    match get_target i with
+    | #Mirage_key.mode_unix ->
+      "Lwt.return (Mirage_crypto_rng_unix.initialize ())"
+    | _ ->
+      (* here we could use the boot argument to select the RNG! *)
+      "Entropy.connect (module Mirage_crypto_rng.Fortuna)"
 end
 
 let default_random = impl random_conf

--- a/lib/mirage_impl_random.ml
+++ b/lib/mirage_impl_random.ml
@@ -9,6 +9,7 @@ let random_conf = object
   method ty = random
   method name = "random"
   method module_name = "Mirage_crypto_rng"
+  method! keys = [ Mirage_key.(abstract prng) ]
   method! packages =
     Mirage_key.(if_ is_unix)
       [ package ~sublibs:["unix"] "mirage-crypto-rng" ]
@@ -18,7 +19,7 @@ let random_conf = object
     | #Mirage_key.mode_unix ->
       "Lwt.return (Mirage_crypto_rng_unix.initialize ())"
     | _ ->
-      (* here we could use the boot argument to select the RNG! *)
+      (* here we could use the boot argument (--prng) to select the RNG! *)
       "Mirage_crypto_entropy.initialize (module Mirage_crypto_rng.Fortuna)"
 end
 

--- a/lib/mirage_impl_random.mli
+++ b/lib/mirage_impl_random.mli
@@ -2,12 +2,6 @@ type random
 
 val random : random Functoria.typ
 
-val stdlib_random : random Functoria.impl
-
 val default_random : random Functoria.impl
 
 val nocrypto : Functoria.job Functoria.impl
-
-val nocrypto_random : random Functoria.impl
-
-val is_entropy_enabled : unit -> bool

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -276,8 +276,8 @@ let prng =
     Fmt.strf
       "This boot parameter is deprecated. A Fortuna PRNG \
        (https://en.wikipedia.org/wiki/Fortuna_(PRNG)) will always be used. \
-       The mirage-entropy (https://github.com/mirage/mirage-entropy) opam \
-       package feeds entropy to Fortuna."
+       The mirage-crypto-entropy (https://github.com/mirage/mirage-crypto) \
+       opam package feeds entropy to Fortuna."
   in
   create_simple ~doc ~stage:`Configure ~default:`Stdlib conv "prng"
 

--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -274,11 +274,10 @@ let prng =
   let conv = Arg.conv ~conv ~serialize ~runtime_conv:"prng" in
   let doc =
     Fmt.strf
-      "Use the $(i,stdlib), a lagged-Fibonacci PRNG \
-       (not cryptographically secure), or $(i,fortuna), a Fortuna PRNG \
-       (https://en.wikipedia.org/wiki/Fortuna_(PRNG)). \
-       The selected PRNG is seeded by mirage-entropy \
-       (https://github.com/mirage/mirage-entropy)."
+      "This boot parameter is deprecated. A Fortuna PRNG \
+       (https://en.wikipedia.org/wiki/Fortuna_(PRNG)) will always be used. \
+       The mirage-entropy (https://github.com/mirage/mirage-entropy) opam \
+       package feeds entropy to Fortuna."
   in
   create_simple ~doc ~stage:`Configure ~default:`Stdlib conv "prng"
 

--- a/mirage.opam
+++ b/mirage.opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.1.0"}
   "ipaddr"             {>= "3.0.0"}
-  "functoria"          {>= "3.0.2"}
+  "functoria"          {>= "3.1.0"}
   "bos"
   "astring"
   "logs"


### PR DESCRIPTION
please see discussion at https://github.com/mirage/mirage-crypto/issues/6

this is a PR against the 3.7 branch. this PR is backwards compatible, but the choice of `--prng` (=nocrypto/fortuna/stdlib) does not have any effect. instead, Fortuna will always be used.