### PR TITLE
Add the context files when the tool calls config.exe

### DIFF
--- a/lib/functoria/cli.ml
+++ b/lib/functoria/cli.ml
@@ -405,6 +405,9 @@ let peek_args ?(with_setup = false) argv =
   | _, `Ok b | Some b, _ -> b
   | _ -> assert false
 
+let peek_context_file argv =
+  match Term.eval_peek_opts ~argv context_file with _, `Ok b -> b | _ -> None
+
 let eval ?(with_setup = true) ?help_ppf ?err_ppf ~name ~version ~configure
     ~query ~describe ~build ~clean ~help argv =
   Cmdliner.Term.eval_choice ?help:help_ppf ?err:err_ppf ~argv ~catch:false

--- a/lib/functoria/cli.mli
+++ b/lib/functoria/cli.mli
@@ -29,6 +29,9 @@ type 'a args = {
 }
 (** The type for global arguments. *)
 
+val peek_context_file : string array -> Fpath.t option
+(** [peek_context_file] reads the [--context-file] option on the command-line. *)
+
 val peek_args : ?with_setup:bool -> string array -> unit args
 (** [peek_args ?with_setup argv] parses the global command-line arguments. If
     [with_setup] is set (by default it is), interprets [-v] and [--color] to

--- a/test/functoria/tool/ambiguous.err.expected
+++ b/test/functoria/tool/ambiguous.err.expected
@@ -8,4 +8,5 @@
                Is_file? dune -> true
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok)
+* Is_file? test.context -> false
 * Run_cmd 'dune exec --root . -- ./config.exe c a b c --dry-run' (ok)

--- a/test/functoria/tool/ambiguous.expected
+++ b/test/functoria/tool/ambiguous.expected
@@ -1,2 +1,2 @@
-out: dune build ./config.exe
-out: dune exec --root . -- ./config.exe c a b c --dry-run
+$(dune build ./config.exe)
+$(dune exec --root . -- ./config.exe c a b c --dry-run)

--- a/test/functoria/tool/build.err.expected
+++ b/test/functoria/tool/build.err.expected
@@ -8,4 +8,5 @@
                Is_file? dune -> true
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok)
+* Is_file? test.context -> false
 * Run_cmd 'dune exec --root . -- ./config.exe build a b c --dry-run' (ok)

--- a/test/functoria/tool/build.expected
+++ b/test/functoria/tool/build.expected
@@ -1,2 +1,2 @@
-out: dune build ./config.exe
-out: dune exec --root . -- ./config.exe build a b c --dry-run
+$(dune build ./config.exe)
+$(dune exec --root . -- ./config.exe build a b c --dry-run)

--- a/test/functoria/tool/clean.err.expected
+++ b/test/functoria/tool/clean.err.expected
@@ -8,6 +8,7 @@
                Is_file? dune -> true
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok)
+* Is_file? test.context -> false
 * Run_cmd 'dune exec --root . -- ./config.exe clean a b c --dry-run' (ok)
 * Ls ./ (0 entry)
 * Rm test.context (no-op)

--- a/test/functoria/tool/clean.expected
+++ b/test/functoria/tool/clean.expected
@@ -1,2 +1,2 @@
-out: dune build ./config.exe
-out: dune exec --root . -- ./config.exe clean a b c --dry-run
+$(dune build ./config.exe)
+$(dune exec --root . -- ./config.exe clean a b c --dry-run)

--- a/test/functoria/tool/configure-help.err.expected
+++ b/test/functoria/tool/configure-help.err.expected
@@ -9,13 +9,19 @@
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok)
 * Write to test.context (25 bytes)
