### PR TITLE
Force ipaddr<5.0 temporary

### DIFF
--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "2.0.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria-runtime"  {>= "3.0.2"}
   "fmt"
   "logs"

--- a/mirage.opam
+++ b/mirage.opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "2.0.0"}
-  "ipaddr"             {>= "3.0.0"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
   "functoria"          {>= "3.0.2"}
   "bos"
   "astring"


### PR DESCRIPTION
That'll unbreak the CI and will be reverted once all the mirage packages are updated.