### PR TITLE
functoria: remove the --build-dir command-line option

### DIFF
--- a/lib/functoria/cli.mli
+++ b/lib/functoria/cli.mli
@@ -23,7 +23,6 @@ open Cmdliner
 type 'a args = {
   context : 'a;
   config_file : Fpath.t;
-  build_dir : Fpath.t option;
   output : string option;
   dry_run : bool;
 }
@@ -84,7 +83,7 @@ val pp_action : 'a Fmt.t -> 'a action Fmt.t
 val args : 'a action -> 'a args
 (** [args a] are [a]'s global arguments. *)
 
-(** {Evalutation} *)
+(** {1 Evalutation} *)
 
 val eval :
   ?with_setup:bool ->

--- a/lib/functoria/info.ml
+++ b/lib/functoria/info.ml
@@ -21,7 +21,6 @@ open Astring
 type t = {
   name : string;
   output : string option;
-  build_dir : Fpath.t;
   keys : Key.Set.t;
   context : Key.context;
   packages : Package.t String.Map.t;
@@ -35,8 +34,6 @@ let main t =
   Fpath.v (main ^ ".ml")
 
 let opam t = t.opam
-
-let build_dir t = t.build_dir
 
 let output t = t.output
 
@@ -68,7 +65,7 @@ let keys t = Key.Set.elements t.keys
 
 let context t = t.context
 
-let v ~packages ~keys ~context ~build_dir ~build_cmd ~src name =
+let v ~packages ~keys ~context ~build_cmd ~src name =
   let keys = Key.Set.of_list keys in
   let opam =
     Opam.v ~depends:packages ~pins:(pins packages) ~build:build_cmd ~src name
@@ -85,16 +82,15 @@ let v ~packages ~keys ~context ~build_dir ~build_cmd ~src name =
             | None -> m ))
       String.Map.empty packages
   in
-  { name; build_dir; keys; packages; context; output = None; opam }
+  { name; keys; packages; context; output = None; opam }
 
 let pp_packages ?(surround = "") ?sep ppf t =
   Fmt.pf ppf "%a" (Fmt.iter ?sep List.iter (Package.pp ~surround)) (packages t)
 
-let pp verbose ppf ({ name; build_dir; keys; context; output; _ } as t) =
+let pp verbose ppf ({ name; keys; context; output; _ } as t) =
   let show name = Fmt.pf ppf "@[<2>%s@ %a@]@," name in
   let list = Fmt.iter ~sep:(Fmt.unit ",@ ") List.iter Fmt.string in
   show "Name      " Fmt.string name;
-  show "Build-dir " Fpath.pp build_dir;
   show "Keys      " (Key.pps context) keys;
   show "Output    " Fmt.(option string) output;
   if verbose then show "Libraries " list (libraries t);
@@ -111,9 +107,8 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 let t =
   let i =
-    v ~packages:[] ~keys:[] ~context:Key.empty_context ~build_cmd:[]
-      ~build_dir:Fpath.(v "dummy")
-      ~src:`None "dummy"
+    v ~packages:[] ~keys:[] ~context:Key.empty_context ~build_cmd:[] ~src:`None
+      "dummy"
   in
   Type.v i
 

--- a/lib/functoria/info.mli
+++ b/lib/functoria/info.mli
@@ -33,9 +33,6 @@ val output : t -> string option
 val with_output : t -> string -> t
 (** [with_output t o] is similar to [t] but with the output set to [Some o]. *)
 
-val build_dir : t -> Fpath.t
-(** Directory in which the build is done. *)
-
 val libraries : t -> string list
 (** [libraries t] are the direct OCamlfind dependencies. *)
 
@@ -58,7 +55,6 @@ val v :
   packages:Package.t list ->
   keys:Key.t list ->
   context:Key.context ->
