### PR TITLE
add PCIe support

### DIFF
--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -116,6 +116,14 @@ let generic_kv_ro = Mirage_impl_fs.generic_kv_ro
 
 let kv_ro_of_fs = Mirage_impl_fs.kv_ro_of_fs
 
+type pci = Mirage_impl_pci.pci
+
+let pci = Mirage_impl_pci.pci
+
+type device_info = Mirage_impl_pci.device_info
+
+let pcidev = Mirage_impl_pci.pcidev
+
 type network = Mirage_impl_network.network
 
 let network = Mirage_impl_network.network

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -224,6 +224,19 @@ val fat_of_files : ?dir:string -> ?regexp:string -> unit -> fs impl
 val kv_ro_of_fs : fs impl -> kv_ro impl
 (** Consider a filesystem implementation as a read-only key/value store. *)
 
+(** {2 PCIe devices} *)
+
+type pci
+(** Abstract type for PCIe configurations. *)
+
+val pci : pci typ
+(** Implementations of the [Mirage_types.PCI] signature. *)
+
+type device_info = Mirage_impl_pci.device_info
+
+val pcidev : ?group:string -> device_info -> string -> pci impl
+(** A custom PCIe device. Exposes a {!Key.interface} key. *)
+
 (** {2 Network interfaces} *)
 
 type network

--- a/lib/mirage/mirage_impl_pci.ml
+++ b/lib/mirage/mirage_impl_pci.ml
@@ -1,0 +1,78 @@
+open Functoria
+open Mirage_impl_misc
+
+module Key = Mirage_key
+
+type pci = PCI
+
+let pci = Type.v PCI
+
+type device_info =
+  { bus_master_enable : bool
+  ; map_bar0 : bool
+  ; map_bar1 : bool
+  ; map_bar2 : bool
+  ; map_bar3 : bool
+  ; map_bar4 : bool
+  ; map_bar5 : bool
+  ; vendor_id : int
+  ; device_id : int
+  ; class_code : int
+  ; subclass_code : int
+  ; progif : int
+  ; dma_size : int
+  }
+
+let all_pci_devices = ref []
+
+let dma_request = ref 0
+
+let pci_conf device_info (dev : string Key.key) =
+  let key = Key.v dev in
+  let keys = [ key ] in
+  let packages_v =
+    Key.match_ Key.(value target) @@ function
+    | `Unix -> [ package "mirage-pci-unix" ]
+    | #Mirage_key.mode_solo5 -> [ package "mirage-pci-solo5" ]
+    | target ->
+      Log.err (fun m -> m "target not supported: %a" Key.pp_target target);
+      failwith "target not supported" in
+  let connect i modname _ =
+    match Mirage_key.(get (Functoria.Info.context i) target) with
+    | `Unix ->
+      Fmt.strf
+        "%s.connect Pci.{ bus_master_enable = %b; map_bar0 = %b; map_bar1 = %b; map_bar2 = %b; map_bar3 = %b; map_bar4 = %b; map_bar5 = %b; vendor_id = %d; device_id = %d; class_code = %d; subclass_code = %d; progif = %d; dma_size = %d } %a"
+        modname
+        device_info.bus_master_enable
+        device_info.map_bar0
+        device_info.map_bar1
+        device_info.map_bar2
+        device_info.map_bar3
+        device_info.map_bar4
+        device_info.map_bar5
+        device_info.vendor_id
+        device_info.device_id
+        device_info.class_code
+        device_info.subclass_code
+        device_info.progif
+        device_info.dma_size
+        Key.serialize_call key
+    | `Hvt ->
+      let dma_offset = !dma_request in
+      dma_request := !dma_request + device_info.dma_size;
+      Fmt.strf
+        "%s.connect ~dma_offset:%d ~dma_size:%d %a"
+        modname
+        dma_offset (* TODO take alignment into account, request might be weirdly sized *)
+        device_info.dma_size
+        Key.serialize_call key
+    | target ->
+      Log.err (fun m -> m "target not supported: %a" Key.pp_target target);
+      failwith "target not supported" in
+  let configure i =
+    all_pci_devices := (device_info, Key.get (Info.context i) dev) :: !all_pci_devices;
+    Action.ok () in
+  impl ~keys ~packages_v ~connect ~configure "Pci" pci
+
+let pcidev ?group device_info dev =
+  pci_conf device_info @@ Key.pci ?group dev

--- a/lib/mirage/mirage_impl_pci.mli
+++ b/lib/mirage/mirage_impl_pci.mli
@@ -1,0 +1,25 @@
+type pci
+
+val pci : pci Functoria.typ
+
+type device_info =
+  { bus_master_enable : bool
+  ; map_bar0 : bool
+  ; map_bar1 : bool
+  ; map_bar2 : bool
+  ; map_bar3 : bool
+  ; map_bar4 : bool
+  ; map_bar5 : bool
+  ; vendor_id : int
+  ; device_id : int
+  ; class_code : int
+  ; subclass_code : int
+  ; progif : int
+  ; dma_size : int
+  }
+
+val pcidev : ?group:string -> device_info -> string -> pci Functoria.impl
+
+val dma_request : int ref
+
+val all_pci_devices : (device_info * string) list ref

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -266,6 +266,11 @@ let block ?group () =
   in
   create_simple ~doc ?group ~stage:`Configure ~default:`Ramdisk conv "block"
 
+(** {3 PCIe device keys} *)
+let pci ?group default =
+  let doc = Fmt.strf "The PCIe device controlled by %a." pp_group group in
+  create_simple ~doc ~default ?group Arg.string "pci"
+
 (** {3 PRNG key} *)
 let prng =
   let conv =

--- a/lib/mirage/mirage_key.mli
+++ b/lib/mirage/mirage_key.mli
@@ -95,6 +95,9 @@ val kv_ro : ?group:string -> unit -> [ `Archive | `Crunch | `Direct | `Fat ] key
 val block : ?group:string -> unit -> [ `XenstoreId | `BlockFile | `Ramdisk ] key
 (** {3 Block device keys} *)
 
