### PR TITLE
Fix ocamlification of unikernel names

### DIFF
--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -55,7 +55,6 @@ module Config = struct
     Key.Set.fold f all_keys skeys
 
   let v ?(keys = []) ?(packages = []) ?(init = []) ~build_cmd ~src name jobs =
-    let name = Name.ocamlify name in
     let packages = Key.pure @@ packages in
     let jobs = Impl.abstract jobs in
     let keys = Key.Set.(union (of_list keys) (get_if_context jobs)) in
@@ -205,8 +204,8 @@ module Make (P : S) = struct
         Fmt.pr "%a\n%!" Fmt.(list ~sep:(any " ") Fpath.pp) files
     | `Makefile ->
         let file =
-          Makefile.v ~build_dir ~depext ~name:P.name ?extra_repo
-            (Info.name info)
+          Makefile.v ~build_dir ~depext ~builder_name:P.name ?extra_repo
+            (Misc.Name.opamify (Info.name info))
         in
         Fmt.pr "%a\n%!" Makefile.pp file
     | `Dune `Config ->
@@ -242,9 +241,10 @@ module Make (P : S) = struct
 
   (* Configuration step. *)
 
-  let generate_opam ~name scope (args : _ Cli.args) () =
+  let generate_opam ~opam_name scope (args : _ Cli.args) () =
     let { Config.info; jobs; _ } = args.Cli.context in
     let install = Key.eval (Info.context info) (Engine.install info jobs) in
+    let name = Misc.Name.Opam.to_string opam_name in
     let fname =
       match scope with
       | `Monorepo -> "-monorepo.opam"
@@ -304,11 +304,12 @@ module Make (P : S) = struct
     let* () = Action.rmdir (mirage_dir args) in
     Action.rmdir (artifacts_dir args)
 
-  let generate_makefile ~build_dir ~depext ~extra_repo name =
+  let generate_makefile ~build_dir ~depext ~extra_repo opam_name =
     let file = Fpath.(v "Makefile") in
     let contents =
       Fmt.to_to_string Makefile.pp
-        (Makefile.v ~build_dir ~depext ~name:P.name ?extra_repo name)
+        (Makefile.v ~build_dir ~depext ~builder_name:P.name ?extra_repo
+           opam_name)
     in
     Filegen.write file contents
 
@@ -317,13 +318,17 @@ module Make (P : S) = struct
     (* Get application name *)
     let build_dir = build_dir args in
     let name = P.name_of_target info in
-    let* () = generate_makefile ~build_dir ~depext ~extra_repo name in
+    let opam_name = Misc.Name.opamify name in
+    let* () =
+      generate_makefile ~build_dir ~depext ~extra_repo
+        (Misc.Name.opamify (Info.name info))
+    in
     let* _ = Action.mkdir (mirage_dir args) in
     let* () =
       Action.with_dir (mirage_dir args) (fun () ->
           (* OPAM files *)
-          let* () = generate_opam `Switch ~name args () in
-          let* () = generate_opam `Monorepo ~name args () in
+          let* () = generate_opam `Switch ~opam_name args () in
+          let* () = generate_opam `Monorepo ~opam_name args () in
           (* Generate application specific-files *)
           Log.info (fun m -> m "in dir %a" (Cli.pp_args (fun _ _ -> ())) args);
           configure_main info init device_graph)

