### PR TITLE
forward port changes from mirage 3.8 branch

### DIFF
--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -148,8 +148,7 @@ module Make (P : S) = struct
     let purpose = Fmt.strf "configure: create %a" Fpath.pp main in
     Log.info (fun m -> m "Generating: %a (main file)" Fpath.pp main);
     Action.with_output ~path:main ~append:false ~purpose (fun ppf ->
-        Fmt.pf ppf "%a@.@.let _ = Printexc.record_backtrace true@.@." Fmt.text
-          P.prelude)
+        Fmt.pf ppf "%a@.@." Fmt.text P.prelude)
     >>= fun () ->
     Engine.configure i jobs >>= fun () -> Engine.connect i ~init jobs
 

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -159,7 +159,7 @@ let create_ipv4 = Mirage_impl_ip.create_ipv4
 let create_ipv6 = Mirage_impl_ip.create_ipv6
 
 type ipv4_config = Mirage_impl_ip.ipv4_config = {
-  network : Ipaddr.V4.Prefix.t * Ipaddr.V4.t;
+  network : Ipaddr.V4.Prefix.t;
   gateway : Ipaddr.V4.t option;
 }
 
@@ -347,7 +347,7 @@ module Project = struct
     let keys = Key.[ v target; v warn_error; v target_debug ] in
     let packages_v =
       (* XXX: use %%VERSION_NUM%% here instead of hardcoding a version? *)