+(** {3 PCIe device keys} *)
+val pci : ?group:string -> string -> string key
+
 (** {3 PRNG key} *)
 
 val prng : [ `Stdlib | `Nocrypto ] key

--- a/mirage-types.opam
+++ b/mirage-types.opam
@@ -32,6 +32,7 @@ depends: [
   "mirage-fs" {>= "3.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "mirage-channel" {>= "4.0.0"}
+  "mirage-pci"
 ]
 synopsis: "Module type definitions for MirageOS applications"
 description: """


### PR DESCRIPTION
This is my current working state of PCIe support in MirageOS. Currently PCIe devices are supported on Linux via [`mirage-pci-unix`](https://github.com/Reperator/mirage-pci-unix) and Solo5 (hvt on Linux only) via [`mirage-pci-solo5`](https://github.com/Reperator/mirage-pci-solo5). Both versions use the host's IOMMU through VFIO. The only driver currently supported is [`ixy.ml`](https://github.com/ixy-languages/ixy.ml) which acts as a MirageOS network device.

There are still a few little things to be ironed out and a bunch of cleanup to be done, and also the modifications to Solo5 are not upstreamed (and I doubt they will be in the current state). Currently I don't have the time to deal with it. If somebody were to review the code and point out what needs to be done, I'd be happy to take a look in the coming weeks.

I built the modifications against the latest MirageOS stable release and only just now rebased onto master.

To try a full setup an ixgbe-compatible NIC, a [modified build of mirage-solo5](https://github.com/mirage/mirage-solo5/pull/59), a [modified build of hvt](https://github.com/Solo5/solo5/pull/469) and ixy.ml are required. I tested such a setup using [mirage_iperf](https://github.com/TImada/mirage_iperf) with a tweaked config.