--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -205,7 +205,7 @@ module Make (P : S) = struct
     | `Makefile ->
         let file =
           Makefile.v ~build_dir ~depext ~builder_name:P.name ?extra_repo
-            (Misc.Name.opamify (Info.name info))
+            (Misc.Name.opamify name)
         in
         Fmt.pr "%a\n%!" Makefile.pp file
     | `Dune `Config ->
@@ -320,8 +320,7 @@ module Make (P : S) = struct
     let name = P.name_of_target info in
     let opam_name = Misc.Name.opamify name in
     let* () =
-      generate_makefile ~build_dir ~depext ~extra_repo
-        (Misc.Name.opamify (Info.name info))
+      generate_makefile ~build_dir ~depext ~extra_repo (Misc.Name.opamify name)
     in
     let* _ = Action.mkdir (mirage_dir args) in
     let* () =

--- a/lib/functoria/makefile.ml
+++ b/lib/functoria/makefile.ml
@@ -19,13 +19,13 @@
 type t = {
   depext : bool;
   build_dir : Fpath.t;
-  name : string;
-  unikernel_name : string;
+  builder_name : string;
+  unikernel_opam_name : Misc.Name.Opam.t;
   extra_repo : string option;
 }
 
-let v ?extra_repo ~build_dir ~name ~depext unikernel_name =
-  { depext; build_dir; name; unikernel_name; extra_repo }
+let v ?extra_repo ~build_dir ~builder_name ~depext unikernel_opam_name =
+  { depext; build_dir; builder_name; unikernel_opam_name; extra_repo }
 
 let depext_rules =
   {|
@@ -72,7 +72,7 @@ let pp_extra_rules ppf t =
         rules
 
 let pp ppf t =
-  let mirage_dir = Fpath.(t.build_dir / t.name) in
+  let mirage_dir = Fpath.(t.build_dir / t.builder_name) in
   let pp_depext_lockfile ppf = function
     | true -> Fmt.string ppf "\n\t@$(MAKE) -s depext-lockfile"
     | false -> ()
@@ -119,6 +119,8 @@ build::
 clean::
 	mirage clean
 |}
-    Fpath.pp t.build_dir Fpath.pp mirage_dir t.unikernel_name pp_extra_rules t
-    t.name pp_no_depext t.depext pp_add_repo t.extra_repo pp_or_remove_repo
-    t.extra_repo pp_depext_lockfile t.depext pp_final_remove_repo t.extra_repo
+    Fpath.pp t.build_dir Fpath.pp mirage_dir
+    (Misc.Name.Opam.to_string t.unikernel_opam_name)
+    pp_extra_rules t t.builder_name pp_no_depext t.depext pp_add_repo
+    t.extra_repo pp_or_remove_repo t.extra_repo pp_depext_lockfile t.depext
+    pp_final_remove_repo t.extra_repo

--- a/lib/functoria/makefile.mli
+++ b/lib/functoria/makefile.mli
@@ -21,9 +21,9 @@ type t
 val v :
   ?extra_repo:string ->
   build_dir:Fpath.t ->
-  name:string ->
+  builder_name:string ->
   depext:bool ->
-  string ->
+  Misc.Name.Opam.t ->
   t
 
 val pp : t Fmt.t

--- a/lib/functoria/misc.ml
+++ b/lib/functoria/misc.ml
@@ -33,6 +33,25 @@ end
 (* {Misc informations} *)
 
 module Name = struct
+  module Opam = struct
+    type t = string
+
+    let to_string = Fun.id
+  end
+
+  let opamify s =
+    let b = Buffer.create (String.length s) in
+    String.iter
+      (function
+        | ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-') as c ->
+            Buffer.add_char b c
+        | '.' -> Buffer.add_char b '_'
+        | _ -> ())
+      s;
+    let s' = Buffer.contents b in
+    if String.length s' = 0 then raise (Invalid_argument s);
+    s'
+
   let ocamlify s =
     let b = Buffer.create (String.length s) in
     String.iter

--- a/lib/functoria/misc.mli
+++ b/lib/functoria/misc.mli
@@ -32,5 +32,12 @@ module type Monoid = sig
 end
 
 module Name : sig
+  module Opam : sig
+    type t
+
+    val to_string : t -> string
+  end
+
+  val opamify : string -> Opam.t
   val ocamlify : string -> string
 end

--- a/test/mirage/query/config_dash_in_name.ml
+++ b/test/mirage/query/config_dash_in_name.ml
@@ -1,0 +1,9 @@
+open Mirage
+
+let main = main "App" job
+
+let key =
+  let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
+  Key.(create "hello" Arg.(opt string "Hello World!" doc))
+
+let () = register ~keys:[ Key.v key ] ~src:`None "noop-functor.v0" [ main ]

--- a/test/mirage/query/dune
+++ b/test/mirage/query/dune
@@ -1,6 +1,12 @@
 (executable
  (name config)
+ (modules config)
+ (libraries mirage))
+
+(executable
+ (name config_dash_in_name)
+ (modules config_dash_in_name)
  (libraries mirage))
 
 (cram
- (deps config.exe))
+ (deps config.exe config_dash_in_name.exe))

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -34,7 +34,7 @@ Query makefile
   -include Makefile.user
   BUILD_DIR = ./
   MIRAGE_DIR = ./mirage
