### PR TITLE
Makefile: check that a single opam file is present

### DIFF
--- a/lib/mirage_configure.ml
+++ b/lib/mirage_configure.ml
@@ -143,10 +143,13 @@ let configure_makefile ~no_depext ~opam_name =
                   \t$(OPAM) depext --yes --update %s ;\\\n\
                   \t$(OPAM) pin remove --no-action %s\n\
                   \n\
+                  CHECK_ONE_OPAM_FILE=`/bin/sh -c 'if [ $$(ls *opam | wc -l) -ne 1 ]; then exit 1; fi'`\n\
+                  \n\
                   .PHONY: all depend depends clean build\n\
                   all:: build\n\
                   \n\
                   depend depends::%s\n\
+                  \t$(CHECK_ONE_OPAM_FILE)\n\
                   \t$(OPAM) install -y --deps-only .\n\
                   \n\
                   build::\n\


### PR DESCRIPTION
In #1198 a failure was observed if there are spurious opam files present
in the current working directory. While we can't inside of mirage handle this
properly, we can protect the `opam install -y --deps-only .` (which installs
dependencies of all present opam files) by checking that exactly one opam
file is present in the current working directory.

as noted in #1198 I don't see how we can -- inside mirage -- handle the case that dune exits due to an opam file in the working directory which name is not a dune project name.