### PR TITLE
mirage build: remove predicate(...), which is no longer necessary

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,8 +1,2 @@
-version = 0.14.2
-break-cases=all
-break-infix=fit-or-vertical
-field-space=loose
-margin=79
-parens-tuple=always
-sequence-style=terminator
-type-decl=sparse
+version = 0.15.0
+disable = true

--- a/lib/mirage_build.ml
+++ b/lib/mirage_build.ml
@@ -8,8 +8,7 @@ module Info = Functoria.Info
 
 let compile ignore_dirs libs warn_error target =
   let tags =
-    [ Fmt.strf "predicate(%s)" (backend_predicate target);
-      "warn(A-4-41-42-44-48)";
+    [ "warn(A-4-41-42-44-48)";
       "debug";
       "bin_annot";
       "strict_sequence";

--- a/lib/mirage_impl_misc.ml
+++ b/lib/mirage_impl_misc.ml
@@ -6,12 +6,6 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 let get_target i = Mirage_key.(get (Functoria.Info.context i) target)
 
-(* Mirage implementation backing the target. *)
-let backend_predicate = function
-  | #Mirage_key.mode_xen -> "mirage_xen"
-  | #Mirage_key.mode_solo5 -> "mirage_solo5"
-  | #Mirage_key.mode_unix -> "mirage_unix"
-
 let connect_err name number =
   Fmt.strf "The %s connect expects exactly %d argument%s"
     name number (if number = 1 then "" else "s")

--- a/lib/mirage_impl_misc.mli
+++ b/lib/mirage_impl_misc.mli
@@ -3,7 +3,6 @@ open Rresult
 module Log : Logs.LOG
 
 val get_target : Functoria.Info.t -> Mirage_key.mode
-val backend_predicate : Mirage_key.mode -> string
 
 val connect_err : string -> int -> string
 


### PR DESCRIPTION
This was introduced in #636 for building mirage-entropy and nocrypto, but is no
longer used and necessary. The build ecosystem changed since then.