### PR TITLE
functoria: do not hide sub-command outputs

### DIFF
--- a/lib/functoria/action.mli
+++ b/lib/functoria/action.mli
@@ -89,12 +89,16 @@ val get_var : string -> string option t
 (** [get_var v] gets the value of the variable [c] in the environment. (see
     [Bos.OS.Env.get]) *)
 
-val run_cmd :
-  ?err:Format.formatter -> ?out:Format.formatter -> Bos.Cmd.t -> unit t
-(** Run a command. (see [Bos.OS.Cmd.run]) *)
+type channel = [ `Null | `Fmt of Format.formatter ]
+(** The type for channels. *)
 
-val run_cmd_out : ?err:Format.formatter -> Bos.Cmd.t -> string t
-(** Run a command and return stdout. (See [Bos.OS.Cmd.run_out]) *)
+val run_cmd : ?err:channel -> ?out:channel -> Bos.Cmd.t -> unit t
+(** Run a command. By default, [err] is [Fmt.stderr] and [out] is [Fmt.stdout].
+    (see [Bos.OS.Cmd.run]) *)
+
+val run_cmd_out : ?err:channel -> Bos.Cmd.t -> string t
+(** Run a command and return stdout. By default [err] is [Fmt.stderr]. (See
+    [Bos.OS.Cmd.run_out]) *)
 
 val write_file : Fpath.t -> string -> unit t
 (** Write some data to a file. (see [Bos.OS.File.write]) *)

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -40,11 +40,9 @@ module Make (P : S) = struct
   let build_dir t = Fpath.parent t.Cli.config_file
 
   let run_cmd ?ppf ?err_ppf command =
-    match ppf with
-    | None -> Action.run_cmd ?err:err_ppf command
-    | Some help_ppf ->
-        Action.run_cmd_out ?err:err_ppf command >|= fun output ->
-        Fmt.pf help_ppf "%s%!" output
+    let err = match err_ppf with None -> None | Some f -> Some (`Fmt f) in
+    let out = match ppf with None -> None | Some f -> Some (`Fmt f) in
+    Action.run_cmd ?err ?out command
 
   (* re-exec the command by calling config.exe with the same argv as
      the current command. *)
@@ -197,7 +195,7 @@ module Make (P : S) = struct
       let env =
         let commands cmd =
           match Bos.Cmd.line_exec cmd with
-          | Some "dune" -> Some ("[...]", "")
+          | Some "dune" -> Some (Fmt.str "out: %a\n" Bos.Cmd.pp cmd, "")
           | _ -> None
         in
         Action.env ~commands ~files:(`Passtrough (Fpath.v ".")) ()

--- a/test/functoria/test_action.ml
+++ b/test/functoria/test_action.ml
@@ -259,16 +259,16 @@ let test_run_cmd () =
 
   let cmd = Bos.Cmd.v "some-command" in
   test "run_cmd succeeds if the command exists" ~env:yay ~cmd ~expected:(Ok ())
-    ~expected_log:[ "Run_cmd 'some-command' (ok: out=\"yay\" err=\"\")" ]
+    ~expected_log:[ "Run_cmd 'some-command' (ok)" ]
     ();
 
   let err_b = Buffer.create 10 in
-  let err = Fmt.with_buffer err_b in
+  let err = `Fmt (Fmt.with_buffer err_b) in
   let out_b = Buffer.create 10 in
-  let out = Fmt.with_buffer out_b in
+  let out = `Fmt (Fmt.with_buffer out_b) in
   test "run_cmd succeeds if the command exists" ~env:yay_err ~cmd ~out ~err
     ~expected:(Ok ())
-    ~expected_log:[ "Run_cmd 'some-command' (ok: out=\"yay\" err=\"err\")" ]
+    ~expected_log:[ "Run_cmd 'some-command' (ok)" ]
     ();
   Alcotest.(check string) "cmd out" "yay" (Buffer.contents out_b);
   Alcotest.(check string) "cmd err" "err" (Buffer.contents err_b)
@@ -290,14 +290,14 @@ let test_run_cmd_out () =
   let cmd = Bos.Cmd.v "some-command" in
   test "run_cmd_out succeeds if the command exists" ~env:yay ~cmd
     ~expected:(Ok "yay")
-    ~expected_log:[ "Run_cmd 'some-command' (ok: out=\"yay\" err=\"\")" ]
+    ~expected_log:[ "Run_cmd 'some-command' (ok)" ]
     ();
 
   let err_b = Buffer.create 10 in
-  let err = Fmt.with_buffer err_b in
+  let err = `Fmt (Fmt.with_buffer err_b) in
   test "run_cmd_out succeeds if the command exists" ~env:yay_err ~cmd ~err
     ~expected:(Ok "yay")
-    ~expected_log:[ "Run_cmd 'some-command' (ok: out=\"yay\" err=\"err\")" ]
+    ~expected_log:[ "Run_cmd 'some-command' (ok)" ]
     ();
   Alcotest.(check string) "cmd_out err" "err" (Buffer.contents err_b)
 

--- a/test/functoria/tool/ambiguous.err.expected
+++ b/test/functoria/tool/ambiguous.err.expected
@@ -7,5 +7,5 @@
                Write to dune.build (32 bytes)
                Is_file? dune -> true
                Read dune (221 bytes)]
-* Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe c a b c --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune build ./config.exe' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe c a b c --dry-run' (ok)

--- a/test/functoria/tool/ambiguous.expected
+++ b/test/functoria/tool/ambiguous.expected
@@ -1,0 +1,2 @@
+out: dune build ./config.exe
+out: dune exec --root . -- ./config.exe c a b c --dry-run

--- a/test/functoria/tool/build.err.expected
+++ b/test/functoria/tool/build.err.expected
@@ -7,5 +7,5 @@
                Write to dune.build (32 bytes)
                Is_file? dune -> true
                Read dune (221 bytes)]
-* Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe build a b c --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune build ./config.exe' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe build a b c --dry-run' (ok)

--- a/test/functoria/tool/build.expected
+++ b/test/functoria/tool/build.expected
@@ -1,0 +1,2 @@
+out: dune build ./config.exe
+out: dune exec --root . -- ./config.exe build a b c --dry-run

--- a/test/functoria/tool/clean.err.expected
+++ b/test/functoria/tool/clean.err.expected
@@ -7,8 +7,8 @@
                Write to dune.build (32 bytes)
                Is_file? dune -> true
                Read dune (221 bytes)]
-* Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe clean a b c --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune build ./config.exe' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe clean a b c --dry-run' (ok)
 * Ls ./ (0 entry)
 * Rm .test.config (no-op)
 * Get_var INSIDE_FUNCTORIA_TESTS -> <not set>

--- a/test/functoria/tool/clean.expected
+++ b/test/functoria/tool/clean.expected
@@ -1,0 +1,2 @@
+out: dune build ./config.exe
+out: dune exec --root . -- ./config.exe clean a b c --dry-run

--- a/test/functoria/tool/configure-help.err.expected
+++ b/test/functoria/tool/configure-help.err.expected
@@ -7,15 +7,15 @@
                Write to dune.build (32 bytes)
                Is_file? dune -> true
                Read dune (221 bytes)]
-* Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
+* Run_cmd 'dune build ./config.exe' (ok)
 * Write to .test.config (25 bytes)
-* Run_cmd 'dune exec --root . -- ./config.exe configure help --dry-run' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe query name' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe query opam' (ok: out="[...]" err="")
-* Is_file? [...].opam -> false
-* Write to [...].opam (35 bytes)
-* Run_cmd 'dune exec --root . -- ./config.exe query install' (ok: out="[...]" err="")
-* Is_file? [...].install -> false
-* Write to [...].install (35 bytes)
+* Run_cmd 'dune exec --root . -- ./config.exe configure help --dry-run' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe query name' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe query opam' (ok)
+* Is_file? out: dune exec --root . -- ./config.exe query name.opam -> false
+* Write to out: dune exec --root . -- ./config.exe query name.opam (81 bytes)
+* Run_cmd 'dune exec --root . -- ./config.exe query install' (ok)
+* Is_file? out: dune exec --root . -- ./config.exe query name.install -> false
+* Write to out: dune exec --root . -- ./config.exe query name.install (84 bytes)
 * Is_file? Makefile -> false
-* Write to Makefile (380 bytes)
+* Write to Makefile (515 bytes)

--- a/test/functoria/tool/configure-help.expected
+++ b/test/functoria/tool/configure-help.expected
@@ -1,0 +1,2 @@
+out: dune build ./config.exe
+out: dune exec --root . -- ./config.exe configure help --dry-run

--- a/test/functoria/tool/configure.err.expected
+++ b/test/functoria/tool/configure.err.expected
@@ -7,15 +7,15 @@
                Write to dune.build (32 bytes)
                Is_file? dune -> true
                Read dune (221 bytes)]
-* Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
+* Run_cmd 'dune build ./config.exe' (ok)
 * Write to .test.config (26 bytes)
