### PR TITLE
Fix cmdliner term generation for keys with the same name but differen…

### DIFF
--- a/test/functoria/test_key.ml
+++ b/test/functoria/test_key.ml
@@ -87,6 +87,14 @@ let test_equal () =
   Alcotest.(check @@ neg key) "different defaults" k1 k2;
   Alcotest.(check @@ key) "same defaults" k1 k3
 
+let test_cmdliner () =
+  let k1 = Key.(v @@ create "foo" Arg.(opt int 1 (info [ "foo" ]))) in
+  let k2 = Key.(v @@ create "foo" Arg.(opt int 2 (info [ "foo" ]))) in
+  let keys = Key.Set.of_list [ k1; k2 ] in
+  let context = Key.context ~with_required:true keys in
+  let _ = eval (fun x -> x) context [] in
+  ()
+
 let suite =
   List.map
     (fun (n, f) -> (n, `Quick, f))
@@ -96,4 +104,5 @@ let suite =
       ("get", test_get);
       ("find", test_find);
       ("merge", test_merge);
+      ("cmdliner", test_cmdliner);
     ]


### PR DESCRIPTION
…t defaults

Since https://github.com/mirage/mirage/pull/1162 the (CLI) name is not enough
to distinguish between keys. This means that we build a cmdliner term with
multiple keys having the same name. In that case cmdliner will explode at
runtime with something like:

    Fatal error: exception Invalid_argument("option name --interface defined twice
      (doc strings are 'The network interface listened by the unikernel.  ' and
      'The network interface listened by the unikernel.  ')")

This happens when we call `mirage --help`, `mirage describe`, `mirage clean`
with partial implementation choices (e.g. without a corresponding
`mirage configure`).