### PR TITLE
Preview: upgrade to ocamlformat.0.17.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.15.0
+version = 0.16.0
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.16.0
+version = 0.17.0
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/lib/functoria/action.ml
+++ b/lib/functoria/action.ml
@@ -168,7 +168,7 @@ let rec interpret_command : type r. r command -> r or_err = function
       Log.debug (fun l -> l "size-of %a" Fpath.pp path);
       match Bos.OS.Path.stat path with
       | Ok s -> Ok (Some s.Unix.st_size)
-      | _ -> Ok None )
+      | _ -> Ok None)
   | Run_cmd cmd -> Rresult.(interpret_cmd cmd >>| fun _ -> ())
   | Run_cmd_out cmd -> interpret_cmd cmd
   | Set_var (c, v) ->
@@ -215,7 +215,7 @@ let rec interpret_command : type r. r command -> r or_err = function
         Ok r
       with e ->
         Rresult.R.error_msgf "couldn't open output channel for %s: %a" purpose
-          Fmt.exn e )
+          Fmt.exn e)
 
 and run : type r. r t -> r or_err = function
   | Done r -> Ok r
@@ -393,7 +393,7 @@ end = struct
           t.files []
         |> function
         | [] -> None
-        | x -> Some (List.rev x) )
+        | x -> Some (List.rev x))
 
   let write t path f =
     let path = mk_path t path in
@@ -497,7 +497,7 @@ let rec interpret_dry : type r. env:Env.t -> r command -> r domain =
       | None ->
           dom
             (error_msg "a file named '%a' already exists" Fpath.pp path)
-            env [ log "error" ] )
+            env [ log "error" ])
   | Rmdir path ->
       Log.debug (fun l -> l "Rmdir %a" Fpath.pp path);
       let log s = Fmt.str "Rmdir %a (%s)" Fpath.pp path s in
@@ -516,7 +516,7 @@ let rec interpret_dry : type r. env:Env.t -> r command -> r domain =
           match List.filter filter es with
           | ([] | [ _ ]) as e ->
               dom (Ok e) env [ logs "%d entry" (List.length e) ]
-          | es -> dom (Ok es) env [ logs "%d entries" (List.length es) ] ) )
+          | es -> dom (Ok es) env [ logs "%d entries" (List.length es) ]))
   | Rm path -> (
       Log.debug (fun l -> l "Rm %a" Fpath.pp path);
       let log s = Fmt.str "Rm %a (%s)" Fpath.pp path s in
@@ -524,8 +524,7 @@ let rec interpret_dry : type r. env:Env.t -> r command -> r domain =
       | Some (env, b) ->
           dom (Ok ()) env [ log (if b then "removed" else "no-op") ]
       | None ->
-          dom (error_msg "%a is a directory" Fpath.pp path) env [ log "error" ]
-      )
+          dom (error_msg "%a is a directory" Fpath.pp path) env [ log "error" ])
   | Is_file path ->
       Log.debug (fun l -> l "Is_file %a" Fpath.pp path);
       let r = Env.is_file env path in
@@ -547,7 +546,7 @@ let rec interpret_dry : type r. env:Env.t -> r command -> r domain =
       let domain = interpret_dry_cmd env cmd in
       match domain.result with
       | Ok _ -> { domain with result = Ok () }
-      | Error _ as r -> { domain with result = r } )
+      | Error _ as r -> { domain with result = r })
   | Run_cmd_out cmd -> interpret_dry_cmd env cmd
   | Write_file (path, s) ->
       Log.debug (fun l -> l "Write_file %a" Fpath.pp path);
@@ -563,7 +562,7 @@ let rec interpret_dry : type r. env:Env.t -> r command -> r domain =
           let log =
             Fmt.str "Read %a (%d bytes)" Fpath.pp path (String.length r)
           in
-          dom (Ok r) env [ log ] )
+          dom (Ok r) env [ log ])
   | Tmp_file (_, pat) ->
       Log.debug (fun l -> l "Tmp_file %s" Fmt.(str pat "*"));
       let r = Env.tmp_file env pat in
