### PR TITLE
opam, generated opam: bump lower bound to OCaml 4.08

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -221,7 +221,7 @@ module Project = struct
         (* XXX: use %%VERSION_NUM%% here instead of hardcoding a version? *)
         let min = "3.8.1" and max = "3.9.0" in
         let common = [
-          package ~build:true ~min:"4.06.0" "ocaml";
+          package ~build:true ~min:"4.08.0" "ocaml";
           package "lwt";
           package ~min ~max "mirage-types-lwt";
           package ~min ~max "mirage-types";

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -17,7 +17,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.1.0"}
   "ipaddr"             {>= "5.0.0"}
   "functoria-runtime"  {>= "3.0.2"}

--- a/mirage-types-lwt.opam
+++ b/mirage-types-lwt.opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends:   [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.1.0"}
   "mirage-types" {= version}
 ]

--- a/mirage-types.opam
+++ b/mirage-types.opam
@@ -17,7 +17,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.1.0"}
   "mirage-device" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}

--- a/mirage.opam
+++ b/mirage.opam
@@ -17,7 +17,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.1.0"}
   "ipaddr"             {>= "5.0.0"}
   "functoria"          {>= "3.1.0"}


### PR DESCRIPTION
Several libraries used by mirage are supported on OCaml 4.08 and above, let's
bump the lower bound to 4.08.