-* Run_cmd 'dune exec --root . -- ./config.exe configure help --dry-run' (ok)
-* Run_cmd 'dune exec --root . -- ./config.exe query name' (ok)
-* Run_cmd 'dune exec --root . -- ./config.exe query opam' (ok)
-* Is_file? out: dune exec --root . -- ./config.exe query name.opam -> false
-* Write to out: dune exec --root . -- ./config.exe query name.opam (81 bytes)
-* Run_cmd 'dune exec --root . -- ./config.exe query install' (ok)
-* Is_file? out: dune exec --root . -- ./config.exe query name.install -> false
-* Write to out: dune exec --root . -- ./config.exe query name.install (84 bytes)
+* Is_file? test.context -> true
+* Run_cmd 'dune exec --root . -- ./config.exe configure help --dry-run
+           --context test.context' (ok)
+* Is_file? test.context -> true
+* Run_cmd 'dune exec --root . -- ./config.exe query name --context test.context' (ok)
+* Is_file? test.context -> true
+* Run_cmd 'dune exec --root . -- ./config.exe query opam --context test.context' (ok)
+* Is_file? $(dune exec --root . -- ./config.exe query name --context test.context).opam -> false
+* Write to $(dune exec --root . -- ./config.exe query name --context test.context).opam (102 bytes)
+* Is_file? test.context -> true
+* Run_cmd 'dune exec --root . -- ./config.exe query install --context
+           test.context' (ok)
+* Is_file? $(dune exec --root . -- ./config.exe query name --context test.context).install -> false
+* Write to $(dune exec --root . -- ./config.exe query name --context test.context).install (105 bytes)
 * Is_file? Makefile -> false
-* Write to Makefile (515 bytes)
+* Write to Makefile (578 bytes)

--- a/test/functoria/tool/configure-help.expected
+++ b/test/functoria/tool/configure-help.expected
@@ -1,2 +1,3 @@
-out: dune build ./config.exe
-out: dune exec --root . -- ./config.exe configure help --dry-run
+$(dune build ./config.exe)
+$(dune exec --root . -- ./config.exe configure help --dry-run --context
+    test.context)

--- a/test/functoria/tool/configure.err.expected
+++ b/test/functoria/tool/configure.err.expected
@@ -9,13 +9,19 @@
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok)
 * Write to test.context (26 bytes)
-* Run_cmd 'dune exec --root . -- ./config.exe configure a b c --dry-run' (ok)
-* Run_cmd 'dune exec --root . -- ./config.exe query name' (ok)
-* Run_cmd 'dune exec --root . -- ./config.exe query opam' (ok)
-* Is_file? out: dune exec --root . -- ./config.exe query name.opam -> false
-* Write to out: dune exec --root . -- ./config.exe query name.opam (81 bytes)
-* Run_cmd 'dune exec --root . -- ./config.exe query install' (ok)
-* Is_file? out: dune exec --root . -- ./config.exe query name.install -> false
-* Write to out: dune exec --root . -- ./config.exe query name.install (84 bytes)
+* Is_file? test.context -> true
+* Run_cmd 'dune exec --root . -- ./config.exe configure a b c --dry-run
+           --context test.context' (ok)
+* Is_file? test.context -> true
+* Run_cmd 'dune exec --root . -- ./config.exe query name --context test.context' (ok)
+* Is_file? test.context -> true
+* Run_cmd 'dune exec --root . -- ./config.exe query opam --context test.context' (ok)
+* Is_file? $(dune exec --root . -- ./config.exe query name --context test.context).opam -> false
+* Write to $(dune exec --root . -- ./config.exe query name --context test.context).opam (102 bytes)
+* Is_file? test.context -> true
+* Run_cmd 'dune exec --root . -- ./config.exe query install --context
+           test.context' (ok)
+* Is_file? $(dune exec --root . -- ./config.exe query name --context test.context).install -> false
+* Write to $(dune exec --root . -- ./config.exe query name --context test.context).install (105 bytes)
 * Is_file? Makefile -> false
-* Write to Makefile (515 bytes)
+* Write to Makefile (578 bytes)

--- a/test/functoria/tool/configure.expected
+++ b/test/functoria/tool/configure.expected
@@ -1,2 +1,3 @@
-out: dune build ./config.exe
-out: dune exec --root . -- ./config.exe configure a b c --dry-run
+$(dune build ./config.exe)
+$(dune exec --root . -- ./config.exe configure a b c --dry-run --context
+    test.context)

