### PR TITLE
fix Mirage_key.Arg.ip_address (serialise emitted superfluous '.')

### DIFF
--- a/lib/mirage_key.ml
+++ b/lib/mirage_key.ml
@@ -30,7 +30,7 @@ module Arg = struct
       | Error (`Msg m) -> `Error ("Can't parse ip address: "^s^": "^m)
       | Ok ip -> `Ok ip
     and serialize ppf t =
-      Fmt.pf ppf "(Ipaddr.%s.of_string_exn %S)" m (to_string t)
+      Fmt.pf ppf "(%s.of_string_exn %S)" m (to_string t)
     and pp ppf t =
       Fmt.string ppf (to_string t)
     in
@@ -48,13 +48,13 @@ module Arg = struct
   let of_module (type t) d m (module M:S with type t = t) =
     make d m M.of_string M.to_string
 
-  let ipv4_address = of_module "ipv4_address" "V4" (module Ipaddr.V4)
-  let ipv4 = of_module "ipv4" "V4.Prefix" (module Ipaddr.V4.Prefix)
+  let ipv4_address = of_module "ipv4_address" "Ipaddr.V4" (module Ipaddr.V4)
+  let ipv4 = of_module "ipv4" "Ipaddr.V4.Prefix" (module Ipaddr.V4.Prefix)
 
-  let ipv6_address = of_module "ipv6_address" "V6" (module Ipaddr.V6)
-  let ipv6 = of_module "ipv6" "V6.Prefix" (module Ipaddr.V6.Prefix)
+  let ipv6_address = of_module "ipv6_address" "Ipaddr.V6" (module Ipaddr.V6)
+  let ipv6 = of_module "ipv6" "Ipaddr.V6.Prefix" (module Ipaddr.V6.Prefix)
 
-  let ip_address = of_module "ip_address" "" (module Ipaddr)
+  let ip_address = of_module "ip_address" "Ipaddr" (module Ipaddr)
 end
 
 (** {2 Documentation helper} *)


### PR DESCRIPTION
unfortunately this slipped through the release 3.10.. it only affects users of `Mirage_key.Arg.ip_address` -- I'll do a 3.10.1 release