@@ -631,7 +630,7 @@ and dry_run : type r. env:Env.t -> r t -> r domain =
         let new_log = List.rev domain.logs @ log in
         match domain.result with
         | Ok x -> go (k x) ~env:domain.env new_log
-        | Error _ as e -> dom e domain.env new_log )
+        | Error _ as e -> dom e domain.env new_log)
   in
   let domain = go t ~env [] in
   { domain with logs = List.rev domain.logs }

--- a/lib/functoria/cli.ml
+++ b/lib/functoria/cli.ml
@@ -357,7 +357,7 @@ module Subcommands = struct
           | `Ok t when t = "topics" ->
               List.iter print_endline cmds;
               `Ok ()
-          | `Ok t -> `Help (man_format, Some t) )
+          | `Ok t -> `Help (man_format, Some t))
     in
     ( Term.(
         const (fun args _ _ () -> Help args)
@@ -469,7 +469,7 @@ let rec find_next_kind argv i =
           Fmt.invalid_arg "ambiguous sub-command: %a\n%!"
             Fmt.Dump.(list string)
             (List.map fst cs)
-      | [ (_, k) ] -> (Some k, remove_argv argv i) )
+      | [ (_, k) ] -> (Some k, remove_argv argv i))
 
 let rec find_next_choice argv i =
   match next_pos_arg argv i with
@@ -487,7 +487,7 @@ let rec find_next_choice argv i =
               (Some c, remove_argv argv i)
           | `Query ->
               let k, argv = find_next_kind argv (i + 1) in
-              (Some (`Query k), remove_argv argv i) ) )
+              (Some (`Query k), remove_argv argv i)))
 
 let peek_choice argv =
   try match find_next_choice argv 1 with Some c, _ -> `Ok c | _ -> `Default

--- a/lib/functoria/context_cache.ml
+++ b/lib/functoria/context_cache.ml
@@ -62,7 +62,7 @@ let read file =
             args
         in
         Action.ok args
-      with Failure e -> Action.error e )
+      with Failure e -> Action.error e)
 
 let peek t term =
   match Cmdliner.Term.eval_peek_opts ~argv:t term with

--- a/lib/functoria/filegen.ml
+++ b/lib/functoria/filegen.ml
@@ -55,13 +55,13 @@ module Make (P : PROJECT) = struct
         let lines = String.cuts ~sep:"\n" ~empty:true (String.trim contents) in
         match List.rev lines with
         | x :: _ -> String.is_infix ~affix:(short_headers `Sexp) x
-        | _ -> false )
+        | _ -> false)
     | _ -> (
         match lang file with
         | None -> false
         | Some lang ->
             let affix = short_headers lang in
-            String.is_infix ~affix contents )
+            String.is_infix ~affix contents)
 
   let can_overwrite file =
     Action.is_file file >>= function
@@ -82,7 +82,7 @@ module Make (P : PROJECT) = struct
       | _ -> (
           match lang file with
           | None -> Fmt.invalid_arg "%a: invalide lang" Fpath.pp file
-          | Some lang -> Fmt.str "%s\n\n%s" (headers lang) contents )
+          | Some lang -> Fmt.str "%s\n\n%s" (headers lang) contents)
 
   let write file contents =
     can_overwrite file >>= function

--- a/lib/functoria/impl.ml
+++ b/lib/functoria/impl.ml
@@ -151,11 +151,11 @@ let rec equal : type t1 t2. t1 t -> t2 t -> (t1, t2) Typeid.witness =
           equal_tl c.args c'.args (Device.witness c.dev c'.dev) )
       with
       | true, Eq -> Eq
-      | _ -> NotEq )
+      | _ -> NotEq)
   | App a, App b -> (
       match equal_tl a.args b.args (equal a.f b.f) with
       | Eq -> Eq
-      | NotEq -> NotEq )
+      | NotEq -> NotEq)
   | If x1, If x2 -> (
       match
         ( equal x1.default x2.default,
@@ -166,7 +166,7 @@ let rec equal : type t1 t2. t1 t -> t2 t -> (t1, t2) Typeid.witness =
             x1.branches x2.branches )
       with
       | Eq, true, true -> Eq
-      | _ -> NotEq )
+      | _ -> NotEq)
   | _ -> NotEq
 
 and equal_abstract (Abstract x) (Abstract y) = Typeid.to_bool @@ equal x y
