### PR TITLE
Forward-port mirage/functoria#194

### DIFF
--- a/lib/functoria/key.mli
+++ b/lib/functoria/key.mli
@@ -178,7 +178,10 @@ val abstract : 'a key -> t
 (** Deprecated, use {!v}. *)
 
 val equal : t -> t -> bool
-(** [equa] is the equality function of untyped keys. *)
+(** [equal] is the equality function of untyped keys. *)
+
+val hash : t -> int
+(** [hash] is the hash function for untyped keys. *)
 
 val compare : t -> t -> int
 (** [compare] compares untyped keys. *)

--- a/test/functoria/test_key.ml
+++ b/test/functoria/test_key.ml
@@ -78,10 +78,20 @@ let test_merge () =
   Alcotest.(check (option string))
     "merge c" (Some "foo") (Key.get context key_c)
 
+let key = Alcotest.testable Key.pp Key.equal
+
+let test_equal () =
+  let k1 = Key.(v @@ create "foo" Arg.(opt int 1 (info [ "foo" ]))) in
+  let k2 = Key.(v @@ create "foo" Arg.(opt int 2 (info [ "foo" ]))) in
+  let k3 = Key.(v @@ create "foo" Arg.(opt int 1 (info [ "foo" ]))) in
+  Alcotest.(check @@ neg key) "different defaults" k1 k2;
+  Alcotest.(check @@ key) "same defaults" k1 k3
+
 let suite =
   List.map
     (fun (n, f) -> (n, `Quick, f))
     [
+      ("equal", test_equal);
       ("eval", test_eval);
       ("get", test_get);
       ("find", test_find);


### PR DESCRIPTION
While fixing this, I've noticed that there is a difference between 3.7 and the dev branch on how the device are distinguished:in 3.7 it using their name and keys; in the dev branch it's using a unique ID per device. That difference could possibly cause the duplication on some devices and might cause issue if their init function is called twice. This could be an issue for entropy/random devices as pointed out by @hannesm. I plan to investigate and address this in a separate PR.