-  UNIKERNEL_NAME = noop-functor_v0
+  UNIKERNEL_NAME = noop-functor_v0-unix
   OPAM = opam
   
   all:: build

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -3,7 +3,7 @@ Query unikernel dune
   (copy_files ./config/*)
   
   (rule
-   (target noop_functor_v0)
+   (target noop-functor.v0)
    (enabled_if (= %{context_name} "default"))
    (action
     (copy main.exe %{target})))
@@ -23,10 +23,10 @@ Query dist dune
   $ ./config_dash_in_name.exe query dune.dist
   (rule
    (mode (promote (until-clean)))
-   (target noop_functor_v0)
+   (target noop-functor.v0)
    (enabled_if (= %{context_name} "default"))
    (action
-    (copy ../noop_functor_v0 %{target}))
+    (copy ../noop-functor.v0 %{target}))
   )
 
 Query makefile
@@ -34,7 +34,7 @@ Query makefile
   -include Makefile.user
   BUILD_DIR = ./
   MIRAGE_DIR = ./mirage
-  UNIKERNEL_NAME = noop_functor_v0
+  UNIKERNEL_NAME = noop-functor_v0
   OPAM = opam
   
   all:: build
@@ -80,7 +80,7 @@ Query dune-project
   $ ./config_dash_in_name.exe query dune-project
   (lang dune 2.7)
   
-  (name noop_functor_v0-unix)
+  (name noop-functor.v0-unix)
   
   (implicit_transitive_deps true)
 
@@ -107,7 +107,7 @@ Query unikernel dune (hvt)
     (run solo5-elftool gen-manifest manifest.json manifest.c)))
   
   (rule
-   (target noop_functor_v0.hvt)
+   (target noop-functor.v0.hvt)
    (enabled_if (= %{context_name} "mirage-hvt"))
    (deps main.exe)
    (action
@@ -123,8 +123,8 @@ Query dist dune (hvt)
   $ ./config_dash_in_name.exe query --target hvt dune.dist
   (rule
    (mode (promote (until-clean)))
-   (target noop_functor_v0.hvt)
+   (target noop-functor.v0.hvt)
    (enabled_if (= %{context_name} "mirage-hvt"))
    (action
-    (copy ../noop_functor_v0.hvt %{target}))
+    (copy ../noop-functor.v0.hvt %{target}))
   )

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -1,0 +1,130 @@
+Query unikernel dune
+  $ ./config_dash_in_name.exe query dune.build
+  (copy_files ./config/*)
+  
+  (rule
+   (target noop_functor_v0)
+   (enabled_if (= %{context_name} "default"))
+   (action
+    (copy main.exe %{target})))
+  
+  (executable
+   (name main)
+   (libraries lwt mirage-bootvar-unix mirage-clock-unix mirage-logs
+     mirage-runtime mirage-unix)
+   (link_flags (-thread))
+   (modules (:standard \ config))
+   (flags -g -w +A-4-41-42-44 -bin-annot -strict-sequence -principal
+     -safe-string)
+   (enabled_if (= %{context_name} "default"))
+  )
+
+Query dist dune
+  $ ./config_dash_in_name.exe query dune.dist
+  (rule
+   (mode (promote (until-clean)))
+   (target noop_functor_v0)
+   (enabled_if (= %{context_name} "default"))
+   (action
+    (copy ../noop_functor_v0 %{target}))
+  )
+
+Query makefile
+  $ ./config_dash_in_name.exe query Makefile
+  -include Makefile.user
+  BUILD_DIR = ./
+  MIRAGE_DIR = ./mirage
+  UNIKERNEL_NAME = noop_functor_v0
+  OPAM = opam
+  
+  all:: build
+  
+  .PHONY: all depend depends clean build repo-add repo-rm depext-lockfile
+  
+  repo-add:
+  	echo -e "\e[2musing overlay repository mirage-tmp: https://github.com/mirage/opam-overlays.git \e[0m"
+  	$(OPAM) repo add mirage-tmp https://github.com/mirage/opam-overlays.git ||\
+  	$(OPAM) repo set-url mirage-tmp https://github.com/mirage/opam-overlays.git
+  
+  repo-rm:
+  	echo -e "\e[2mremoving overlay repository mirage-tmp\e[0m"
+  	$(OPAM) repo remove mirage-tmp
+  
+  
+  depext-lockfile:
+  	echo " ↳ lockfile depexts"
+  	opam install --cli 2.1 --ignore-pin-depends --depext-only --locked $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  
+  
+  depend depends::$(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
+  	@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l mirage/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  
+  $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam
+  	@echo " ↳ opam install switch dependencies"
+  	@$(OPAM) install ./$(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam --deps-only --yes
+  	@$(MAKE) -s repo-add
+  	@echo " ↳ generate lockfile for monorepo dependencies"
+  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l ./$(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked --ocaml-version $(shell ocamlc --version)  || (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(MAKE) -s depext-lockfile && $(MAKE) -s repo-rm || (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  
+  build::
+  	mirage build
+  
+  clean::
+  	mirage clean
+  
+...
+
+Query dune-project
+  $ ./config_dash_in_name.exe query dune-project
+  (lang dune 2.7)
+  
+  (name noop_functor_v0-unix)
+  
+  (implicit_transitive_deps true)
+
+Query unikernel dune (hvt)
+  $ ./config_dash_in_name.exe query --target hvt dune.build
+  (copy_files ./config/*)
+  
+  (executable
+   (enabled_if (= %{context_name} "mirage-hvt"))
+   (name main)
+   (modes (native exe))
+   (libraries lwt mirage-bootvar-solo5 mirage-clock-freestanding mirage-logs
+     mirage-runtime mirage-solo5)
+   (link_flags -g -w +A-4-41-42-44 -bin-annot -strict-sequence -principal
+     -safe-string -cclib "-z solo5-abi=hvt")
+   (modules (:standard \ config manifest))
+   (foreign_stubs (language c) (names manifest))
+  )
+  
+  (rule
+   (targets manifest.c)
+   (deps manifest.json)
+   (action
+    (run solo5-elftool gen-manifest manifest.json manifest.c)))
+  
+  (rule
+   (target noop_functor_v0.hvt)
+   (enabled_if (= %{context_name} "mirage-hvt"))
+   (deps main.exe)
+   (action
+    (copy main.exe %{target})))
+  
+  (alias
+    (name default)
+    (enabled_if (= %{context_name} "mirage-hvt"))
+    (deps (alias_rec all))
+    )
+
+Query dist dune (hvt)
+  $ ./config_dash_in_name.exe query --target hvt dune.dist
+  (rule
+   (mode (promote (until-clean)))
+   (target noop_functor_v0.hvt)
+   (enabled_if (= %{context_name} "mirage-hvt"))
+   (action
+    (copy ../noop_functor_v0.hvt %{target}))
+  )

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -76,7 +76,7 @@ Query Makefile
   -include Makefile.user
   BUILD_DIR = ./
   MIRAGE_DIR = ./mirage
-  UNIKERNEL_NAME = noop
+  UNIKERNEL_NAME = noop-hvt
   OPAM = opam
   
   all:: build
@@ -122,7 +122,7 @@ Query Makefile without depexts
   -include Makefile.user
   BUILD_DIR = ./
   MIRAGE_DIR = ./mirage
-  UNIKERNEL_NAME = noop
+  UNIKERNEL_NAME = noop-hvt
   OPAM = opam
   
   all:: build
@@ -161,7 +161,7 @@ Query Makefile with depext
   -include Makefile.user
   BUILD_DIR = ./
   MIRAGE_DIR = ./mirage
-  UNIKERNEL_NAME = noop
+  UNIKERNEL_NAME = noop-hvt
   OPAM = opam
   
   all:: build

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -80,7 +80,7 @@ Query Makefile
   -include Makefile.user
   BUILD_DIR = ./
   MIRAGE_DIR = ./mirage
-  UNIKERNEL_NAME = noop
+  UNIKERNEL_NAME = noop-unix
   OPAM = opam
   
   all:: build
@@ -127,7 +127,7 @@ Query Makefile without depexts
   -include Makefile.user
   BUILD_DIR = ./
   MIRAGE_DIR = ./mirage
-  UNIKERNEL_NAME = noop
+  UNIKERNEL_NAME = noop-unix
   OPAM = opam
   
   all:: build
@@ -167,7 +167,7 @@ Query Makefile with depext
   -include Makefile.user
   BUILD_DIR = ./
   MIRAGE_DIR = ./mirage
-  UNIKERNEL_NAME = noop
+  UNIKERNEL_NAME = noop-unix
   OPAM = opam
   
   all:: build


### PR DESCRIPTION
This PR fixes the first question of https://github.com/mirage/mirage/issues/1249

What it does is remove ocamlification of the name in `Config.v` and introduce _opamification_ for Makefile generation and opam file generation. _opamification_ is a less constrained transformation from arbitrary names to opam-friendly package names. 

First commit adds tests to highlight the changes. Second commit actually perform the changes.