--- a/test/functoria/tool/default.err.expected
+++ b/test/functoria/tool/default.err.expected
@@ -8,4 +8,5 @@
                Is_file? dune -> true
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok)
+* Is_file? test.context -> false
 * Run_cmd 'dune exec --root . -- ./config.exe --dry-run' (ok)

--- a/test/functoria/tool/default.expected
+++ b/test/functoria/tool/default.expected
@@ -1,2 +1,2 @@
-out: dune build ./config.exe
-out: dune exec --root . -- ./config.exe --dry-run
+$(dune build ./config.exe)
+$(dune exec --root . -- ./config.exe --dry-run)

--- a/test/functoria/tool/describe.err.expected
+++ b/test/functoria/tool/describe.err.expected
@@ -8,4 +8,5 @@
                Is_file? dune -> true
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok)
+* Is_file? test.context -> false
 * Run_cmd 'dune exec --root . -- ./config.exe describe a b c --dry-run' (ok)

--- a/test/functoria/tool/describe.expected
+++ b/test/functoria/tool/describe.expected
@@ -1,2 +1,2 @@
-out: dune build ./config.exe
-out: dune exec --root . -- ./config.exe describe a b c --dry-run
+$(dune build ./config.exe)
+$(dune exec --root . -- ./config.exe describe a b c --dry-run)

--- a/test/functoria/tool/help-configure.err.expected
+++ b/test/functoria/tool/help-configure.err.expected
@@ -8,4 +8,5 @@
                Is_file? dune -> true
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok)
+* Is_file? test.context -> false
 * Run_cmd 'dune exec --root . -- ./config.exe help configure --dry-run' (ok)

--- a/test/functoria/tool/help-configure.expected
+++ b/test/functoria/tool/help-configure.expected
@@ -1,2 +1,2 @@
-out: dune build ./config.exe
-out: dune exec --root . -- ./config.exe help configure --dry-run
+$(dune build ./config.exe)
+$(dune exec --root . -- ./config.exe help configure --dry-run)

--- a/test/functoria/tool/help.err.expected
+++ b/test/functoria/tool/help.err.expected
@@ -8,4 +8,5 @@
                Is_file? dune -> true
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok)
+* Is_file? test.context -> false
 * Run_cmd 'dune exec --root . -- ./config.exe help a b c --dry-run' (ok)

--- a/test/functoria/tool/help.expected
+++ b/test/functoria/tool/help.expected
@@ -1,2 +1,2 @@
-out: dune build ./config.exe
-out: dune exec --root . -- ./config.exe help a b c --dry-run
+$(dune build ./config.exe)
+$(dune exec --root . -- ./config.exe help a b c --dry-run)

--- a/test/functoria/tool/query.err.expected
+++ b/test/functoria/tool/query.err.expected
@@ -8,4 +8,5 @@
                Is_file? dune -> true
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok)
+* Is_file? test.context -> false
 * Run_cmd 'dune exec --root . -- ./config.exe query a b c --dry-run' (ok)

--- a/test/functoria/tool/query.expected
+++ b/test/functoria/tool/query.expected
@@ -1,2 +1,2 @@
-out: dune build ./config.exe
-out: dune exec --root . -- ./config.exe query a b c --dry-run
+$(dune build ./config.exe)
+$(dune exec --root . -- ./config.exe query a b c --dry-run)

--- a/test/functoria/tool/simple-help.err.expected
+++ b/test/functoria/tool/simple-help.err.expected
@@ -8,4 +8,5 @@
                Is_file? dune -> true
                Read dune (221 bytes)]
 * Run_cmd 'dune build ./config.exe' (ok)
+* Is_file? test.context -> false
 * Run_cmd 'dune exec --root . -- ./config.exe help --dry-run' (ok)

--- a/test/functoria/tool/simple-help.expected
+++ b/test/functoria/tool/simple-help.expected
@@ -1,2 +1,2 @@
-out: dune build ./config.exe
-out: dune exec --root . -- ./config.exe help --dry-run
+$(dune build ./config.exe)
+$(dune exec --root . -- ./config.exe help --dry-run)


### PR DESCRIPTION
This fixes a regression introduced in #1145