### PR TITLE
functoria: fix `configure --help' vs. `help configure'

### DIFF
--- a/lib/functoria/cli.ml
+++ b/lib/functoria/cli.ml
@@ -345,8 +345,10 @@ module Subcommands = struct
           | `Ok t -> `Help (man_format, Some t) )
     in
     ( Term.(
-        const (fun args () -> Help args)
+        const (fun args _ _ () -> Help args)
         $ args ~with_setup context
+        $ depext configuration_section
+        $ full_eval
         $ ret (const help $ Term.man_format $ Term.choice_names $ topic)),
       Term.info "help" ~doc:"Display help about $(mname) commands."
         ~man:

--- a/test/functoria/help/dune
+++ b/test/functoria/help/dune
@@ -40,4 +40,4 @@
  (alias runtest)
  (package functoria)
  (action
-  (diff configure-help.out.expected help-configure.out)))
+  (diff configure-help.out help-configure.out)))


### PR DESCRIPTION
Fix the e2e tests