### PR TITLE
[Preview] upgrade to ocamlformat.0.20.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,4 @@
-version = 0.19.0
+version = 0.20.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true
-module-item-spacing = compact

--- a/lib/functoria/action.ml
+++ b/lib/functoria/action.ml
@@ -475,7 +475,8 @@ let rec interpret_dry : type r. env:Env.t -> r command -> r domain =
       | None ->
           dom
             (error_msg "a file named '%a' already exists" Fpath.pp path)
-            env [ log "error" ])
+            env
+            [ log "error" ])
   | Rmdir path ->
       Log.debug (fun l -> l "Rmdir %a" Fpath.pp path);
       let log s = Fmt.str "Rmdir %a (%s)" Fpath.pp path s in
@@ -489,7 +490,8 @@ let rec interpret_dry : type r. env:Env.t -> r command -> r domain =
       | None ->
           dom
             (error_msg "%a: no such file or directory" Fpath.pp root)
-            env [ logs "error" ]
+            env
+            [ logs "error" ]
       | Some es -> (
           match List.filter filter es with
           | ([] | [ _ ]) as e ->

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -335,7 +335,8 @@ let create_simple ?(group = "") ?(stage = `Both) ~doc ~default conv name =
   let doc =
     Arg.info ~docs:unikernel_section
       ~docv:(String.Ascii.uppercase name)
-      ~doc [ prefix ^ name ]
+      ~doc
+      [ prefix ^ name ]
   in
   let key = Arg.opt ~stage conv default doc in
   Key.create (prefix ^ name) key


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.
The changes are due to:
- `module-item-spacing` is now set to `compact` for the default profile
- `module-item-spacing` is now correctly applied to mutually recursive type definitions
- the `.ocamlformat` file has been simplified using the conventional profile
- formatting of list elements has been improved