### PR TITLE
redirect stderr to /dev/null when invoking git

### DIFF
--- a/lib/mirage_configure.ml
+++ b/lib/mirage_configure.ml
@@ -60,9 +60,9 @@ let find_git () =
   Bos.OS.Dir.current () >>= fun cwd ->
   find cwd None >>= fun subdir ->
   let git_branch = Bos.Cmd.(v "git" % "rev-parse" % "--abbrev-ref" % "HEAD") in
-  Bos.OS.Cmd.(run_out git_branch |> out_string |> success) >>= fun branch ->
+  Bos.OS.Cmd.(run_out ~err:err_null git_branch |> out_string |> success) >>= fun branch ->
   let git_remote = Bos.Cmd.(v "git" % "remote" % "get-url" % "origin") in
-  Bos.OS.Cmd.(run_out git_remote |> out_string |> success) >>| fun git_url ->
+  Bos.OS.Cmd.(run_out ~err:err_null git_remote |> out_string |> success) >>| fun git_url ->
   subdir, branch, git_url
 
 let configure_opam ~name info =


### PR DESCRIPTION
As reported in #1188, in case no git remote is specified (or no branch
is configured), git will complain to stderr "fatal: No such remote 'origin'".
The code in question is used to include a src url into the generated opam
file on a best-effort basis, and already handles errors (e.g. the unikernel is
not developed in a git repository) by using a dummy url.