-      let min = "3.7.0" and max = "3.8.0" in
+      let min = "3.8.0" and max = "3.9.0" in
       let common =
         [
           package ~build:true ~min:"4.06.0" "ocaml";

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -374,7 +374,7 @@ val ipv6 : ipv6 typ
 (** The [Mirage_types.IPV6] module signature. *)
 
 type ipv4_config = {
-  network : Ipaddr.V4.Prefix.t * Ipaddr.V4.t;
+  network : Ipaddr.V4.Prefix.t;
   gateway : Ipaddr.V4.t option;
 }
 (** Types for IPv4 manual configuration. *)

--- a/lib/mirage/mirage_configure_xen.ml
+++ b/lib/mirage/mirage_configure_xen.ml
@@ -77,7 +77,7 @@ let configure_main_xl ?substitutions ~ext i =
       let open Mirage_impl_block in
       append fmt "name = '%s'" (lookup substitutions Name);
       append fmt "kernel = '%s'" (lookup substitutions Kernel);
-      append fmt "builder = 'linux'";
+      append fmt "type = 'pv'";
       append fmt "memory = %s" (lookup substitutions Memory);
       append fmt "on_crash = 'preserve'";
       append fmt "";

--- a/lib/mirage/mirage_impl_http.ml
+++ b/lib/mirage/mirage_impl_http.ml
@@ -18,5 +18,5 @@ let cohttp_server conduit =
 let httpaf_server conduit =
   let packages = [ package "httpaf-mirage" ] in
   let extra_deps = [ dep conduit ] in
-  impl ~packages ~connect:(connect "httapf") ~extra_deps
+  impl ~packages ~connect:(connect "httpaf") ~extra_deps
     "Httpaf_mirage.Server_with_conduit" http

--- a/lib/mirage/mirage_impl_ip.ml
+++ b/lib/mirage/mirage_impl_ip.ml
@@ -26,7 +26,7 @@ let ipv4 : ipv4 typ = ip
 let ipv6 : ipv6 typ = ip
 
 type ipv4_config = {
-  network : Ipaddr.V4.Prefix.t * Ipaddr.V4.t;
+  network : Ipaddr.V4.Prefix.t;
   gateway : Ipaddr.V4.t option;
 }
 (** Types for IPv4 manual configuration. *)
@@ -43,7 +43,7 @@ let ( @?? ) x y = opt_map Key.v x @? y
 
 (* convenience function for linking tcpip.unix or .xen for checksums *)
 let right_tcpip_library ?libs ~sublibs pkg =
-  let min = "4.0.0" and max = "5.0.0" in
+  let min = "5.0.0" and max = "6.0.0" in
   Key.match_ Key.(value target) @@ function
   | #Mirage_key.mode_unix ->
       [ package ~min ~max ?libs ~sublibs:("unix" :: sublibs) pkg ]
@@ -57,7 +57,7 @@ let ipv4_keyed_conf ~ip ?gateway () =
   let connect _ modname = function
     | [ _random; _mclock; etif; arp ] ->
         Fmt.strf "%s.connect@[@ %a@ %a@ %s@ %s@]" modname
-          Fmt.(prefix (unit "~ip:") pp_key)
+          Fmt.(prefix (unit "~cidr:") pp_key)
           ip (opt_opt_key "gateway") gateway etif arp
     | _ -> failwith (connect_err "ipv4 keyed" 4)
   in
@@ -96,7 +96,7 @@ let create_ipv4 ?group ?config ?(random = default_random)
   let config =
     match config with
     | None ->
-        let network = Ipaddr.V4.Prefix.of_address_string_exn "10.0.0.2/24"
+        let network = Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24"
         and gateway = Some (Ipaddr.V4.of_string_exn "10.0.0.1") in
         { network; gateway }
     | Some config -> config

--- a/lib/mirage/mirage_impl_ip.mli
+++ b/lib/mirage/mirage_impl_ip.mli
@@ -23,7 +23,7 @@ val ipv4 : ipv4 Functoria.typ
 val ipv6 : ipv6 Functoria.typ
 
 type ipv4_config = {
-  network : Ipaddr.V4.Prefix.t * Ipaddr.V4.t;
+  network : Ipaddr.V4.Prefix.t;
   gateway : Ipaddr.V4.t option;
 }
 

--- a/lib/mirage/mirage_impl_random.ml
+++ b/lib/mirage/mirage_impl_random.ml
@@ -9,7 +9,7 @@ let random = Type.v RANDOM
 let rng ?(time = default_time) ?(mclock = default_monotonic_clock) () =
   let keys = [ Mirage_key.(v prng) ] in
   let packages =
-    [ package ~sublibs:[ "mirage" ] ~min:"0.7.0" "mirage-crypto-rng" ]
+    [ package ~min:"0.8.0" ~max:"0.9.0" "mirage-crypto-rng-mirage" ]
   in
   let connect _ modname _ =
     (* here we could use the boot argument (--prng) to select the RNG! *)

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -205,6 +205,153 @@ let tracing_size default =
   let key = Arg.opt ~stage:`Configure Arg.int default doc in
   Key.create "tracing_size" key
 
+(** {2 OCaml runtime} *)
+
+let ocaml_section = "OCAML PARAMETERS"
+
+let backtrace =
+  let doc =
+    "Trigger the printing of a stack backtrace when an uncaught exception \
+     aborts the unikernel."
+  in
+  let doc = Arg.info ~docs:ocaml_section ~docv:"BOOL" ~doc [ "backtrace" ] in
+  let key = Arg.opt Arg.bool true doc in
+  Key.create "backtrace" key
+
+let randomize_hashtables =
+  let doc = "Turn on randomization of all hash tables by default." in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"BOOL" ~doc [ "randomize-hashtables" ]
+  in
+  let key = Arg.opt Arg.bool true doc in
+  Key.create "randomize-hashtables" key
+
+let allocation_policy =
+  let doc =
+    "The policy used for allocating in the OCaml heap. Possible values are: \
+     $(i,next-fit), $(i,first-fit), $(i,best-fit). Best-fit is only supported \
+     since OCaml 4.10."
+  in
+  let serialize ppf = function
+    | `Next_fit -> Fmt.pf ppf "`Next_fit"
+    | `First_fit -> Fmt.pf ppf "`First_fit"
+    | `Best_fit -> Fmt.pf ppf "`Best_fit"
+  and conv = Mirage_runtime.Arg.allocation_policy in
+  let conv =
+    Arg.conv ~conv ~runtime_conv:"Mirage_runtime.Arg.allocation_policy"
+      ~serialize
+  in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"ALLOCATION" ~doc [ "allocation-policy" ]
+  in
+  let key = Arg.opt conv `Next_fit doc in
+  Key.create "allocation-policy" key
+
+let minor_heap_size =
+  let doc = "The size of the minor heap (in words). Default: 256k." in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"MINOR SIZE" ~doc [ "minor-heap-size" ]
+  in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "minor-heap-size" key
+
+let major_heap_increment =
+  let doc =
+    "The size increment for the major heap (in words). If less than or equal \
+     1000, it is a percentage of the current heap size. If more than 1000, it \
+     is a fixed number of words. Default: 15."
+  in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"MAJOR INCREMENT" ~doc
+      [ "major-heap-increment" ]
+  in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "major-heap-increment" key
+
+let space_overhead =
+  let doc =
+    "The percentage of live data of wasted memory, due to GC does not \
+     immediately collect unreachable blocks. The major GC speed is computed \
+     from this parameter, it will work more if smaller. Default: 80."
+  in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"SPACE OVERHEAD" ~doc
+      [ "space-overhead" ]
+  in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "space-overhead" key
+
+let max_space_overhead =
+  let doc =
+    "Heap compaction is triggered when the estimated amount of wasted memory \
+     exceeds this (percentage of live data). If above 1000000, compaction is \
+     never triggered. Default: 500."
+  in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"MAX SPACE OVERHEAD" ~doc
+      [ "max-space-overhead" ]
+  in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "max-space-overhead" key
+
+let gc_verbosity =
+  let doc =
+    "GC messages on standard error output. Sum of flags. Check GC module \
+     documentation for details."
+  in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"VERBOSITY" ~doc [ "gc-verbosity" ]
+  in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "gc-verbosity" key
+
+let gc_window_size =
+  let doc =
+    "The size of the window used by the major GC for smoothing out variations \
+     in its workload. Between 1 adn 50, default: 1."
+  in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"WINDOW SIZE" ~doc [ "gc-window-size" ]
+  in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "gc-window-size" key
+
+let custom_major_ratio =
+  let doc =
+    "Target ratio of floating garbage to major heap size for out-of-heap \
+     memory held by custom values. Default: 44."
+  in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"CUSTOM MAJOR RATIO" ~doc
+      [ "custom-major-ratio" ]
+  in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "custom-major-ratio" key
+
+let custom_minor_ratio =
+  let doc =
+    "Bound on floating garbage for out-of-heap memory held by custom values in \
+     the minor heap. Default: 100."
+  in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"CUSTOM MINOR RATIO" ~doc
+      [ "custom-minor-ratio" ]
+  in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "custom-minor-ratio" key
+
+let custom_minor_max_size =
+  let doc =
+    "Maximum amount of out-of-heap memory for each custom value allocated in \
+     the minor heap. Default: 8192 bytes."
+  in
+  let doc =
+    Arg.info ~docs:ocaml_section ~docv:"CUSTOM MINOR MAX SIZE" ~doc
+      [ "custom-minor-max-size" ]
+  in
+  let key = Arg.(opt (some int) None doc) in
+  Key.create "custom-minor-max-size" key
+
 (** {2 General mirage keys} *)
 
 let create_simple ?(group = "") ?(stage = `Both) ~doc ~default conv name =

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -50,15 +50,15 @@ module Arg = struct
   let ipv4_address = of_module "ipv4_address" "V4" (module Ipaddr.V4)
 
   let ipv4 =
