### PR TITLE
Do not use $(mname) in the default value for CLI args

### DIFF
--- a/lib/functoria/cli.mli
+++ b/lib/functoria/cli.mli
@@ -29,10 +29,10 @@ type 'a args = {
 }
 (** The type for global arguments. *)
 
-val peek_context_file : string array -> Fpath.t option
+val peek_context_file : mname:string -> string array -> Fpath.t option
 (** [peek_context_file] reads the [--context-file] option on the command-line. *)
 
-val peek_args : ?with_setup:bool -> string array -> unit args
+val peek_args : ?with_setup:bool -> mname:string -> string array -> unit args
 (** [peek_args ?with_setup argv] parses the global command-line arguments. If
     [with_setup] is set (by default it is), interprets [-v] and [--color] to
     set-up the terminal configuration as a side-effect. *)
@@ -114,6 +114,7 @@ val eval :
   build:'a Term.t ->
   clean:'a Term.t ->
   help:'a Term.t ->
+  mname:string ->
   string array ->
   'a action Term.result
 (** Parse the functoria command line. The arguments to [~configure],
@@ -128,5 +129,5 @@ type 'a result =
 (** Similar to {!Cmdliner.Term.result} but help is folded into [`Ok] and errors
     also carry global command-line parameters. *)
 
-val peek : ?with_setup:bool -> string array -> unit result
+val peek : ?with_setup:bool -> mname:string -> string array -> unit result
 (** [peek] is the same as {!eval} but without failing on unknown arguments. *)

--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -320,14 +320,14 @@ module Make (P : S) = struct
 
     handle_parse_args_result
       (Cli.eval ~name:P.name ~version:P.version ~configure ~query ~describe
-         ~build ~clean ~help argv)
+         ~build ~clean ~help ~mname:P.name argv)
 
   let register ?packages ?keys ?(init = default_init) ?(src = `Auto) name jobs =
     (* 1. Pre-parse the arguments set the log level, config file
        and root directory. *)
     let argv = Sys.argv in
     (* TODO: do not are parse the command-line twice *)
-    let args = Cli.peek_args argv in
+    let args = Cli.peek_args ~mname:P.name argv in
     let run () =
       let build_cmd = get_build_cmd args in
       let main_dev = P.create (init @ jobs) in

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -47,7 +47,7 @@ module Make (P : S) = struct
         Fpath.(normalize (dir / (P.name ^ ".context")))
 
   let add_context_file t argv =
-    match Cli.peek_context_file argv with
+    match Cli.peek_context_file ~mname:P.name argv with
     | Some _ -> Action.ok argv
     | None -> (
         let file = context_file t in
@@ -189,7 +189,7 @@ module Make (P : S) = struct
     let result =
       Cli.eval ?help_ppf ?err_ppf ~name:P.name ~version:P.version
         ~configure:context ~query:context ~describe:context ~build:context
-        ~clean:context ~help:context argv
+        ~clean:context ~help:context ~mname:P.name argv
     in
     let ok = Action.ok () in
     let error = Action.error error in
@@ -266,7 +266,7 @@ module Make (P : S) = struct
   let pp_unit _ _ = ()
 
   let run_with_argv ?help_ppf ?err_ppf argv =
-    let t = Cli.peek ~with_setup:true argv in
+    let t = Cli.peek ~with_setup:true ~mname:P.name argv in
     match t with
     | `Version ->
         Log.info (fun l -> l "version");

--- a/test/functoria/test_cli.ml
+++ b/test/functoria/test_cli.ml
@@ -27,7 +27,7 @@ let test_configure () =
   in
   let result =
     eval ~configure:extra_term ~query:extra_term ~describe:extra_term
-      ~build:extra_term ~clean:extra_term ~help:extra_term
+      ~build:extra_term ~clean:extra_term ~help:extra_term ~mname:"test"
       [| "name"; "configure"; "--xyz"; "--verbose" |]
   in
   Alcotest.(check result_b)
@@ -57,7 +57,7 @@ let test_describe () =
   in
   let result =
     eval ~configure:extra_term ~query:extra_term ~describe:extra_term
-      ~build:extra_term ~clean:extra_term ~help:extra_term
+      ~build:extra_term ~clean:extra_term ~help:extra_term ~mname:"test"
       [|
         "name";
         "describe";
@@ -97,7 +97,7 @@ let test_build () =
   in
   let result =
     eval ~configure:extra_term ~query:extra_term ~describe:extra_term
-      ~build:extra_term ~clean:extra_term ~help:extra_term
+      ~build:extra_term ~clean:extra_term ~help:extra_term ~mname:"test"
       [| "name"; "build"; "--cde"; "-x"; "--color=never"; "-v"; "-v" |]
   in
   Alcotest.(check result_b)
@@ -124,6 +124,7 @@ let test_clean () =
   let result =
     eval ~configure:extra_term ~query:extra_term ~describe:extra_term
       ~build:extra_term ~clean:extra_term ~help:extra_term [| "name"; "clean" |]
+      ~mname:"test"
   in
   Alcotest.(check result_b)
     "clean"
@@ -150,6 +151,7 @@ let test_help () =
   let result =
     eval ~help_ppf:null ~configure:extra_term ~query:extra_term
       ~describe:extra_term ~build:extra_term ~clean:extra_term ~help:extra_term
+      ~mname:"test"
       [| "name"; "help"; "--help"; "plain" |]
   in
   Alcotest.(check result_b) "help" `Help result
@@ -166,7 +168,7 @@ let test_default () =
   let result =
     eval ~help_ppf:null ~configure:extra_term ~query:extra_term
       ~describe:extra_term ~build:extra_term ~clean:extra_term ~help:extra_term
-      [| "name" |]
+      ~mname:"test" [| "name" |]
   in
   Alcotest.(check result_b) "default" `Help result
 


### PR DESCRIPTION
The behavior was changed in https://github.com/dbuenzli/cmdliner/pull/111 so
it allows mirage to work with the dev version of cmdliner