### PR TITLE
functoria: simplify re-exec of query commands

### DIFF
--- a/lib/functoria/cli.mli
+++ b/lib/functoria/cli.mli
@@ -59,6 +59,9 @@ type query_kind =
   | `Files of [ `Configure | `Build ]
   | `Makefile ]
 
+val pp_query_kind : query_kind Fmt.t
+(** [pp_query_kind] is the pretty-printer for query kinds. *)
+
 type 'a query_args = { args : 'a args; kind : query_kind; depext : bool }
 (** The type for arguments of the [query] sub-command. *)
 
@@ -120,23 +123,3 @@ type 'a result =
 
 val peek : ?with_setup:bool -> string array -> unit result
 (** [peek] is the same as {!eval} but without failing on unknown arguments. *)
-
-(** {1 Argv Transformers} *)
-
-type choice =
-  [ `Configure
-  | `Build
-  | `Clean
-  | `Query of query_kind option
-  | `Describe
-  | `Help ]
-(** The type for sub-command choices. *)
-
-val pp_choice : choice Fmt.t
-(** [pp_choice] is a pretty-printer for choices. *)
-
-val map_choice :
-  (choice option -> choice option) -> string array -> string array
-(** [map_choice f argv] is [argv] where the sub-command have been changed by
-    applying [f]. Raise [Invalid_argument] if the sub-command names are
-    ambiguous. *)

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -67,9 +67,9 @@ module Make (P : S) = struct
     let ppf = Fmt.with_buffer buf in
     re_exec t ~ppf ?err_ppf argv >|= fun () -> Buffer.contents buf
 
-  let query k t ?err_ppf argv =
-    let argv = Cli.map_choice (fun _ -> Some (`Query (Some k))) argv in
-    re_exec_out t ?err_ppf argv
+  let query k t ?err_ppf _argv =
+    re_exec_out t ?err_ppf
+      [| ""; "query"; Fmt.to_to_string Cli.pp_query_kind k |]
 
   (* Generate a `dune.config` file in the build directory. *)
   let generate_dune_config t =

--- a/test/functoria/test_cli.ml
+++ b/test/functoria/test_cli.ml
@@ -186,67 +186,6 @@ let test_read_full_eval () =
   check "--eval test --no-eval" (Some false)
     (Cli.peek_full_eval [| "--eval"; "test"; "--no-eval" |])
 
-let test_map_choice () =
-  let test = Alcotest.(check (array string)) in
-  let cmd x =
-    match x with
-    | "" -> [| "test"; "-v"; "bar"; "--foo" |]
-    | _ -> [| "test"; x; "-v"; "bar"; "--foo" |]
-  in
-
-  test "replace (existing)" (cmd "configure")
-    (Cli.map_choice
-       (function
-         | Some `Build -> Some `Configure
-         | x -> Alcotest.failf "bad choice: " Cli.pp_choice x)
-       (cmd "build"));
-
-  test "replace (query no args)" (cmd "configure")
-    (Cli.map_choice
-       (function
-         | Some (`Query None) -> Some `Configure
-         | x -> Alcotest.failf "bad choice: " Cli.pp_choice x)
-       (cmd "query"));
-
-  test "remove build"
-    [| "test"; "-v"; "bar"; "--foo" |]
-    (Cli.map_choice
-       (function
-         | Some `Build -> None
-         | x -> Alcotest.failf "bad choice: " Cli.pp_choice x)
-       (cmd "build"));
-
-  test "replace (query with args)" (cmd "configure")
-    (Cli.map_choice
-       (function
-         | Some (`Query (Some _)) -> Some `Configure
-         | x -> Alcotest.failf "bad choice: " Cli.pp_choice x)
-       [| "test"; "query"; "-v"; "bar"; "opam"; "--foo" |]);
-
-  test "remove query" (cmd "")
-    (Cli.map_choice
-       (function
-         | Some (`Query (Some _)) -> None
-         | x -> Alcotest.failf "bad choice: " Cli.pp_choice x)
-       [| "test"; "query"; "-v"; "bar"; "opam"; "--foo" |]);
-
-  test "add configure" (cmd "configure")
-    (Cli.map_choice
-       (function
-         | None -> Some `Configure
-         | x -> Alcotest.failf "bad choice: " Cli.pp_choice x)
-       [| "test"; "-v"; "bar"; "--foo" |]);
-
-  test "replace (no-op)" (cmd "-x")
-    (Cli.map_choice
-       (function None -> None | Some _ -> Alcotest.fail "bad choice")
-       (cmd "-x"));
-
-  try
-    let _ = Cli.map_choice (fun _ -> None) [| ""; "c" |] in
-    Alcotest.fail "an error should be raised"
-  with Invalid_argument _ -> ()
-
 let suite =
   [
     ("read_full_eval", `Quick, test_read_full_eval);
@@ -256,5 +195,4 @@ let suite =
     ("clean", `Quick, test_clean);
     ("help", `Quick, test_help);
     ("default", `Quick, test_default);
-    ("map_choice", `Quick, test_map_choice);
   ]

--- a/test/functoria/tool/configure-help.err.expected
+++ b/test/functoria/tool/configure-help.err.expected
@@ -10,11 +10,11 @@
 * Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
 * Write to .test.config (25 bytes)
 * Run_cmd 'dune exec --root . -- ./config.exe configure help --dry-run' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe query name help --dry-run' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe query opam help --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune exec --root . -- ./config.exe query name' (ok: out="[...]" err="")
+* Run_cmd 'dune exec --root . -- ./config.exe query opam' (ok: out="[...]" err="")
 * Is_file? [...].opam -> false
 * Write to [...].opam (35 bytes)
-* Run_cmd 'dune exec --root . -- ./config.exe query install help --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune exec --root . -- ./config.exe query install' (ok: out="[...]" err="")
 * Is_file? [...].install -> false
 * Write to [...].install (35 bytes)
 * Is_file? Makefile -> false

--- a/test/functoria/tool/configure.err.expected
+++ b/test/functoria/tool/configure.err.expected
@@ -10,11 +10,11 @@
 * Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
 * Write to .test.config (26 bytes)
 * Run_cmd 'dune exec --root . -- ./config.exe configure a b c --dry-run' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe query name a b c --dry-run' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe query opam a b c --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune exec --root . -- ./config.exe query name' (ok: out="[...]" err="")
+* Run_cmd 'dune exec --root . -- ./config.exe query opam' (ok: out="[...]" err="")
 * Is_file? [...].opam -> false
 * Write to [...].opam (35 bytes)
-* Run_cmd 'dune exec --root . -- ./config.exe query install a b c --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune exec --root . -- ./config.exe query install' (ok: out="[...]" err="")
 * Is_file? [...].install -> false
 * Write to [...].install (35 bytes)
 * Is_file? Makefile -> false


### PR DESCRIPTION
It is not necessary to pass all the arguments as the context has been cached
already.

Extracted from #1085 