### PR TITLE
mirage: --depext is now part of functoria

### DIFF
--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -338,7 +338,7 @@ module Project = struct
     Install.v ~bin:[ bin ~name k ] ~etc:(etc ~name k) ()
 
   let create jobs =
-    let keys = Key.[ v target; v warn_error; v target_debug; v no_depext ] in
+    let keys = Key.[ v target; v warn_error; v target_debug ] in
     let packages_v =
       (* XXX: use %%VERSION_NUM%% here instead of hardcoding a version? *)
       let min = "3.7.0" and max = "3.8.0" in

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -190,12 +190,6 @@ let target_debug =
   let key = Arg.flag ~stage:`Configure doc in
   Key.create "target_debug" key
 
-let no_depext =
-  let doc = "Disable call to depext when generating Makefile." in
-  let doc = Arg.info ~docs:mirage_section ~docv:"BOOL" ~doc [ "no-depext" ] in
-  let key = Arg.flag ~stage:`Configure doc in
-  Key.create "no_depext" key
-
 (** {3 Tracing} *)
 
 let tracing_size default =

--- a/lib/mirage/mirage_key.mli
+++ b/lib/mirage/mirage_key.mli
@@ -70,9 +70,6 @@ val warn_error : bool key
 val target_debug : bool key
 (** [-g]. Enables target-specific support for debugging. *)
 
-val no_depext : bool key
-(** [--no-depext]. Disables opam depext in depend target of generated Makefile. *)
-
 val tracing_size : int -> int key
 (** [--tracing-size]: Key setting the tracing ring buffer size. *)
 


### PR DESCRIPTION
Follow-up of #1124 (and extracted from #1085)