-  build_dir:Fpath.t ->
   build_cmd:string list ->
   src:[ `Auto | `None | `Some of string ] ->
   string ->

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -604,7 +604,6 @@ module FS : sig
   val fat_shell_script :
     Format.formatter ->
     block_file:string ->
-    root:Fpath.t ->
     dir:Fpath.t ->
     regexp:string ->
     unit

--- a/lib/mirage/mirage_configure.ml
+++ b/lib/mirage/mirage_configure.ml
@@ -72,7 +72,6 @@ let configure_opam ~name info =
 
 let configure i =
   let name = Info.name i in
-  let root = Fpath.to_string (Info.build_dir i) in
   let ctx = Info.context i in
   let target = Key.(get ctx target) in
   Log.info (fun m -> m "Configuring for target: %a" Key.pp_target target);
@@ -95,7 +94,7 @@ let configure i =
   | `Xen ->
       configure_main_xl ~ext:"xl" i >>= fun () ->
       configure_main_xl ~substitutions:[] ~ext:"xl.in" i >>= fun () ->
-      configure_main_xe ~root ~name >>= fun () ->
-      Mirage_configure_libvirt.configure_main ~root ~name
-  | `Virtio -> Mirage_configure_libvirt.configure_virtio ~root ~name
+      configure_main_xe ~name >>= fun () ->
+      Mirage_configure_libvirt.configure_main ~name
+  | `Virtio -> Mirage_configure_libvirt.configure_virtio ~name
   | _ -> Action.ok ()

--- a/lib/mirage/mirage_configure_libvirt.ml
+++ b/lib/mirage/mirage_configure_libvirt.ml
@@ -5,7 +5,7 @@ let filename ~name = Fpath.(v (name ^ "_libvirt") + "xml")
 
 let append fmt s = Fmt.pf fmt (s ^^ "@.")
 
-let configure_main ~root ~name =
+let configure_main ~name =
   let open Codegen in
   Action.with_output ~path:(filename ~name) ~purpose:"libvirt.xml" (fun fmt ->
       append fmt "<!-- %s -->" (generated_header ());
@@ -16,7 +16,7 @@ let configure_main ~root ~name =
       append fmt "    <vcpu placement='static'>1</vcpu>";
       append fmt "    <os>";
       append fmt "        <type arch='armv7l' machine='xenpv'>linux</type>";
-      append fmt "        <kernel>%s/%s.xen</kernel>" root name;
+      append fmt "        <kernel>%s.xen</kernel>" name;
       append fmt "        <cmdline> </cmdline>";
       (* the libxl driver currently needs an empty cmdline to be able to
            start the domain on arm - due to this?
@@ -56,7 +56,7 @@ let configure_main ~root ~name =
       append fmt "    </devices>";
       append fmt "</domain>")
 
-let configure_virtio ~root ~name =
+let configure_virtio ~name =
   let open Codegen in
   Action.with_output ~path:(filename ~name) ~purpose:"libvirt.xml" (fun fmt ->
       append fmt "<!-- %s -->" (generated_header ());
@@ -67,7 +67,7 @@ let configure_virtio ~root ~name =
       append fmt "    <vcpu placement='static'>1</vcpu>";
       append fmt "    <os>";
       append fmt "        <type arch='x86_64' machine='pc'>hvm</type>";
-      append fmt "        <kernel>%s/%s.virtio</kernel>" root name;
+      append fmt "        <kernel>%s.virtio</kernel>" name;
       append fmt "        <!-- Command line arguments can be given if required:";
       append fmt "        <cmdline>-l *:debug</cmdline>";
       append fmt "        -->";

--- a/lib/mirage/mirage_configure_libvirt.mli
+++ b/lib/mirage/mirage_configure_libvirt.mli
@@ -2,8 +2,8 @@ open Functoria
 
 val filename : name:string -> Fpath.t
 
-val configure_main : root:string -> name:string -> unit Action.t
+val configure_main : name:string -> unit Action.t
 
-val configure_virtio : root:string -> name:string -> unit Action.t
+val configure_virtio : name:string -> unit Action.t
 
 val clean : name:string -> unit Action.t

--- a/lib/mirage/mirage_configure_xen.mli
+++ b/lib/mirage/mirage_configure_xen.mli
@@ -23,6 +23,6 @@ val configure_main_xl :
 
 val clean_main_xl : name:string -> ext:string -> unit Action.t
 
-val configure_main_xe : root:string -> name:string -> unit Action.t
+val configure_main_xe : name:string -> unit Action.t
 
 val clean_main_xe : name:string -> unit Action.t

--- a/lib/mirage/mirage_impl_block.ml
+++ b/lib/mirage/mirage_impl_block.ml
@@ -53,10 +53,9 @@ let xenstore_id_of_index number =
   else (1 lsl 28) lor (number lsl 8)
 
 let block_conf file =
-  let connect_name target root =
+  let connect_name target =
     match target with
-    | #Mirage_key.mode_unix ->
-        Fpath.(to_string (root / file)) (* open the file directly *)
+    | #Mirage_key.mode_unix -> file (* open the file directly *)
     | #Mirage_key.mode_xen ->
         let b = make_block_t file in
         xenstore_id_of_index b.number |> string_of_int
@@ -80,9 +79,7 @@ let block_conf file =
   let connect i s _ =
     match get_target i with
     | `Muen -> failwith "Block devices not supported on Muen target."
-    | _ ->
-        Fmt.strf "%s.connect %S" s
-          (connect_name (get_target i) @@ Info.build_dir i)
+    | _ -> Fmt.strf "%s.connect %S" s (connect_name (get_target i))
   in
   Device.v ~configure ~packages_v ~connect "Block" block
 

--- a/lib/mirage/mirage_impl_fs.mli
+++ b/lib/mirage/mirage_impl_fs.mli
@@ -15,9 +15,4 @@ val generic_kv_ro :
   Mirage_impl_kv.ro Functoria.impl
 
 val fat_shell_script :
-  Format.formatter ->
-  block_file:string ->
-  root:Fpath.t ->
-  dir:Fpath.t ->
-  regexp:string ->
-  unit
+  Format.formatter -> block_file:string -> dir:Fpath.t -> regexp:string -> unit

--- a/lib/mirage/mirage_impl_kv.ml
+++ b/lib/mirage/mirage_impl_kv.ml
@@ -33,10 +33,7 @@ let crunch dirname =
 
 let direct_kv_ro dirname =
   let packages = [ package ~min:"2.1.0" ~max:"3.0.0" "mirage-kv-unix" ] in
-  let connect i modname _names =
-    let path = Fpath.(Info.build_dir i / dirname) in
-    Fmt.strf "%s.connect \"%a\"" modname Fpath.pp path
-  in
+  let connect _ modname _names = Fmt.strf "%s.connect \"%s\"" modname dirname in
   impl ~packages ~connect "Mirage_kv_unix" ro
 
 let direct_kv_ro dirname =
@@ -59,10 +56,7 @@ let rw = Type.v RW
 
 let direct_kv_rw dirname =
   let packages = [ package ~min:"2.1.0" ~max:"3.0.0" "mirage-kv-unix" ] in
-  let connect i modname _names =
-    let path = Fpath.(Info.build_dir i / dirname) in
-    Fmt.strf "%s.connect \"%a\"" modname Fpath.pp path
-  in
+  let connect _ modname _names = Fmt.strf "%s.connect \"%s\"" modname dirname in
   impl ~packages ~connect "Mirage_kv_unix" rw
 
 let mem_kv_rw_config =

--- a/test/functoria-test/functoria_test.ml
+++ b/test/functoria-test/functoria_test.ml
@@ -19,7 +19,7 @@ let run ?(keys = []) ?init context device =
   let packages = Key.eval context (Engine.packages t) in
   let info =
     Functoria.Info.v ~packages ~context ~keys ~build_cmd:[ "build"; "me" ]
-      ~build_dir:(Fpath.v ".") ~src:`None "foo"
+      ~src:`None "foo"
   in
   prelude info >>= fun () ->
   Engine.configure info t >>= fun () ->

--- a/test/functoria/help/configure-help.out.expected
+++ b/test/functoria/help/configure-help.out.expected
@@ -8,9 +8,6 @@ DESCRIPTION
        The configure command initializes a fresh test application.
 
 CONFIGURE OPTIONS
-       -b DIR, --build-dir=DIR
-           The directory where the build is done.
-
        --dry-run
            Display I/O actions instead of executing them.
 

--- a/test/functoria/help/help-configure.out.expected
+++ b/test/functoria/help/help-configure.out.expected
@@ -8,9 +8,6 @@ DESCRIPTION
        The configure command initializes a fresh test application.
 
 CONFIGURE OPTIONS
-       -b DIR, --build-dir=DIR
-           The directory where the build is done.
-
        --dry-run
            Display I/O actions instead of executing them.
 

--- a/test/functoria/test_cli.ml
+++ b/test/functoria/test_cli.ml
@@ -42,7 +42,6 @@ let test_configure () =
            context = (true, false);
            output = None;
            config_file = Fpath.v "config.ml";
-           build_dir = None;
            dry_run = false;
          }))
     result
@@ -77,7 +76,6 @@ let test_describe () =
                context = (false, true);
                output = None;
                config_file = Fpath.v "config.ml";
-               build_dir = None;
                dry_run = false;
              };
            dotcmd = "dot";
@@ -107,7 +105,6 @@ let test_build () =
            context = (true, true);
            output = None;
            config_file = Fpath.v "config.ml";
-           build_dir = None;
            dry_run = false;
          }))
     result
@@ -132,7 +129,6 @@ let test_clean () =
            context = (false, false);
            output = None;
            config_file = Fpath.v "config.ml";
-           build_dir = None;
            dry_run = false;
          }))
     result
@@ -178,7 +174,6 @@ let test_peek () =
          {
            context = ();
            output = Some "bar";
-           build_dir = None;
            config_file = Fpath.v "config.ml";
            dry_run = false;
          }))
@@ -197,7 +192,6 @@ let test_peek () =
          {
            context = ();
            output = None;
-           build_dir = None;
            config_file = Fpath.v "bar";
            dry_run = true;
          }))

--- a/test/mirage-fat-shell-script/test.expected
+++ b/test/mirage-fat-shell-script/test.expected
@@ -15,7 +15,7 @@ fi
 
 IMG=$(pwd)/BLOCK_FILE
 rm -f ${IMG}
-cd ROOT/DIR
+cd DIR
 SIZE=$(du -s . | cut -f 1)
 ${FAT} create ${IMG} ${SIZE}KiB
 ${FAT} add ${IMG} REGEXP

--- a/test/mirage-fat-shell-script/test.ml
+++ b/test/mirage-fat-shell-script/test.ml
@@ -21,8 +21,8 @@ let print_banner s =
   print_newline ()
 
 let test_output_fat =
-  Mirage.FS.fat_shell_script ~block_file:"BLOCK_FILE" ~root:(Fpath.v "ROOT")
-    ~dir:(Fpath.v "DIR") ~regexp:"REGEXP"
+  Mirage.FS.fat_shell_script ~block_file:"BLOCK_FILE" ~dir:(Fpath.v "DIR")
+    ~regexp:"REGEXP"
 
 let () =
   let tests = [ ("output_fat", test_output_fat) ] in

--- a/test/mirage/action/test.ml
+++ b/test/mirage/action/test.ml
@@ -17,7 +17,7 @@ let print_banner s =
 
 let info context =
   Info.v ~packages:[] ~keys:[] ~context ~src:`None
-    ~build_cmd:[ "mirage"; "build" ] ~build_dir:(Fpath.v "BUILD_DIR") "NAME"
+    ~build_cmd:[ "mirage"; "build" ] "NAME"
 
 let test target =
   print_banner target;


### PR DESCRIPTION
This is not used anywhere and it makes it very hard to change the build logic.

This is extracted from #1085 

/cc @hannesm to double-check that this option is indeed not used/useful.