### PR TITLE
add ocaml runtime arguments (OCAMLRUNPARAM)

### DIFF
--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -198,6 +198,96 @@ let tracing_size default =
   let key = Arg.opt ~stage:`Configure Arg.int default doc in
   Key.create "tracing_size" key
 
+(** {2 OCaml runtime} *)
+
+let ocaml_section = "OCAML PARAMETERS"
+
+let backtrace =
+  let doc = "Trigger the printing of a stack backtrace when an uncaught exception aborts the unikernel." in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"BOOL" ~doc ["backtrace"] in
+  let key = Arg.opt Arg.bool true doc in
+  Key.create "backtrace" key
+
+let randomize_hashtables =
+  let doc = "Turn on randomization of all hash tables by default." in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"BOOL" ~doc ["randomize-hashtables"] in
+  let key = Arg.opt Arg.bool true doc in
+  Key.create "randomize-hashtables" key
+
+let allocation_policy =
+  let doc =
+    "The policy used for allocating in the OCaml heap. Possible values are: \
+      $(i,next-fit), $(i,first-fit), $(i,best-fit). \
+     Best-fit is only supported since OCaml 4.10."
+  in
+  let serialize ppf = function
+    | `Next_fit -> Fmt.pf ppf "`Next_fit"
+    | `First_fit -> Fmt.pf ppf "`First_fit"
+    | `Best_fit -> Fmt.pf ppf "`Best_fit"
+  and conv = Mirage_runtime.Arg.allocation_policy
+  in
+  let conv = Arg.conv ~conv ~runtime_conv:"Mirage_runtime.Arg.allocation_policy" ~serialize in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"ALLOCATION" ~doc ["allocation-policy"]
+  in
+  let key = Arg.opt conv `Next_fit doc in
+  Key.create "allocation-policy" key
+
+let minor_heap_size =
+  let doc = "The size of the minor heap (in words). Default: 256k." in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"MINOR SIZE" ~doc ["minor-heap-size"] in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "minor-heap-size" key
+
+let major_heap_increment =
+  let doc = "The size increment for the major heap (in words). If less than or equal 1000, it is a percentage of the current heap size. If more than 1000, it is a fixed number of words. Default: 15." in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"MAJOR INCREMENT" ~doc ["major-heap-increment"] in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "major-heap-increment" key
+
+let space_overhead =
+  let doc = "The percentage of live data of wasted memory, due to GC does not immediately collect unreachable blocks. The major GC speed is computed from this parameter, it will work more if smaller. Default: 80." in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"SPACE OVERHEAD" ~doc ["space-overhead"] in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "space-overhead" key
+
+let max_space_overhead =
+  let doc = "Heap compaction is triggered when the estimated amount of wasted memory exceeds this (percentage of live data). If above 1000000, compaction is never triggered. Default: 500." in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"MAX SPACE OVERHEAD" ~doc ["max-space-overhead"] in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "max-space-overhead" key
+
+let gc_verbosity =
+  let doc = "GC messages on standard error output. Sum of flags. Check GC module documentation for details." in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"VERBOSITY" ~doc ["gc-verbosity"] in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "gc-verbosity" key
+
+let gc_window_size =
+  let doc = "The size of the window used by the major GC for smoothing out variations in its workload. Between 1 adn 50, default: 1." in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"WINDOW SIZE" ~doc ["gc-window-size"] in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "gc-window-size" key
+
+let custom_major_ratio =
+  let doc = "Target ratio of floating garbage to major heap size for out-of-heap memory held by custom values. Default: 44." in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"CUSTOM MAJOR RATIO" ~doc ["custom-major-ratio"] in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "custom-major-ratio" key
+
+let custom_minor_ratio =
+  let doc = "Bound on floating garbage for out-of-heap memory held by custom values in the minor heap. Default: 100." in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"CUSTOM MINOR RATIO" ~doc ["custom-minor-ratio"] in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "custom-minor-ratio" key
+
+let custom_minor_max_size =
+  let doc = "Maximum amount of out-of-heap memory for each custom value allocated in the minor heap. Default: 8192 bytes." in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"CUSTOM MINOR MAX SIZE" ~doc ["custom-minor-max-size"] in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "custom-minor-max-size" key
+
+
 (** {2 General mirage keys} *)
 
 let create_simple ?(group="") ?(stage=`Both) ~doc ~default conv name =

--- a/lib/mirage_key.mli
+++ b/lib/mirage_key.mli
@@ -71,6 +71,44 @@ val no_depext: bool key
 val tracing_size: int -> int key
 (** [--tracing-size]: Key setting the tracing ring buffer size. *)
 
+(** {2 OCaml runtime keys}
+
+    The OCaml runtime is usually configurable via the [OCAMLRUNPARAM]
+    environment variable. We provide boot parameters covering these options. *)
+
+val backtrace : bool key
+(** [--backtrace]: Output a backtrace if an uncaught exception terminated the unikernel. *)
+
+val randomize_hashtables : bool key
+(** [--randomize-hashtables]: Randomize all hash tables. *)
+
+(** {3 GC control}
+
+    The OCaml garbage collector can be configured, as described in detail in
+    {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html#TYPEcontrol}GC control}.
+
+    The following keys allow boot time configuration. *)
+
+val allocation_policy : [ `Next_fit | `First_fit | `Best_fit ] key
+
+val minor_heap_size : int option key
+
+val major_heap_increment : int option key
+
+val space_overhead : int option key
+
+val max_space_overhead : int option key
+
+val gc_verbosity : int option key
+
+val gc_window_size : int option key
+
+val custom_major_ratio : int option key
+
+val custom_minor_ratio : int option key
+
+val custom_minor_max_size : int option key
+
 (** {2 Generic keys}
 
     Some keys have a [group] optional argument. This group argument allows to

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -100,6 +100,12 @@ module Arg = struct
     in
     parser, serialize
 
+  let allocation_policy =
+    Cmdliner.Arg.enum [
+      "next-fit", `Next_fit;
+      "first-fit", `First_fit;
+      "best-fit", `Best_fit
+    ]
 end
 
 include

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -70,6 +70,9 @@ module Arg: sig
   val log_threshold: log_threshold Cmdliner.Arg.converter
   (** [log_threshold] converts log reporter threshold. *)
 
+  val allocation_policy : [`Next_fit|`First_fit|`Best_fit] Cmdliner.Arg.converter
+  (** [allocation_policy] converts allocation policy. *)
+
 end
 
 include module type of Functoria_runtime with module Arg := Arg


### PR DESCRIPTION
the main motivation behind this PR is that I'd like to pass on the GC strategy (since 4.10 there's best-fit) without recompiling the unikernel (since the OCaml runtime allows this as a rutime configurable option).

Now, I was as well unsatisfied with the hardcoded emission of `let _ = Printexc.record_backtrace true` into every `main.ml` file (which can now be safely removed :).

This PR defines several boot parameters (also configure stage --> both), mostly equivalent of what the `OCAMLRUNPARAM` environment variable allows. The documentation has been inspired by gc.mli and http://caml.inria.fr/pub/docs/manual-ocaml/runtime.html#s%3Aocamlrun-options .

For how the code is generated: my goal is to avoid repeating to hardcode defaults from the OCaml runtime, thus the keys are of type `int option key` -- now there's some dirty `match` generated for them, I'd be fine if there's a better way to achieve this (I looked into the codebase, and only found things for `int key option`).

I'd be happy to get review + feedback on this PR (it targets the 3-series, but I'm fine to develop one for master as well, once accepted).