### PR TITLE
WIP: [Mirage 3.x] Adapt to Solo5 and ocaml-freestanding 0.7.0

### DIFF
--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -265,8 +265,8 @@ module Project = struct
           package ~min:"6.0.0" ~max:"7.0.0" "mirage-xen" ::
           common
         | #Mirage_key.mode_solo5 as tgt ->
-          package ~min:"0.6.0" ~max:"0.7.0" ~ocamlfind:[] (Mirage_configure_solo5.solo5_bindings_pkg tgt) ::
-          package ~min:"0.6.1" ~max:"0.7.0" "mirage-solo5" ::
+          package ~min:"0.7.0" ~max:"0.8.0" ~ocamlfind:[] (Mirage_configure_solo5.solo5_bindings_pkg tgt) ::
+          package ~min:"0.6.5" ~max:"0.8.0" "mirage-solo5" ::
           common
 
       method! build = build

--- a/lib/mirage_configure_solo5.ml
+++ b/lib/mirage_configure_solo5.ml
@@ -73,14 +73,20 @@ let solo5_platform_pkg = function
   | _ ->
     invalid_arg "solo5 platform package only defined for solo5 targets"
 
-let cflags pkg = pkg_config pkg ["--cflags"]
+let cc target =
+  solo5_config target ["--cc"] >>= fun s ->
+  Rresult.R.open_error_msg (Bos.Cmd.of_string s)
+
+let cflags target =
+  solo5_config target ["--cflags"] >>= fun s ->
+  Rresult.R.open_error_msg (Bos.Cmd.of_string s)
 
 let compile_manifest target =
-  let bindings = solo5_bindings_pkg target in
   let c = "_build/manifest.c" in
   let obj = "_build/manifest.o" in
-  cflags bindings >>= fun cflags ->
-  let cmd = Bos.Cmd.(v "cc" %% of_list cflags % "-c" % c % "-o" % obj)
+  cc target >>= fun cc ->
+  cflags target >>= fun cflags ->
+  let cmd = Bos.Cmd.(cc %% cflags % "-c" % c % "-o" % obj)
   in
   Log.info (fun m -> m "executing %a" Bos.Cmd.pp cmd);
   Bos.OS.Cmd.run cmd

--- a/lib/mirage_impl_misc.ml
+++ b/lib/mirage_impl_misc.ml
@@ -54,8 +54,22 @@ let pkg_config pkgs args =
   in
   Bos.OS.Env.set_var var (Some value) >>= fun () ->
   let cmd = Bos.Cmd.(v "pkg-config" % pkgs %% of_list args) in
-  Bos.OS.Cmd.(run_out cmd |> out_string |> success) >>| fun data ->
-  String.cuts ~sep:" " ~empty:false data
+  Bos.OS.Cmd.(run_out cmd |> out_string |> success)
+
+(* Invoke solo5-config for target and return output if successful. *)
+let solo5_config target args =
+  let target_string = match target with
+    | `Virtio -> "--target=virtio"
+    | `Muen -> "--target=muen"
+    | `Hvt -> "--target=hvt"
+    | `Genode -> "--target=genode"
+    | `Spt -> "--target=spt"
+    | `Xen | `Qubes -> "--target=xen"
+    | _ ->
+      invalid_arg "solo5_config only defined for solo5 targets"
+  in
+  let cmd = Bos.Cmd.(v "solo5-config" % target_string %% of_list args) in
+  Bos.OS.Cmd.(run_out cmd |> out_string |> success)
 
 (* Implement something similar to the @name/file extended names of findlib. *)
 let rec expand_name ~lib param =

--- a/lib/mirage_impl_misc.mli
+++ b/lib/mirage_impl_misc.mli
@@ -23,7 +23,8 @@ val query_ocamlfind :
   -> (string list, [> Rresult.R.msg]) result
 
 val opam_prefix : (string, [> R.msg ]) result Lazy.t
-val pkg_config : string -> string list -> (string list, [> R.msg ]) result
+val pkg_config : string -> string list -> (string, [> R.msg ]) result
+val solo5_config : [> Mirage_key.mode_solo5 | Mirage_key.mode_xen ] -> string list -> (string, [> R.msg ]) result
 val extra_c_artifacts : string -> string list -> (string list, [> R.msg ]) result
 
 val terminal : unit -> bool

--- a/lib/mirage_link.mli
+++ b/lib/mirage_link.mli
@@ -1,9 +1,3 @@
 open Rresult
 
-val static_libs : string -> (string list, [> R.msg ]) result
-val ldflags : string -> (string list, [> R.msg ]) result
-val ldpostflags : string -> (string list, [> R.msg ]) result
-
-val find_ld : string -> string
-
 val link : Functoria.Info.t -> string -> Mirage_key.mode -> bool -> (string, [> R.msg ]) result


### PR DESCRIPTION
This change adapts the Solo5-based targets supported by the mirage tool to the new cross-compilation toolchain provided by the combination of the Solo5 "bottom half" and ocaml-freestanding "top half" changes, both of which will be released as version 0.7.0 when ready.

Thanks to @TheLortex for doing the bulk of the work on the ocaml-freestanding changes and for being patient with my requests to do things in a way that lets us have a single ocaml-freestanding supporting both Mirage 3.x and the new dune-based Mirage 4.x (master).

Depends on:

- [ ] Solo5 "bottom half" (Solo5/solo5#488)
- [ ] ocaml-freestanding "top half" (mirage/ocaml-freestanding#90)
- [ ] mirage-solo5 0.6.5 (mirage/mirage-solo5#74)
- [ ] mirage-xen (TBA)

Questions/Notes:

1. mirage-solo5 is deliberately kept in the 0.6.x series to avoid having to cut new releases of mirage-*-solo5, all of which have an upper bound on `mirage-solo5 <= 0.7.0`. I think this is fine since it's APIs have not changed.
2. mirage-xen is not done yet, but the changes should be analogous to mirage/mirage-solo5#74.
3. do we use `ldpostflags` for anything?
4. Is there a better way to drop the `List` in usage of `find_ld` and `cc`?

Please review. If you'd like to test the full stack, the following set of pins is required:

```
opam pin add solo5.0.7.0 git+https://github.com/mato/solo5#split-packages
opam pin add solo5-config-ocaml-static.0.7.0 git+https://github.com/mato/solo5#split-packages
opam pin add solo5-bindings-hvt.0.7.0 git+https://github.com/mato/solo5#split-packages
opam pin add solo5-bindings-muen.0.7.0 git+https://github.com/mato/solo5#split-packages
opam pin add solo5-bindings-spt.0.7.0 git+https://github.com/mato/solo5#split-packages
opam pin add solo5-bindings-virtio.0.7.0 git+https://github.com/mato/solo5#split-packages
opam pin add solo5-bindings-xen.0.7.0 git+https://github.com/mato/solo5#split-packages
opam pin add ocaml-freestanding.0.7.0 git+https://github.com/TheLortex/ocaml-freestanding#mirage-4
opam pin add mirage-solo5.0.6.5 git+https://github.com/TheLortex/mirage-solo5#revert-makefile
opam pin add mirage git+https://github.com/mato/mirage#3-adapt-to-ocaml-freestanding
```

Note that the bindings packages are co-installable now, if you're testing pick the ones that you want/are available on your system.