@@ -181,7 +181,7 @@ and equal_tl :
   match (x, y, eq) with
   | Nil, Nil, Eq -> Eq
   | Cons (h1, t1), Cons (h2, t2), Eq -> (
-      match (equal h1 h2, equal_tl t1 t2 Eq) with Eq, Eq -> Eq | _ -> NotEq )
+      match (equal h1 h2, equal_tl t1 t2 Eq) with Eq, Eq -> Eq | _ -> NotEq)
   | _ -> NotEq
 
 module Tbl = Hashtbl.Make (struct

--- a/lib/functoria/info.ml
+++ b/lib/functoria/info.ml
@@ -79,7 +79,7 @@ let v ~packages ~keys ~context ~build_cmd ~src name =
         | Some p' -> (
             match Package.merge p p' with
             | Some p -> String.Map.add n p m
-            | None -> m ))
+            | None -> m))
       String.Map.empty packages
   in
   { name; keys; packages; context; output = None; opam }

--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -151,7 +151,7 @@ module Arg = struct
     | 0 -> (
         match compare x.info y.info with
         | 0 -> compare_kind x.kind y.kind
-        | i -> i )
+        | i -> i)
     | i -> i
 
   let hash x =
@@ -193,7 +193,7 @@ module Arg = struct
     | Flag -> (serialize bool) ppf v
     | Opt (_, c) -> (serialize c) ppf v
     | Required c -> (
-        match v with Some v -> (serialize c) ppf v | None -> assert false )
+        match v with Some v -> (serialize c) ppf v | None -> assert false)
 
   (* This is only called by serialize_ro, hence a configure time
            key, so the value is known. *)
@@ -245,7 +245,7 @@ let rec compare (Any x) (Any y) =
   | 0 -> (
       match Arg.compare x.arg y.arg with
       | 0 -> compare_setters x.setters y.setters
-      | i -> i )
+      | i -> i)
   | i -> i
 
 and compare_setters : type a b. a setter list -> b setter list -> int =
@@ -255,7 +255,7 @@ and compare_setters : type a b. a setter list -> b setter list -> int =
   | [], _ -> -1
   | _, [] -> 1
   | Setter (x, _) :: tx, Setter (y, _) :: ty -> (
-      match compare (Any x) (Any y) with 0 -> compare_setters tx ty | i -> i )
+      match compare (Any x) (Any y) with 0 -> compare_setters tx ty | i -> i)
 
 (* Set of keys, without runtime name conflicts. This is useful to create a
    valid cmdliner term. *)

--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -254,7 +254,7 @@ module Make (P : S) = struct
         | Cli.Clean t ->
             let t = with_output t in
             Log.info (fun m -> pp_info m (Some Logs.Debug) t);
-            clean t )
+            clean t)
 
   let action_run args a =
     if not args.Cli.dry_run then Action.run a
@@ -278,7 +278,7 @@ module Make (P : S) = struct
     | Some file -> (
         Action.is_file file >>= function
         | false -> Action.errorf "cannot find file `%a'" Fpath.pp file
-        | true -> Context_cache.read file >|= fun t -> t )
+        | true -> Context_cache.read file >|= fun t -> t)
 
   let run_configure_with_argv argv args config =
     (*   whether to fully evaluate the graph *)

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -53,7 +53,7 @@ module Make (P : S) = struct
         let file = context_file t in
         Action.is_file file >|= function
         | false -> argv (* should only happen when doing configure --help *)
