### PR TITLE
functoria: remove the [ignore_dirs] parameter

### DIFF
--- a/lib/functoria/app.ml
+++ b/lib/functoria/app.ml
@@ -88,8 +88,6 @@ module type S = sig
 
   val packages : package list
 
-  val ignore_dirs : string list
-
   val version : string
 
   val create : job impl list -> job impl

--- a/lib/functoria/app.mli
+++ b/lib/functoria/app.mli
@@ -39,9 +39,6 @@ module type S = sig
   val packages : package list
   (** The packages to load when compiling the configuration file. *)
 
-  val ignore_dirs : string list
-  (** Directories to ignore when compiling the configuration file. *)
-
   val version : string
   (** Version of the custom DSL. *)
 

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -315,8 +315,6 @@ module Project = struct
   (* The ocamlfind packages to use when compiling config.ml *)
   let packages = [ package "mirage" ]
 
-  let ignore_dirs = Mirage_build.ignore_dirs
-
   let bin ~name = function
     | #Mirage_key.mode_solo5 as tgt ->
         let ext = snd (Mirage_configure_solo5.solo5_pkg tgt) in

--- a/lib/mirage/mirage_build.mli
+++ b/lib/mirage/mirage_build.mli
@@ -1,7 +1,5 @@
 open Functoria
 
-val ignore_dirs : string list
-
 val compile :
   string list -> string list -> bool -> Mirage_key.mode -> unit Action.t
 

--- a/test/f0/f0.ml
+++ b/test/f0/f0.ml
@@ -55,8 +55,6 @@ module C = struct
 
   let packages = [ Functoria.package "functoria"; Functoria.package "f0" ]
 
-  let ignore_dirs = []
-
   let keys = Key.[ v vote; v warn_error ]
 
   let connect _ _ _ = "()"


### PR DESCRIPTION
It is not used anymore (since config.ml got compiled with dune) and
none complained so I guess nobody used it. (note: it's still used by 
ocamlbuild to build the mirage projects)

Extracted from #1085 