### PR TITLE
Use let* syntax for the Action API

### DIFF
--- a/lib/functoria/action.ml
+++ b/lib/functoria/action.ml
@@ -652,6 +652,14 @@ module Infix = struct
   let ( >|= ) x f = map ~f x
 end
 
+module Syntax = struct
+  open Infix
+
+  let ( let* ) = ( >>= )
+
+  let ( let+ ) = ( >|= )
+end
+
 module List = struct
   open Infix
 

--- a/lib/functoria/action.mli
+++ b/lib/functoria/action.mli
@@ -54,6 +54,12 @@ module Infix : sig
   val ( >|= ) : 'a t -> ('a -> 'b) -> 'b t
 end
 
+module Syntax : sig
+  val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
+
+  val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+end
+
 (** {1 Actions} *)
 
 val rm : Fpath.t -> unit t

--- a/lib/functoria/device.ml
+++ b/lib/functoria/device.ml
@@ -16,7 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Action.Infix
+open Action.Syntax
 open Astring
 
 type abstract_key = Key.t
@@ -157,8 +157,9 @@ let extend ?packages ?packages_v ?files ?pre_configure ?post_configure
     Key.(pure List.append $ merge_packages packages packages_v $ t.packages)
   in
   let exec pre f post i =
-    exec_hook i pre >>= fun () ->
-    f i >>= fun () -> exec_hook i post
+    let* () = exec_hook i pre in
+    let* () = f i in
+    exec_hook i post
   in
   let configure = exec pre_configure t.configure post_configure in
   let build = exec pre_build t.build post_build in

--- a/lib/functoria/engine.ml
+++ b/lib/functoria/engine.ml
@@ -17,7 +17,7 @@
  *)
 
 open Astring
-open Action.Infix
+open Action.Syntax
 
 type t = Device.Graph.t
 
@@ -96,7 +96,10 @@ let find_all_devices info g i =
   Device.Graph.fold f g []
 
 let iter_actions f t =
-  let f v res = res >>= fun () -> f v in
+  let f v res =
+    let* () = res in
+    f v
+  in
   Device.Graph.fold f t (Action.ok ())
 
 let build info t =
@@ -115,7 +118,7 @@ let append_main i msg fmt =
 let configure info t =
   let f (v : t) =
     let (D { dev; args; _ }) = v in
-    Device.configure dev info >>= fun () ->
+    let* () = Device.configure dev info in
     if args = [] then Action.ok ()
     else
       append_main info "configure" "@[<2>module %s =@ %a@]@."
@@ -154,7 +157,7 @@ let connect ?(init = []) info t =
     append_main info "connect" "%a" emit_connect
       (var_name, arg_names, Device.connect dev info impl_name)
   in
-  iter_actions f t >>= fun () ->
+  let* () = iter_actions f t in
   let main_name = Device.Graph.var_name t in
   let init_names =
     List.fold_left

--- a/lib/mirage/impl/mirage_impl_fs.ml
+++ b/lib/mirage/impl/mirage_impl_fs.ml
@@ -1,7 +1,7 @@
 open Functoria
 open Mirage_impl_block
 open Mirage_impl_misc
-open Action.Infix
+open Action.Syntax
 module Key = Mirage_key
 
 type t = FS
@@ -59,15 +59,17 @@ let fat_block ?(dir = ".") ?(regexp = "*") () =
   let pre_build _ =
     let dir = Fpath.of_string dir |> Rresult.R.error_msg_to_invalid_arg in
     Log.info (fun m -> m "Generating block generator script: %s" file);
-    Action.with_output ~mode:0o755 ~path:(Fpath.v file)
-      ~purpose:"fat shell script" (fun fmt ->
-        fat_shell_script fmt ~block_file ~dir ~regexp)
-    >>= fun () ->
+    let* () =
+      Action.with_output ~mode:0o755 ~path:(Fpath.v file)
+        ~purpose:"fat shell script" (fun fmt ->
+          fat_shell_script fmt ~block_file ~dir ~regexp)
+    in
     Log.info (fun m -> m "Executing block generator script: ./%s" file);
     Action.run_cmd (Bos.Cmd.v ("./" ^ file))
   in
   let pre_clean _ =