-        | true -> Array.append argv [| "--context"; Fpath.to_string file |] )
+        | true -> Array.append argv [| "--context"; Fpath.to_string file |])
 
   let run_cmd ?ppf ?err_ppf command =
     let err = match err_ppf with None -> None | Some f -> Some (`Fmt f) in
@@ -276,7 +276,7 @@ module Make (P : S) = struct
         | _ ->
             run args
             @@ handle_parse_args ~save_args:false args ?ppf:help_ppf ?err_ppf
-                 argv )
+                 argv)
 
   let run () = run_with_argv Sys.argv
 end

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -410,13 +410,11 @@ module Project = struct
           (* The Mirage/Xen PVH platform package has different version numbers
              than Mirage/Solo5, so needs its own case here. *)
           package ~min:"0.6.0" ~max:"0.7.0" ~libs:[] "solo5-bindings-xen"
-          :: package ~min:"6.0.0" ~max:"7.0.0" "mirage-xen"
-          :: common
+          :: package ~min:"6.0.0" ~max:"7.0.0" "mirage-xen" :: common
       | #Mirage_key.mode_solo5 as tgt ->
           package ~min:"0.6.0" ~max:"0.7.0" ~libs:[]
             (Mirage_configure_solo5.solo5_bindings_pkg tgt)
-          :: package ~min:"0.6.1" ~max:"0.7.0" "mirage-solo5"
-          :: common
+          :: package ~min:"0.6.1" ~max:"0.7.0" "mirage-solo5" :: common
     in
     let install_v i = Key.match_ Key.(value target) (install i) in
     let extra_deps = List.map dep jobs in

--- a/lib/mirage/mirage_build.ml
+++ b/lib/mirage/mirage_build.ml
@@ -75,11 +75,11 @@ let build i =
   let libs = Info.libraries i in
   let target_debug = Key.(get ctx target_debug) in
   compile ignore_dirs libs warn_error target >>= fun () ->
-  ( match target with
+  (match target with
   | #Mirage_key.mode_solo5 | #Mirage_key.mode_xen ->
       Mirage_configure_solo5.generate_manifest_c () >>= fun () ->
       Mirage_configure_solo5.compile_manifest target
-  | _ -> Action.ok () )
+  | _ -> Action.ok ())
   >>= fun () ->
   link i name target target_debug >|= fun out ->
   Log.info (fun m -> m "Build succeeded: %s" out)

--- a/lib/mirage/mirage_configure.ml
+++ b/lib/mirage/mirage_configure.ml
@@ -36,13 +36,13 @@ let configure i =
   if target_debug && target <> `Hvt then
     Log.warn (fun m -> m "-g not supported for target: %a" Key.pp_target target);
   configure_myocamlbuild () >>= fun () ->
-  ( match target with
+  (match target with
   | #Mirage_key.mode_solo5 -> generate_manifest_json true ()
   (* On Xen, a Solo5 manifest must be present to keep the build system and
      Solo5 happy, but we intentionally do not generate any devices[] as
      their naming does not follow the Solo5 rules. *)
   | #Mirage_key.mode_xen -> generate_manifest_json false ()
-  | _ -> Action.ok () )
+  | _ -> Action.ok ())
   >>= fun () ->
   match target with
   | `Xen ->
@@ -57,8 +57,8 @@ let files i =
   let target = Key.(get ctx target) in
   Fpath.v "myocamlbuild.ml"
   ::
-  ( match target with
+  (match target with
   | `Virtio -> Mirage_configure_solo5.files i
   | #Mirage_key.mode_solo5 -> Mirage_configure_solo5.files i
   | `Xen -> Mirage_configure_xen.files i
-  | _ -> [] )
+  | _ -> [])

--- a/lib/mirage/mirage_impl_misc.ml
+++ b/lib/mirage/mirage_impl_misc.ml
@@ -75,7 +75,7 @@ let extra_c_artifacts target pkgs =
             if ldflags <> "" then
               let ldflags = String.cuts ldflags ~sep:" " in
               let ldflags = List.map (expand_name ~lib) ldflags in
-              acc @ (("-L" ^ dir) :: ldflags)
+              acc @ ("-L" ^ dir) :: ldflags
             else acc)
       [] data
   in

--- a/lib/mirage/mirage_impl_misc.ml
+++ b/lib/mirage/mirage_impl_misc.ml
@@ -56,7 +56,7 @@ let rec expand_name ~lib param =
       | None -> prefix ^ Fpath.(to_string (v lib / name))
       | Some (name, rest) ->
           let rest = expand_name ~lib rest in
-          prefix ^ Fpath.(to_string (v lib / name / rest)) )
+          prefix ^ Fpath.(to_string (v lib / name / rest)))
 
 (* Get the linker flags for any extra C objects we depend on.
  * This is needed when building a Xen/Solo5 image as we do the link manually. *)

--- a/lib/mirage/mirage_impl_stack.ml
+++ b/lib/mirage/mirage_impl_stack.ml
@@ -25,7 +25,7 @@ let stackv4_direct_conf () =
     | _ -> failwith (connect_err "direct stackv4" 9)
   in
   impl ~packages_v ~connect "Tcpip_stack_direct.Make"
-    ( time
+    (time
     @-> random
     @-> network
     @-> ethernet
@@ -34,7 +34,7 @@ let stackv4_direct_conf () =
     @-> Mirage_impl_icmp.icmpv4
     @-> udpv4
     @-> tcpv4
-    @-> stackv4 )
+    @-> stackv4)
 
 let direct_stackv4 ?(mclock = default_monotonic_clock) ?(time = default_time)
     ?(random = rng ~time ~mclock ()) network eth arp ip =
@@ -124,14 +124,14 @@ let stackv6_direct_conf () =
     | _ -> failwith (connect_err "direct stackv6" 9)
   in
   impl ~packages_v ~connect "Tcpip_stack_direct.MakeV6"
-    ( time
+    (time
     @-> random
     @-> network
     @-> ethernet
     @-> ipv6
     @-> udpv6
     @-> tcpv6
-    @-> stackv6 )
+    @-> stackv6)
 
 let direct_stackv6 ?(mclock = default_monotonic_clock)
     ?(random = default_random) ?(time = default_time) network eth ip =
@@ -191,7 +191,7 @@ let stackv4v6_direct_conf () =
     | _ -> failwith (connect_err "direct stack" 8)
   in
   impl ~packages_v ~connect "Tcpip_stack_direct.MakeV4V6"
-    ( time
+    (time
     @-> random
     @-> network
     @-> ethernet
@@ -200,7 +200,7 @@ let stackv4v6_direct_conf () =
     @-> Mirage_impl_icmp.icmpv4
     @-> udp
     @-> tcp
-    @-> stackv4v6 )
+    @-> stackv4v6)
 
 let direct_stackv4v6 ?(mclock = default_monotonic_clock)
     ?(random = default_random) ?(time = default_time) ~ipv4_only ~ipv6_only

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -104,8 +104,8 @@ let target_conv : mode Cmdliner.Arg.converter =
       if s = "ukvm" then (
         if !first_ukvm_mention then (
           Logs.warn (fun m -> m "%s" ukvm_warning);
-          first_ukvm_mention := false );
-        "hvt" )
+          first_ukvm_mention := false);
+        "hvt")
       else s
     in
     parser str
@@ -132,7 +132,7 @@ let default_target =
   | exception Not_found -> (
       match Action.run @@ Action.run_cmd_out Bos.Cmd.(v "uname" % "-s") with
       | Ok "Darwin" -> `MacOSX
-      | _ -> `Unix )
+      | _ -> `Unix)
 
 let target =
   let doc =

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -34,7 +34,7 @@ let set_level ~default l =
             Fmt.(pf stdout)
               "%a %s is not a valid log source.\n%!"
               Fmt.(styled `Yellow string)
-              "Warning:" src ))
+              "Warning:" src))
     l
 
 module Arg = struct
@@ -109,7 +109,7 @@ module Arg = struct
 end
 
 include (
-  Functoria_runtime : module type of Functoria_runtime with module Arg := Arg )
+  Functoria_runtime : module type of Functoria_runtime with module Arg := Arg)
 
 let exit_hooks = ref []
 


### PR DESCRIPTION
edit: This is a preview of the not-yet-released ocamlformat.0.17.0, please wait until the package is published in opam to merge this PR.

Hi, this pull-request is a preview of the soon to be released ocamlformat.0.16.0. The main change in the diff is that `indicate-multiline-delimiters` option has now be switched to `no` on the conventional profile to improve consistency and minimize the diffs in the future.
Let me now if you notice any regressions.