### PR TITLE
functoria: only `<tool> configure' should save the context cache

### DIFF
--- a/test/functoria/query/files-configure.expected
+++ b/test/functoria/query/files-configure.expected
@@ -1,1 +1,1 @@
-.test.config dune.build key_gen.ml main.ml
+dune.build key_gen.ml main.ml

--- a/test/functoria/tool/clean.err.expected
+++ b/test/functoria/tool/clean.err.expected
@@ -10,5 +10,6 @@
 * Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
 * Run_cmd 'dune exec --root . -- ./config.exe clean a b c --dry-run' (ok: out="[...]" err="")
 * Ls ./ (0 entry)
+* Rm .test.config (no-op)
 * Get_var INSIDE_FUNCTORIA_TESTS -> <not set>
 * Rmdir _build (no-op)

--- a/test/functoria/tool/configure-help.err.expected
+++ b/test/functoria/tool/configure-help.err.expected
@@ -8,6 +8,7 @@
                Is_file? dune -> true
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
+* Write to .test.config (25 bytes)
 * Run_cmd 'dune exec --root . -- ./config.exe configure help --dry-run' (ok: out="[...]" err="")
 * Run_cmd 'dune exec --root . -- ./config.exe query name help --dry-run' (ok: out="[...]" err="")
 * Run_cmd 'dune exec --root . -- ./config.exe query opam help --dry-run' (ok: out="[...]" err="")

--- a/test/functoria/tool/configure.err.expected
+++ b/test/functoria/tool/configure.err.expected
@@ -8,6 +8,7 @@
                Is_file? dune -> true
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
+* Write to .test.config (26 bytes)
 * Run_cmd 'dune exec --root . -- ./config.exe configure a b c --dry-run' (ok: out="[...]" err="")
 * Run_cmd 'dune exec --root . -- ./config.exe query name a b c --dry-run' (ok: out="[...]" err="")
 * Run_cmd 'dune exec --root . -- ./config.exe query opam a b c --dry-run' (ok: out="[...]" err="")


### PR DESCRIPTION
Extracted from #1085 and #1118 