### PR TITLE
Fix functoria-runtime tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,4 @@ doc:
 
 test:
 	dune runtest
+	INSIDE_FUNCTORIA_TESTS=1 dune exec -- test/functoria-e2e/test.exe

--- a/test/functoria-query/install.expected
+++ b/test/functoria-query/install.expected
@@ -1,5 +1,5 @@
 bin: [
-  "_build/default/test/functoria-query/main.exe" {"noop"}
+  "test/functoria-query/main.exe" {"noop"}
 ]
 etc: [
   "test/functoria-query/vote" {"vote"}


### PR DESCRIPTION
The CI wasn't testing these tests anymore (as it switched to use `dune runtest` instead of `opam install -t`) so the breakage went unoticed.

These tests really need to be ported to dune (currently not possible to do this directly as they are recursively calling dune).