### PR TITLE
Lint mirage-runtime.opam file

### DIFF
--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
   "ipaddr"             {>= "5.0.0"}
-  "functoria-runtime"  {>= "3.0.2"}
+  "functoria-runtime"  {= version}
   "fmt" {>= "0.8.4"}
   "logs"
   "lwt" {>= "4.0.0"}


### PR DESCRIPTION
`mirage-runtime` requires the same version as `functoria-runtime`.