-    Action.rm (Fpath.v file) >>= fun () -> Action.rm (Fpath.v block_file)
+    let* () = Action.rm (Fpath.v file) in
+    Action.rm (Fpath.v block_file)
   in
   let packages = [ fat_pkg ] in
   let block = Mirage_impl_block.block_conf block_file in

--- a/lib/mirage/impl/mirage_impl_kv.ml
+++ b/lib/mirage/impl/mirage_impl_kv.ml
@@ -1,5 +1,5 @@
 open Functoria
-open Action.Infix
+open Action.Syntax
 open Astring
 module Key = Mirage_key
 
@@ -19,14 +19,14 @@ let crunch dirname =
   let build _i =
     let dir = Fpath.(v dirname) in
     let file = Fpath.(v (String.Ascii.lowercase name) + "ml") in
-    Action.is_dir dir >>= function
-    | true ->
-        Mirage_impl_misc.Log.info (fun m -> m "Generating: %a" Fpath.pp file);
-        Action.run_cmd Bos.Cmd.(v "ocaml-crunch" % "-o" % p file % p dir)
-    | false -> Action.errorf "The directory %s does not exist." dirname
+    let* is_dir = Action.is_dir dir in
+    if is_dir then (
+      Mirage_impl_misc.Log.info (fun m -> m "Generating: %a" Fpath.pp file);
+      Action.run_cmd Bos.Cmd.(v "ocaml-crunch" % "-o" % p file % p dir) )
+    else Action.errorf "The directory %s does not exist." dirname
   in
   let clean _i =
-    Action.rm Fpath.(v name + "ml") >>= fun () ->
+    let* () = Action.rm Fpath.(v name + "ml") in
     Action.rm Fpath.(v name + "mli")
   in
   impl ~packages ~connect ~build ~clean name ro

--- a/lib/mirage/impl/mirage_impl_tracing.ml
+++ b/lib/mirage/impl/mirage_impl_tracing.ml
@@ -1,6 +1,6 @@
 open Functoria
 open Mirage_impl_misc
-open Action.Infix
+open Action.Syntax
 module Key = Mirage_key
 
 type tracing = job
@@ -26,7 +26,8 @@ let mprof_trace ~size () =
         ]
   in
   let build _ =
-    query_ocamlfind [ "lwt.tracing" ] >>= function
+    let* query = query_ocamlfind [ "lwt.tracing" ] in
+    match query with
     | [] ->
         Action.error
           "lwt.tracing module not found. Hint:opam pin add lwt \

--- a/lib/mirage/mirage_build.ml
+++ b/lib/mirage/mirage_build.ml
@@ -1,5 +1,5 @@
 open Functoria
-open Action.Infix
+open Action.Syntax
 open Astring
 open Mirage_impl_misc
 module Key = Mirage_key
@@ -64,9 +64,9 @@ let build i =
   let warn_error = Key.(get ctx warn_error) in
   let target = Key.(get ctx target) in
   let libs = Info.libraries i in
-  compile ignore_dirs libs warn_error target >>= fun () ->
-  Mirage_target.build i >>= fun () ->
-  Mirage_target.link ~name i >|= fun out ->
+  let* () = compile ignore_dirs libs warn_error target in
+  let* () = Mirage_target.build i in
+  let+ out = Mirage_target.link ~name i in
   Log.info (fun m -> m "Build succeeded: %s" out)
 
 let files i =

--- a/lib/mirage/mirage_clean.ml
+++ b/lib/mirage/mirage_clean.ml
@@ -1,25 +1,26 @@
 open Functoria
-open Action.Infix
+open Action.Syntax
 module Info = Functoria.Info
 
 let clean_binary name suffix = Action.rm Fpath.(v name + suffix)
 
 let clean i =
   let name = Info.name i in
