### PR TITLE
mirage: require ocaml-freestanding 0.7.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,4 @@
-version = 0.19.0
+version = 0.20.1
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true
-module-item-spacing = compact

--- a/lib/functoria/action.ml
+++ b/lib/functoria/action.ml
@@ -475,7 +475,8 @@ let rec interpret_dry : type r. env:Env.t -> r command -> r domain =
       | None ->
           dom
             (error_msg "a file named '%a' already exists" Fpath.pp path)
-            env [ log "error" ])
+            env
+            [ log "error" ])
   | Rmdir path ->
       Log.debug (fun l -> l "Rmdir %a" Fpath.pp path);
       let log s = Fmt.str "Rmdir %a (%s)" Fpath.pp path s in
@@ -489,7 +490,8 @@ let rec interpret_dry : type r. env:Env.t -> r command -> r domain =
       | None ->
           dom
             (error_msg "%a: no such file or directory" Fpath.pp root)
-            env [ logs "error" ]
+            env
+            [ logs "error" ]
       | Some es -> (
           match List.filter filter es with
           | ([] | [ _ ]) as e ->

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -335,7 +335,8 @@ let create_simple ?(group = "") ?(stage = `Both) ~doc ~default conv name =
   let doc =
     Arg.info ~docs:unikernel_section
       ~docv:(String.Ascii.uppercase name)
-      ~doc [ prefix ^ name ]
+      ~doc
+      [ prefix ^ name ]
   in
   let key = Arg.opt ~stage conv default doc in
   Key.create (prefix ^ name) key

--- a/lib/mirage/target/solo5.ml
+++ b/lib/mirage/target/solo5.ml
@@ -5,8 +5,6 @@ module Key = Mirage_key
 module Log = Mirage_impl_misc.Log
 
 let solo5_manifest_path = Fpath.v "manifest.json"
-let flags_generator target = Fmt.str "%a-ldflags.sh" Key.pp_target target
-let flags_file target = Fmt.str "%a-ldflags" Key.pp_target target
 
 type solo5_target = [ `Virtio | `Muen | `Hvt | `Genode | `Spt ]
 type xen_target = [ `Xen | `Qubes ]

--- a/lib/mirage/target/solo5.ml
+++ b/lib/mirage/target/solo5.ml
@@ -15,7 +15,10 @@ type t = [ solo5_target | xen_target ]
 let cast = function #t as t -> t | _ -> invalid_arg "not a solo5 target."
 
 let build_packages =
-  [ Functoria.package ~scope:`Switch ~build:true "ocaml-freestanding" ]
+  [
+    Functoria.package ~min:"0.7.0" ~scope:`Switch ~build:true
+      "ocaml-freestanding";
+  ]
 
 let runtime_packages target =
   match target with

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -27,7 +27,7 @@ Query global opam
   depends: [
     "mirage" { build & >= "4.0.0" & < "4.1.0" }
     "ocaml" { build & >= "4.08.0" }
-    "ocaml-freestanding" { build }
+    "ocaml-freestanding" { build & >= "0.7.0" }
     "opam-monorepo" { build & >= "0.2.6" }
   ]
   
@@ -64,7 +64,7 @@ Query packages
   "mirage-runtime" { >= "4.0.0" & < "4.1.0" }
   "mirage-solo5" { >= "0.7.0" & < "0.8.0" }
   "ocaml" { build & >= "4.08.0" }
-  "ocaml-freestanding" { build }
+  "ocaml-freestanding" { build & >= "0.7.0" }
   "opam-monorepo" { build & >= "0.2.6" }
 
 Query files


### PR DESCRIPTION
as seen on https://ci.mirage.io/pipelines/pr-372-mirage-4-mirage-mirage-dev/pr-372-mirage-4-mirage-mirage-dev-f4b813668ee45d2371dc75fc8f1890997ecdbe00/x86_64-debian-10-4.13/2022-01-07/114419-ocluster-build-203a20

otherwise e.g. freestanding 0.6.6 is installed (and build fails)