-* Run_cmd 'dune exec --root . -- ./config.exe configure a b c --dry-run' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe query name' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe query opam' (ok: out="[...]" err="")
-* Is_file? [...].opam -> false
-* Write to [...].opam (35 bytes)
-* Run_cmd 'dune exec --root . -- ./config.exe query install' (ok: out="[...]" err="")
-* Is_file? [...].install -> false
-* Write to [...].install (35 bytes)
+* Run_cmd 'dune exec --root . -- ./config.exe configure a b c --dry-run' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe query name' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe query opam' (ok)
+* Is_file? out: dune exec --root . -- ./config.exe query name.opam -> false
+* Write to out: dune exec --root . -- ./config.exe query name.opam (81 bytes)
+* Run_cmd 'dune exec --root . -- ./config.exe query install' (ok)
+* Is_file? out: dune exec --root . -- ./config.exe query name.install -> false
+* Write to out: dune exec --root . -- ./config.exe query name.install (84 bytes)
 * Is_file? Makefile -> false
-* Write to Makefile (380 bytes)
+* Write to Makefile (515 bytes)

--- a/test/functoria/tool/configure.expected
+++ b/test/functoria/tool/configure.expected
@@ -1,0 +1,2 @@
+out: dune build ./config.exe
+out: dune exec --root . -- ./config.exe configure a b c --dry-run

--- a/test/functoria/tool/default.err.expected
+++ b/test/functoria/tool/default.err.expected
@@ -7,5 +7,5 @@
                Write to dune.build (32 bytes)
                Is_file? dune -> true
                Read dune (221 bytes)]
-* Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune build ./config.exe' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe --dry-run' (ok)

--- a/test/functoria/tool/default.expected
+++ b/test/functoria/tool/default.expected
@@ -1,0 +1,2 @@
+out: dune build ./config.exe
+out: dune exec --root . -- ./config.exe --dry-run

--- a/test/functoria/tool/describe.err.expected
+++ b/test/functoria/tool/describe.err.expected
@@ -7,5 +7,5 @@
                Write to dune.build (32 bytes)
                Is_file? dune -> true
                Read dune (221 bytes)]
-* Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe describe a b c --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune build ./config.exe' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe describe a b c --dry-run' (ok)

--- a/test/functoria/tool/describe.expected
+++ b/test/functoria/tool/describe.expected
@@ -1,0 +1,2 @@
+out: dune build ./config.exe
+out: dune exec --root . -- ./config.exe describe a b c --dry-run

--- a/test/functoria/tool/help-configure.err.expected
+++ b/test/functoria/tool/help-configure.err.expected
@@ -7,5 +7,5 @@
                Write to dune.build (32 bytes)
                Is_file? dune -> true
                Read dune (221 bytes)]
-* Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe help configure --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune build ./config.exe' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe help configure --dry-run' (ok)

--- a/test/functoria/tool/help-configure.expected
+++ b/test/functoria/tool/help-configure.expected
@@ -1,0 +1,2 @@
+out: dune build ./config.exe
+out: dune exec --root . -- ./config.exe help configure --dry-run

--- a/test/functoria/tool/help.err.expected
+++ b/test/functoria/tool/help.err.expected
@@ -7,5 +7,5 @@
                Write to dune.build (32 bytes)
                Is_file? dune -> true
                Read dune (221 bytes)]
-* Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe help a b c --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune build ./config.exe' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe help a b c --dry-run' (ok)

--- a/test/functoria/tool/help.expected
+++ b/test/functoria/tool/help.expected
@@ -1,0 +1,2 @@
+out: dune build ./config.exe
+out: dune exec --root . -- ./config.exe help a b c --dry-run

--- a/test/functoria/tool/query.err.expected
+++ b/test/functoria/tool/query.err.expected
@@ -7,5 +7,5 @@
                Write to dune.build (32 bytes)
                Is_file? dune -> true
                Read dune (221 bytes)]
-* Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe query a b c --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune build ./config.exe' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe query a b c --dry-run' (ok)

--- a/test/functoria/tool/query.expected
+++ b/test/functoria/tool/query.expected
@@ -1,0 +1,2 @@
+out: dune build ./config.exe
+out: dune exec --root . -- ./config.exe query a b c --dry-run

--- a/test/functoria/tool/simple-help.err.expected
+++ b/test/functoria/tool/simple-help.err.expected
@@ -7,5 +7,5 @@
                Write to dune.build (32 bytes)
                Is_file? dune -> true
                Read dune (221 bytes)]
-* Run_cmd 'dune build ./config.exe' (ok: out="[...]" err="")
-* Run_cmd 'dune exec --root . -- ./config.exe help --dry-run' (ok: out="[...]" err="")
+* Run_cmd 'dune build ./config.exe' (ok)
+* Run_cmd 'dune exec --root . -- ./config.exe help --dry-run' (ok)

--- a/test/functoria/tool/simple-help.expected
+++ b/test/functoria/tool/simple-help.expected
@@ -1,0 +1,2 @@
+out: dune build ./config.exe
+out: dune exec --root . -- ./config.exe help --dry-run


### PR DESCRIPTION
- By default, show stdout and stderr outputs;
- Also make sure that stderr/stdout are printed in case of errors.