-  Mirage_target.clean i >>= fun () ->
-  Mirage_configure.clean_myocamlbuild () >>= fun () ->
-  Action.rm Fpath.(v "main.native.o") >>= fun () ->
-  Action.rm Fpath.(v "main.native") >>= fun () ->
-  Action.rm Fpath.(v name) >>= fun () ->
-  Action.List.iter ~f:(clean_binary name)
-    [ "xen"; "elf"; "hvt"; "spt"; "virtio"; "muen"; "genode" ]
-  >>= fun () ->
+  let* () = Mirage_target.clean i in
+  let* () = Mirage_configure.clean_myocamlbuild () in
+  let* () = Action.rm Fpath.(v "main.native.o") in
+  let* () = Action.rm Fpath.(v "main.native") in
+  let* () = Action.rm Fpath.(v name) in
+  let* () =
+    Action.List.iter ~f:(clean_binary name)
+      [ "xen"; "elf"; "hvt"; "spt"; "virtio"; "muen"; "genode" ]
+  in
   (* The following deprecated names are kept here to allow "mirage clean" to
    * continue to work after an upgrade. *)
-  Action.rm Fpath.(v "Makefile.solo5-hvt") >>= fun () ->
-  Action.rmdir Fpath.(v "_build-solo5-hvt") >>= fun () ->
-  Action.rm Fpath.(v "solo5-hvt") >>= fun () ->
-  Action.rm Fpath.(v name + "ukvm") >>= fun () ->
-  Action.rm Fpath.(v "Makefile.ukvm") >>= fun () ->
-  Action.rmdir Fpath.(v "_build-ukvm") >>= fun () ->
+  let* () = Action.rm Fpath.(v "Makefile.solo5-hvt") in
+  let* () = Action.rmdir Fpath.(v "_build-solo5-hvt") in
+  let* () = Action.rm Fpath.(v "solo5-hvt") in
+  let* () = Action.rm Fpath.(v name + "ukvm") in
+  let* () = Action.rm Fpath.(v "Makefile.ukvm") in
+  let* () = Action.rmdir Fpath.(v "_build-ukvm") in
   Action.rm Fpath.(v "ukvm-bin")

--- a/lib/mirage/target/mirage_target.ml
+++ b/lib/mirage/target/mirage_target.ml
@@ -1,5 +1,5 @@
 open Functoria
-open Action.Infix
+open Action.Syntax
 module Key = Mirage_key
 
 let choose : Key.mode -> (module S.TARGET) = function
@@ -47,4 +47,6 @@ let ocamlbuild_tags target =
   let (module Target) = choose target in
   Target.ocamlbuild_tags
 
-let clean i = Solo5.clean i >>= fun () -> Unix.clean i
+let clean i =
+  let* () = Solo5.clean i in
+  Unix.clean i

--- a/lib/mirage/target/unix.ml
+++ b/lib/mirage/target/unix.ml
@@ -1,5 +1,5 @@
 open Functoria
-open Action.Infix
+open Action.Syntax
 
 type t = [ `Unix | `MacOSX ]
 
@@ -15,7 +15,8 @@ let build _ = Action.ok ()
 
 let link ~name _ =
   let link = Bos.Cmd.(v "ln" % "-nfs" % "_build/main.native" % name) in
-  Action.run_cmd link >|= fun () -> name
+  let+ () = Action.run_cmd link in
+  name
 
 let install i =
   let name = match Info.output i with None -> Info.name i | Some n -> n in

--- a/test/functoria-test/functoria_test.ml
+++ b/test/functoria-test/functoria_test.ml
@@ -1,5 +1,5 @@
 open Functoria
-open Action.Infix
+open Action.Syntax
 
 let prelude i =
   Action.with_output ~path:(Info.main i) ~purpose:"init tests" @@ fun ppf ->
@@ -21,6 +21,7 @@ let run ?(keys = []) ?init context device =
       ~src:`None "foo"
   in
   let t = Impl.eval ~context t in
-  prelude info >>= fun () ->
-  Engine.configure info t >>= fun () ->
-  Engine.connect ?init info t >>= fun () -> Engine.build info t
+  let* () = prelude info in
+  let* () = Engine.configure info t in
+  let* () = Engine.connect ?init info t in
+  Engine.build info t


### PR DESCRIPTION
Instead of using infix operators, use custom `let*` / `let+` operators. This allows code to be written in a more _direct style_. 

(based on https://github.com/mirage/mirage/pull/1212)