-    let serialize fmt (prefix, ip) =
-      Format.fprintf fmt "(Ipaddr.V4.Prefix.of_address_string_exn %S)"
-      @@ Ipaddr.V4.Prefix.to_address_string prefix ip
+    let serialize fmt cidr =
+      Format.fprintf fmt "(Ipaddr.V4.Prefix.of_string_exn %S)"
+      @@ Ipaddr.V4.Prefix.to_string cidr
     in
-    let print fmt (prefix, ip) =
-      Format.fprintf fmt "%s" @@ Ipaddr.V4.Prefix.to_address_string prefix ip
+    let print fmt cidr =
+      Format.fprintf fmt "%s" @@ Ipaddr.V4.Prefix.to_string cidr
     in
     let parse str =
-      match Ipaddr.V4.Prefix.of_address_string str with
+      match Ipaddr.V4.Prefix.of_string str with
       | Error (`Msg m) ->
           `Error (str ^ " is not a valid IPv4 address and netmask: " ^ m)
       | Ok n -> `Ok n

--- a/lib/mirage/mirage_key.mli
+++ b/lib/mirage/mirage_key.mli
@@ -73,6 +73,46 @@ val target_debug : bool key
 val tracing_size : int -> int key
 (** [--tracing-size]: Key setting the tracing ring buffer size. *)
 
+(** {2 OCaml runtime keys}
+
+    The OCaml runtime is usually configurable via the [OCAMLRUNPARAM]
+    environment variable. We provide boot parameters covering these options. *)
+
+val backtrace : bool key
+(** [--backtrace]: Output a backtrace if an uncaught exception terminated the
+    unikernel. *)
+
+val randomize_hashtables : bool key
+(** [--randomize-hashtables]: Randomize all hash tables. *)
+
+(** {3 GC control}
+
+    The OCaml garbage collector can be configured, as described in detail in
+    {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html#TYPEcontrol} GC
+    control}.
+
+    The following keys allow boot time configuration. *)
+
+val allocation_policy : [ `Next_fit | `First_fit | `Best_fit ] key
+
+val minor_heap_size : int option key
+
+val major_heap_increment : int option key
+
+val space_overhead : int option key
+
+val max_space_overhead : int option key
+
+val gc_verbosity : int option key
+
+val gc_window_size : int option key
+
+val custom_major_ratio : int option key
+
+val custom_minor_ratio : int option key
+
+val custom_minor_max_size : int option key
+
 (** {2 Generic keys}
 
     Some keys have a [group] optional argument. This group argument allows to

--- a/lib/mirage/mirage_key.mli
+++ b/lib/mirage/mirage_key.mli
@@ -25,7 +25,7 @@ module Arg : sig
 
   val ipv4_address : Ipaddr.V4.t converter
 
-  val ipv4 : (Ipaddr.V4.Prefix.t * Ipaddr.V4.t) converter
+  val ipv4 : Ipaddr.V4.Prefix.t converter
 
   val ipv6 : Ipaddr.V6.t converter
 
@@ -117,7 +117,7 @@ val interface : ?group:string -> string -> string key
 module V4 : sig
   open Ipaddr.V4
 
-  val network : ?group:string -> Prefix.t * t -> (Prefix.t * t) key
+  val network : ?group:string -> Prefix.t -> Prefix.t key
   (** A network defined by an address and netmask. *)
 
   val gateway : ?group:string -> t option -> t option key

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -64,11 +64,11 @@ module Arg = struct
   let ipv4_address = of_module (module Ipaddr.V4)
 
   let ipv4 =
-    let serialize fmt (prefix, ip) =
-      Format.fprintf fmt "%S" @@ Ipaddr.V4.Prefix.to_address_string prefix ip
+    let serialize fmt cidr =
+      Format.fprintf fmt "%S" @@ Ipaddr.V4.Prefix.to_string cidr
     in
     let parse str =
-      match Ipaddr.V4.Prefix.of_address_string str with
+      match Ipaddr.V4.Prefix.of_string str with
       | Error (`Msg m) ->
           `Error (str ^ " is not a valid IPv4 address and netmask: " ^ m)
       | Ok n -> `Ok n

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -108,6 +108,14 @@ module Arg = struct
       | `Src s, l -> Fmt.pf ppf "%s:%s" s (string_of_level l)
     in
     (parser, serialize)
+
+  let allocation_policy =
+    Cmdliner.Arg.enum
+      [
+        ("next-fit", `Next_fit);
+        ("first-fit", `First_fit);
+        ("best-fit", `Best_fit);
+      ]
 end
 
 include (

--- a/lib_runtime/mirage/mirage_runtime.mli
+++ b/lib_runtime/mirage/mirage_runtime.mli
@@ -72,6 +72,10 @@ module Arg : sig
 
   val log_threshold : log_threshold Cmdliner.Arg.converter
   (** [log_threshold] converts log reporter threshold. *)
+
+  val allocation_policy :
+    [ `Next_fit | `First_fit | `Best_fit ] Cmdliner.Arg.converter
+  (** [allocation_policy] converts allocation policy. *)
 end
 
 include module type of Functoria_runtime with module Arg := Arg

--- a/lib_runtime/mirage/mirage_runtime.mli
+++ b/lib_runtime/mirage/mirage_runtime.mli
@@ -61,7 +61,7 @@ module Arg : sig
   val ipv4_address : Ipaddr.V4.t Cmdliner.Arg.converter
   (** [ipv4] converts an IPv4 address. *)
 
-  val ipv4 : (Ipaddr.V4.Prefix.t * Ipaddr.V4.t) Cmdliner.Arg.converter
+  val ipv4 : Ipaddr.V4.Prefix.t Cmdliner.Arg.converter
   (** [ipv4] converts ipv4/netmask to Ipaddr.V4.t * Ipaddr.V4.Prefix.t . *)
 
   val ipv6 : Ipaddr.V6.t Cmdliner.Arg.converter

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "2.0.0"}
-  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
+  "ipaddr"             {>= "5.0.0"}
   "functoria-runtime"  {>= "3.0.2"}
   "fmt"
   "logs"

--- a/mirage.opam
+++ b/mirage.opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "2.0.0"}
-  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
+  "ipaddr"             {>= "5.0.0"}
   "functoria"          {>= "3.0.2"}
   "bos"
   "astring"

--- a/test/mirage/help/build-help.expected
+++ b/test/mirage/help/build-help.expected
@@ -13,6 +13,58 @@ UNIKERNEL PARAMETERS
            *:info,foo:debug means that that the log threshold is set to info
            for every log sources but the foo which is set to debug. 
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/help/clean-help.expected
+++ b/test/mirage/help/clean-help.expected
@@ -14,6 +14,58 @@ UNIKERNEL PARAMETERS
            *:info,foo:debug means that that the log threshold is set to info
            for every log sources but the foo which is set to debug. 
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/help/configure-help.expected
+++ b/test/mirage/help/configure-help.expected
@@ -13,6 +13,58 @@ UNIKERNEL PARAMETERS
            *:info,foo:debug means that that the log threshold is set to info
            for every log sources but the foo which is set to debug. 
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/help/configure-o-help.expected
+++ b/test/mirage/help/configure-o-help.expected
@@ -13,6 +13,58 @@ UNIKERNEL PARAMETERS
            *:info,foo:debug means that that the log threshold is set to info
            for every log sources but the foo which is set to debug. 
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/help/describe-help.expected
+++ b/test/mirage/help/describe-help.expected
@@ -28,6 +28,58 @@ UNIKERNEL PARAMETERS
            *:info,foo:debug means that that the log threshold is set to info
            for every log sources but the foo which is set to debug. 
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/help/help-build.expected
+++ b/test/mirage/help/help-build.expected
@@ -13,6 +13,58 @@ UNIKERNEL PARAMETERS
            *:info,foo:debug means that that the log threshold is set to info
            for every log sources but the foo which is set to debug. 
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/help/help-clean.expected
+++ b/test/mirage/help/help-clean.expected
@@ -14,6 +14,58 @@ UNIKERNEL PARAMETERS
            *:info,foo:debug means that that the log threshold is set to info
            for every log sources but the foo which is set to debug. 
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/help/help-configure-o.expected
+++ b/test/mirage/help/help-configure-o.expected
@@ -13,6 +13,58 @@ UNIKERNEL PARAMETERS
            *:info,foo:debug means that that the log threshold is set to info
            for every log sources but the foo which is set to debug. 
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/help/help-configure.expected
+++ b/test/mirage/help/help-configure.expected
@@ -13,6 +13,58 @@ UNIKERNEL PARAMETERS
            *:info,foo:debug means that that the log threshold is set to info
            for every log sources but the foo which is set to debug. 
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/help/help-describe.expected
+++ b/test/mirage/help/help-describe.expected
@@ -28,6 +28,58 @@ UNIKERNEL PARAMETERS
            *:info,foo:debug means that that the log threshold is set to info
            for every log sources but the foo which is set to debug. 
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/help/help-query.expected
+++ b/test/mirage/help/help-query.expected
@@ -20,6 +20,58 @@ QUERY OPTIONS
        --no-depext
            Disable call to `opam depext' in the project Makefile.
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/help/query-help.expected
+++ b/test/mirage/help/query-help.expected
@@ -20,6 +20,58 @@ QUERY OPTIONS
        --no-depext
            Disable call to `opam depext' in the project Makefile.
 
+OCAML PARAMETERS
+       --allocation-policy=ALLOCATION (absent=next-fit)
+           The policy used for allocating in the OCaml heap. Possible values
+           are: next-fit, first-fit, best-fit. Best-fit is only supported
+           since OCaml 4.10. 
+
+       --backtrace=BOOL (absent=true)
+           Trigger the printing of a stack backtrace when an uncaught
+           exception aborts the unikernel. 
+
+       --custom-major-ratio=CUSTOM MAJOR RATIO
+           Target ratio of floating garbage to major heap size for
+           out-of-heap memory held by custom values. Default: 44. 
+
+       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
+           Maximum amount of out-of-heap memory for each custom value
+           allocated in the minor heap. Default: 8192 bytes. 
+
+       --custom-minor-ratio=CUSTOM MINOR RATIO
+           Bound on floating garbage for out-of-heap memory held by custom
+           values in the minor heap. Default: 100. 
+
+       --gc-verbosity=VERBOSITY
+           GC messages on standard error output. Sum of flags. Check GC
+           module documentation for details. 
+
+       --gc-window-size=WINDOW SIZE
+           The size of the window used by the major GC for smoothing out
+           variations in its workload. Between 1 adn 50, default: 1. 
+
+       --major-heap-increment=MAJOR INCREMENT
+           The size increment for the major heap (in words). If less than or
+           equal 1000, it is a percentage of the current heap size. If more
+           than 1000, it is a fixed number of words. Default: 15. 
+
+       --max-space-overhead=MAX SPACE OVERHEAD
+           Heap compaction is triggered when the estimated amount of wasted
+           memory exceeds this (percentage of live data). If above 1000000,
+           compaction is never triggered. Default: 500. 
+
+       --minor-heap-size=MINOR SIZE
+           The size of the minor heap (in words). Default: 256k. 
+
+       --randomize-hashtables=BOOL (absent=true)
+           Turn on randomization of all hash tables by default. 
+
+       --space-overhead=SPACE OVERHEAD
+           The percentage of live data of wasted memory, due to GC does not
+           immediately collect unreachable blocks. The major GC speed is
+           computed from this parameter, it will work more if smaller.
+           Default: 80. 
+
 MIRAGE PARAMETERS
        -g  Enables target-specific support for debugging. Supported targets:
            hvt (compiles solo5-hvt with GDB server support). 

--- a/test/mirage/query/opam-hvt.expected
+++ b/test/mirage/query/opam-hvt.expected
@@ -10,13 +10,13 @@ build: ["mirage" "build" "--config-file" "config.ml"]
 
 depends: [
   "lwt"
-  "mirage" {build &  >= "3.7.0" & < "3.8.0"}
+  "mirage" {build &  >= "3.8.0" & < "3.9.0"}
   "mirage-bootvar-solo5" { >= "0.6.0" & < "0.7.0"}
   "mirage-clock-freestanding" { >= "3.0.0" & < "4.0.0"}
   "mirage-logs" { >= "1.2.0" & < "2.0.0"}
-  "mirage-runtime" { >= "3.7.0" & < "3.8.0"}
+  "mirage-runtime" { >= "3.8.0" & < "3.9.0"}
   "mirage-solo5" { >= "0.6.1" & < "0.7.0"}
-  "mirage-types" { >= "3.7.0" & < "3.8.0"}
+  "mirage-types" { >= "3.8.0" & < "3.9.0"}
   "ocaml" {build &  >= "4.06.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/test/mirage/query/opam.expected
+++ b/test/mirage/query/opam.expected
@@ -10,12 +10,12 @@ build: ["mirage" "build" "--config-file" "config.ml"]
 
 depends: [
   "lwt"
-  "mirage" {build &  >= "3.7.0" & < "3.8.0"}
+  "mirage" {build &  >= "3.8.0" & < "3.9.0"}
   "mirage-bootvar-unix" { >= "0.1.0" & < "0.2.0"}
   "mirage-clock-unix" { >= "3.0.0" & < "4.0.0"}
   "mirage-logs" { >= "1.2.0" & < "2.0.0"}
-  "mirage-runtime" { >= "3.7.0" & < "3.8.0"}
-  "mirage-types" { >= "3.7.0" & < "3.8.0"}
+  "mirage-runtime" { >= "3.8.0" & < "3.9.0"}
+  "mirage-types" { >= "3.8.0" & < "3.9.0"}
   "mirage-unix" { >= "4.0.0" & < "5.0.0"}
   "ocaml" {build &  >= "4.06.0"}
   "ocamlbuild" {build}

--- a/test/mirage/query/packages-hvt.expected
+++ b/test/mirage/query/packages-hvt.expected
@@ -1,11 +1,11 @@
 "lwt"
-"mirage" {build &  >= "3.7.0" & < "3.8.0"}
+"mirage" {build &  >= "3.8.0" & < "3.9.0"}
 "mirage-bootvar-solo5" { >= "0.6.0" & < "0.7.0"}
 "mirage-clock-freestanding" { >= "3.0.0" & < "4.0.0"}
 "mirage-logs" { >= "1.2.0" & < "2.0.0"}
-"mirage-runtime" { >= "3.7.0" & < "3.8.0"}
+"mirage-runtime" { >= "3.8.0" & < "3.9.0"}
 "mirage-solo5" { >= "0.6.1" & < "0.7.0"}
-"mirage-types" { >= "3.7.0" & < "3.8.0"}
+"mirage-types" { >= "3.8.0" & < "3.9.0"}
 "ocaml" {build &  >= "4.06.0"}
 "ocamlbuild" {build}
 "ocamlfind" {build}

--- a/test/mirage/query/packages.expected
+++ b/test/mirage/query/packages.expected
@@ -1,10 +1,10 @@
 "lwt"
-"mirage" {build &  >= "3.7.0" & < "3.8.0"}
+"mirage" {build &  >= "3.8.0" & < "3.9.0"}
 "mirage-bootvar-unix" { >= "0.1.0" & < "0.2.0"}
 "mirage-clock-unix" { >= "3.0.0" & < "4.0.0"}
 "mirage-logs" { >= "1.2.0" & < "2.0.0"}
-"mirage-runtime" { >= "3.7.0" & < "3.8.0"}
-"mirage-types" { >= "3.7.0" & < "3.8.0"}
+"mirage-runtime" { >= "3.8.0" & < "3.9.0"}
+"mirage-types" { >= "3.8.0" & < "3.9.0"}
 "mirage-unix" { >= "4.0.0" & < "5.0.0"}
 "ocaml" {build &  >= "4.06.0"}
 "ocamlbuild" {build}

--- a/test/mirage/random-unix/main.ml.expected
+++ b/test/mirage/random-unix/main.ml.expected
@@ -80,7 +80,7 @@ let static_ipv4_make__76 = lazy (
   __mclock__9 >>= fun _mclock__9 ->
   __ethernet_make__66 >>= fun _ethernet_make__66 ->
   __arp_make__69 >>= fun _arp_make__69 ->
-  Static_ipv4_make__76.connect ~ip:(Key_gen.ipv4 ())
+  Static_ipv4_make__76.connect ~cidr:(Key_gen.ipv4 ())
                             ?gateway:(Key_gen.ipv4_gateway ())
                             _ethernet_make__66 _arp_make__69
   )

--- a/test/mirage/random-xen/main.ml.expected
+++ b/test/mirage/random-xen/main.ml.expected
@@ -80,7 +80,7 @@ let static_ipv4_make__76 = lazy (
   __mclock__9 >>= fun _mclock__9 ->
   __ethernet_make__66 >>= fun _ethernet_make__66 ->
   __arp_make__69 >>= fun _arp_make__69 ->
-  Static_ipv4_make__76.connect ~ip:(Key_gen.ipv4 ())
+  Static_ipv4_make__76.connect ~cidr:(Key_gen.ipv4 ())
                             ?gateway:(Key_gen.ipv4_gateway ())
                             _ethernet_make__66 _arp_make__69
   )


### PR DESCRIPTION
these are two commits:
- ipaddr 5.0.0 compatibility
- exposing ocamlparam as boot arguments (and removing the hardcoded `Printexc.record_backtrace true`)

//cc @samoht 