### PR TITLE
functoria: use --depext by default (as the mirage tool did)

### DIFF
--- a/lib/functoria/cli.ml
+++ b/lib/functoria/cli.ml
@@ -83,7 +83,7 @@ let depext section =
       ~doc:"Disable call to `opam depext' in the project Makefile."
   in
   let eval_opts = [ (true, depext_doc); (false, no_depext_doc) ] in
-  Arg.(value & vflag false eval_opts)
+  Arg.(value & vflag true eval_opts)
 
 (** Argument specification for --eval *)
 let full_eval =

--- a/test/functoria/query/Makefile.no-depext.expected
+++ b/test/functoria/query/Makefile.no-depext.expected
@@ -11,7 +11,6 @@ DEPEXT ?= $(OPAM) pin add -k path --no-action --yes noop . && \
 all:: build
 
 depend depends::
-	$(DEPEXT)
 	$(OPAM) install -y --deps-only .
 
 build::

--- a/test/functoria/query/dune.inc
+++ b/test/functoria/query/dune.inc
@@ -91,6 +91,19 @@
   (diff Makefile.expected Makefile)))
 
 (rule
+ (target Makefile.no-depext)
+ (action
+  (with-stdout-to
+   %{target}
+   (run ./config.exe query Makefile --no-depext))))
+
+(rule
+ (alias runtest)
+ (package functoria)
+ (action
+  (diff Makefile.no-depext.expected Makefile.no-depext)))
+
+(rule
  (target Makefile.depext)
  (action
   (with-stdout-to

--- a/test/functoria/query/gen.ml
+++ b/test/functoria/query/gen.ml
@@ -30,6 +30,7 @@ let () =
       v "files-configure";
       v "files-build";
       v "Makefile";
+      { file = "Makefile.no-depext"; cmd = "query Makefile --no-depext" };
       { file = "Makefile.depext"; cmd = "query Makefile --depext" };
       { file = "help-query"; cmd = "help query --man-format=plain" };
       { file = "query-help"; cmd = "query --help=plain" };

--- a/test/functoria/test_cli.ml
+++ b/test/functoria/test_cli.ml
@@ -35,7 +35,7 @@ let test_configure () =
     (`Ok
       (Cli.Configure
          {
-           depext = false;
+           depext = true;
            args =
              {
                context = (true, false);

--- a/test/functoria/tool/configure-help.err.expected
+++ b/test/functoria/tool/configure-help.err.expected
@@ -18,4 +18,4 @@
 * Is_file? [...].install -> false
 * Write to [...].install (35 bytes)
 * Is_file? Makefile -> false
-* Write to Makefile (369 bytes)
+* Write to Makefile (380 bytes)

--- a/test/functoria/tool/configure.err.expected
+++ b/test/functoria/tool/configure.err.expected
@@ -18,4 +18,4 @@
 * Is_file? [...].install -> false
 * Write to [...].install (35 bytes)
 * Is_file? Makefile -> false
-* Write to Makefile (369 bytes)
+* Write to Makefile (380 bytes)


### PR DESCRIPTION
This should fix mirage-skeleton