### PR TITLE
xen: fix for xen 4.10+ (as seen in LTS Ubuntu)

### DIFF
--- a/lib/mirage/mirage_configure_xen.ml
+++ b/lib/mirage/mirage_configure_xen.ml
@@ -77,7 +77,7 @@ let configure_main_xl ?substitutions ~ext i =
       let open Mirage_impl_block in
       append fmt "name = '%s'" (lookup substitutions Name);
       append fmt "kernel = '%s'" (lookup substitutions Kernel);
-      append fmt "builder = 'linux'";
+      append fmt "type = 'pv'";
       append fmt "memory = %s" (lookup substitutions Memory);
       append fmt "on_crash = 'preserve'";
       append fmt "";


### PR DESCRIPTION
I notice that current mirage doesn't work on xen 4.10+ (as used in e.g. LTS Ubuntu) because they removed the `builder` argument from the `.xl` file and replaced it with `type`.

See https://wiki.xen.org/wiki/Type_Config_Option

Obviously we're also in the process of refactoring Xen support to use pvh as in #1089 

I don't know whether we should change it to `type = pv` in the meantime. I'm making this PR just in case -- I needed to make this change anyway for my local testing.

Signed-off-by: David Scott <dave@recoil.org>