### PR TITLE
Fix ipv6 key

### DIFF
--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -52,7 +52,7 @@ module Arg = struct
 
   let ipv6_address = of_module "ipv6_address" "Ipaddr.V6" (module Ipaddr.V6)
 
-  let ipv6 = of_module "ipv6_prefix" "Ipaddr.V6.Prefix" (module Ipaddr.V6.Prefix)
+  let ipv6 = of_module "ipv6" "Ipaddr.V6.Prefix" (module Ipaddr.V6.Prefix)
 
   let ip_address = of_module "ip_address" "Ipaddr" (module Ipaddr)
 end


### PR DESCRIPTION
This PR fixes the ipv6 key, which has the wrong label (`ipv6_prefix`) so the generated code wouldn't build. 

The `ping6` mirage-skeleton unikernel is failing because of this:
```
File "key_gen.ml", line 103, characters 48-78:
103 |   (Functoria_runtime.Arg.opt (Cmdliner.Arg.some Mirage_runtime.Arg.ipv6_prefix) 
```