### PR TITLE
No common path & impl. about the OS module - each target implements their own modules

### DIFF
--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -77,7 +77,7 @@ module Config = struct
 end
 
 module type S = sig
-  val prelude : string
+  val prelude : Info.t -> string
   val packages : Package.t list
   val name : string
   val version : string
@@ -167,7 +167,7 @@ module Make (P : S) = struct
     Log.info (fun m -> m "Generating: %a (main file)" Fpath.pp main);
     let* () =
       Action.with_output ~path:main ~append:false ~purpose (fun ppf ->
-          Fmt.pf ppf "%a@.@." Fmt.text P.prelude)
+          Fmt.pf ppf "%a@.@." Fmt.text (P.prelude i))
     in
     let* () = Engine.configure i jobs in
     Engine.connect i ~init jobs

--- a/lib/functoria/lib.mli
+++ b/lib/functoria/lib.mli
@@ -24,7 +24,7 @@
 module type S = sig
   open DSL
 
-  val prelude : string
+  val prelude : Info.t -> string
   (** Prelude printed at the beginning of [main.ml].
 
       It should put in scope:

--- a/lib/mirage/impl/mirage_impl_block.ml
+++ b/lib/mirage/impl/mirage_impl_block.ml
@@ -26,7 +26,7 @@ let make_block_t =
     b
 
 let xen_block_packages =
-  [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "front" ] "mirage-block-xen" ]
+  [ package ~min:"2.1.0" ~max:"3.0.0" ~sublibs:[ "front" ] "mirage-block-xen" ]
 
 (* this function takes a string rather than an int as `id` to allow
    the user to pass stuff like "/dev/xvdi1", which mirage-block-xen

--- a/lib/mirage/impl/mirage_impl_console.ml
+++ b/lib/mirage/impl/mirage_impl_console.ml
@@ -11,7 +11,7 @@ let console_unix str =
   impl ~packages ~connect:(connect str) "Console_unix" console
 
 let console_xen str =
-  let packages = [ package ~min:"4.0.0" ~max:"5.0.0" "mirage-console-xen" ] in
+  let packages = [ package ~min:"5.1.0" ~max:"6.0.0" "mirage-console-xen" ] in
   impl ~packages ~connect:(connect str) "Console_xen" console
 
 let console_solo5 str =

--- a/lib/mirage/impl/mirage_impl_network.ml
+++ b/lib/mirage/impl/mirage_impl_network.ml
@@ -13,7 +13,7 @@ let network_conf (intf : string Key.key) =
     Key.match_ Key.(value target) @@ function
     | `Unix -> [ package ~min:"2.7.0" ~max:"3.0.0" "mirage-net-unix" ]
     | `MacOSX -> [ package ~min:"1.8.0" ~max:"2.0.0" "mirage-net-macosx" ]
-    | `Xen -> [ package ~min:"2.0.0" ~max:"3.0.0" "mirage-net-xen" ]
+    | `Xen -> [ package ~min:"2.1.0" ~max:"3.0.0" "mirage-net-xen" ]
     | `Qubes ->
         [
           package ~min:"2.0.0" ~max:"3.0.0" "mirage-net-xen";

--- a/lib/mirage/impl/mirage_impl_time.ml
+++ b/lib/mirage/impl/mirage_impl_time.ml
@@ -1,6 +1,29 @@
 open Functoria
+module Key = Mirage_key
 
 type time = TIME
 
 let time = Type.v TIME
-let default_time = impl ~packages:[ package "mirage-time" ] "OS.Time" time
+
+let default_time =
+  let unix_time =
+    impl ~packages:[ package "mirage-time" ] "Unix_os.Time" time
+  in
+  let solo5_time =
+    impl ~packages:[ package "mirage-time" ] "Solo5_os.Time" time
+  in
+  let xen_time = impl ~packages:[ package "mirage-time" ] "Xen_os.Time" time in
+  match_impl
+    Key.(value target)
+    [
+      (`Unix, unix_time);
+      (`MacOSX, unix_time);
+      (`Xen, xen_time);
+      (`Qubes, xen_time);
+      (`Virtio, solo5_time);
+      (`Hvt, solo5_time);
+      (`Spt, solo5_time);
+      (`Muen, solo5_time);
+      (`Genode, solo5_time);
+    ]
+    ~default:unix_time

--- a/lib/mirage/impl/mirage_impl_tracing.ml
+++ b/lib/mirage/impl/mirage_impl_tracing.ml
@@ -42,7 +42,7 @@ let mprof_trace ~size () =
            |> Io_page.to_cstruct |> Cstruct.to_bigarray in@ let trace_config = \
            MProf.Trace.Control.make buffer MProf_xen.timestamper in@ \
            MProf.Trace.Control.start trace_config;@ MProf_xen.share_with \
-           ~domid:0 trace_pages@ |> OS.Main.run@]"
+           ~domid:0 trace_pages@ |> Xen_os.Main.run@]"
           Key.serialize_call (Key.v key)
   in
   impl ~keys ~packages_v ~connect "MProf" job

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -277,9 +277,9 @@ module Project = struct
 
   let prelude info =
     Fmt.str
-      {ocaml|open Lwt.Infix\n\
-let return = Lwt.return\n\
-let run t = %s.Main.run t ; exit 0"|ocaml}
+      {ocaml|open Lwt.Infix
+let return = Lwt.return
+let run t = %s.Main.run t ; exit 0|ocaml}
       (os_of_target info)
 
   (* The ocamlfind packages to use when compiling config.ml *)

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -265,14 +265,22 @@ let app_info_partial =
 let app_info = app_info_partial ()
 let app_info_with_opam_deps build_info = app_info_partial ~build_info ()
 
+let os_of_target i =
+  match Info.get i Key.target with
+  | #Key.mode_solo5 -> "Solo5_os"
+  | #Key.mode_unix -> "Unix_os"
+  | #Key.mode_xen -> "Xen_os"
+
 module Project = struct
   let name = "mirage"
   let version = "%%VERSION%%"
 
-  let prelude =
-    "open Lwt.Infix\n\
-     let return = Lwt.return\n\
-     let run t = OS.Main.run t ; exit 0"
+  let prelude info =
+    Fmt.str
+      {ocaml|open Lwt.Infix\n\
+let return = Lwt.return\n\
+let run t = %s.Main.run t ; exit 0"|ocaml}
+      (os_of_target info)
 
   (* The ocamlfind packages to use when compiling config.ml *)
   let packages = [ package "mirage" ]

--- a/lib/mirage/target/unix.ml
+++ b/lib/mirage/target/unix.ml
@@ -4,7 +4,7 @@ module Key = Mirage_key
 type t = [ `Unix | `MacOSX ]
 
 let cast = function #t as t -> t | _ -> invalid_arg "not a unix target."
-let packages _ = [ Functoria.package ~min:"4.0.1" ~max:"5.0.0" "mirage-unix" ]
+let packages _ = [ Functoria.package ~min:"5.0.0" ~max:"6.0.0" "mirage-unix" ]
 
 (*Mirage unix is built on the host build context.*)
 let build_context ?build_dir:_ _ = []

--- a/test/f0/f0.ml
+++ b/test/f0/f0.ml
@@ -26,7 +26,7 @@ let write_key i k f =
 module C = struct
   open Action.Syntax
 
-  let prelude = ""
+  let prelude _ = ""
   let name = "test"
   let version = "1.0~test"
   let packages = [ package "functoria"; package "f0" ]

--- a/test/functoria/e2e/lib/e2e.ml
+++ b/test/functoria/e2e/lib/e2e.ml
@@ -24,7 +24,7 @@ let write_key i k f =
 module C = struct
   open Action.Syntax
 
-  let prelude = "let (>>=) x f = f x\nlet return x = x\nlet run x = x"
+  let prelude _ = "let (>>=) x f = f x\nlet return x = x\nlet run x = x"
   let name = "test"
   let version = "1.0~test"
   let packages = [ package "functoria"; package "e2e" ]

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -53,7 +53,7 @@ Query local opam
     "mirage-clock-unix" { >= "3.0.0" & < "5.0.0" }
     "mirage-logs" { >= "1.2.0" & < "2.0.0" }
     "mirage-runtime" { >= "4.0.0" & < "4.1.0" }
-    "mirage-unix" { >= "4.0.1" & < "5.0.0" }
+    "mirage-unix" { >= "5.0.0" & < "6.0.0" }
   ]
   
   
@@ -67,7 +67,7 @@ Query packages
   "mirage-clock-unix" { >= "3.0.0" & < "5.0.0" }
   "mirage-logs" { >= "1.2.0" & < "2.0.0" }
   "mirage-runtime" { >= "4.0.0" & < "4.1.0" }
-  "mirage-unix" { >= "4.0.1" & < "5.0.0" }
+  "mirage-unix" { >= "5.0.0" & < "6.0.0" }
   "ocaml" { build & >= "4.08.0" }
   "opam-monorepo" { build & >= "0.2.6" }
 

--- a/test/mirage/random-unix/main.ml.expected
+++ b/test/mirage/random-unix/main.ml.expected
@@ -5,18 +5,18 @@ let return x = x
 let run x = x
 
 module Mirage_crypto_rng_mirage_make__3 =
-  Mirage_crypto_rng_mirage.Make(OS.Time)(Mclock)
+  Mirage_crypto_rng_mirage.Make(Unix_os.Time)(Mclock)
 
 module Ethernet_make__5 = Ethernet.Make(Netif)
 
-module Arp_make__6 = Arp.Make(Ethernet_make__5)(OS.Time)
+module Arp_make__6 = Arp.Make(Ethernet_make__5)(Unix_os.Time)
 
 module Static_ipv4_make__7 =
   Static_ipv4.Make(Mirage_crypto_rng_mirage_make__3)(Mclock)
   (Ethernet_make__5)(Arp_make__6)
 
 module Ipv6_make__8 = Ipv6.Make(Netif)(Ethernet_make__5)
-  (Mirage_crypto_rng_mirage_make__3)(OS.Time)(Mclock)
+  (Mirage_crypto_rng_mirage_make__3)(Unix_os.Time)(Mclock)
 
 module Tcpip_stack_direct_ipv4v6__9 =
   Tcpip_stack_direct.IPV4V6(Static_ipv4_make__7)(Ipv6_make__8)
@@ -27,12 +27,12 @@ module Udp_make__11 = Udp.Make(Tcpip_stack_direct_ipv4v6__9)
   (Mirage_crypto_rng_mirage_make__3)
 
 module Tcp_flow_make__12 = Tcp.Flow.Make(Tcpip_stack_direct_ipv4v6__9)
-  (OS.Time)(Mclock)(Mirage_crypto_rng_mirage_make__3)
+  (Unix_os.Time)(Mclock)(Mirage_crypto_rng_mirage_make__3)
 
-module Tcpip_stack_direct_makev4v6__13 = Tcpip_stack_direct.MakeV4V6(OS.Time)
-  (Mirage_crypto_rng_mirage_make__3)(Netif)(Ethernet_make__5)(Arp_make__6)
-  (Tcpip_stack_direct_ipv4v6__9)(Icmpv4_make__10)(Udp_make__11)
-  (Tcp_flow_make__12)
+module Tcpip_stack_direct_makev4v6__13 =
+  Tcpip_stack_direct.MakeV4V6(Unix_os.Time)(Mirage_crypto_rng_mirage_make__3)
+  (Netif)(Ethernet_make__5)(Arp_make__6)(Tcpip_stack_direct_ipv4v6__9)
+  (Icmpv4_make__10)(Udp_make__11)(Tcp_flow_make__12)
 
 module Conduit_mirage_tcp__14 =
   Conduit_mirage.TCP(Tcpip_stack_direct_makev4v6__13)
@@ -42,7 +42,7 @@ module Conduit_mirage_tls__15 = Conduit_mirage.TLS(Conduit_mirage_tcp__14)
 module App_make__16 = App.Make(Conduit_mirage_tls__15)
   (Mirage_crypto_rng_mirage_make__3)
 
-let os_time__1 = lazy (
+let unix_os_time__1 = lazy (
   return ()
   )
 
@@ -51,9 +51,9 @@ let mclock__2 = lazy (
   )
 
 let mirage_crypto_rng_mirage_make__3 = lazy (
-  let __os_time__1 = Lazy.force os_time__1 in
+  let __unix_os_time__1 = Lazy.force unix_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
-  __os_time__1 >>= fun _os_time__1 ->
+  __unix_os_time__1 >>= fun _unix_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
   Mirage_crypto_rng_mirage_make__3.initialize (module Mirage_crypto_rng.Fortuna)
   )
@@ -70,9 +70,9 @@ let ethernet_make__5 = lazy (
 
 let arp_make__6 = lazy (
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
-  let __os_time__1 = Lazy.force os_time__1 in
+  let __unix_os_time__1 = Lazy.force unix_os_time__1 in
   __ethernet_make__5 >>= fun _ethernet_make__5 ->
-  __os_time__1 >>= fun _os_time__1 ->
+  __unix_os_time__1 >>= fun _unix_os_time__1 ->
   Arp_make__6.connect _ethernet_make__5
   )
 
@@ -96,12 +96,12 @@ let ipv6_make__8 = lazy (
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
   let __mirage_crypto_rng_mirage_make__3 =
                                           Lazy.force mirage_crypto_rng_mirage_make__3 in
-  let __os_time__1 = Lazy.force os_time__1 in
+  let __unix_os_time__1 = Lazy.force unix_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
   __netif__4 >>= fun _netif__4 ->
   __ethernet_make__5 >>= fun _ethernet_make__5 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
-  __os_time__1 >>= fun _os_time__1 ->
+  __unix_os_time__1 >>= fun _unix_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
   Ipv6_make__8.connect  ~handle_ra:(Key_gen.accept_router_advertisements ())
                     ?cidr:(Key_gen.ipv6 ())
@@ -138,19 +138,19 @@ let udp_make__11 = lazy (
 let tcp_flow_make__12 = lazy (
   let __tcpip_stack_direct_ipv4v6__9 =
                                       Lazy.force tcpip_stack_direct_ipv4v6__9 in
-  let __os_time__1 = Lazy.force os_time__1 in
+  let __unix_os_time__1 = Lazy.force unix_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
   let __mirage_crypto_rng_mirage_make__3 =
                                           Lazy.force mirage_crypto_rng_mirage_make__3 in
   __tcpip_stack_direct_ipv4v6__9 >>= fun _tcpip_stack_direct_ipv4v6__9 ->
-  __os_time__1 >>= fun _os_time__1 ->
+  __unix_os_time__1 >>= fun _unix_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
   Tcp_flow_make__12.connect _tcpip_stack_direct_ipv4v6__9
   )
 
 let tcpip_stack_direct_makev4v6__13 = lazy (
-  let __os_time__1 = Lazy.force os_time__1 in
+  let __unix_os_time__1 = Lazy.force unix_os_time__1 in
   let __mirage_crypto_rng_mirage_make__3 =
                                           Lazy.force mirage_crypto_rng_mirage_make__3 in
   let __netif__4 = Lazy.force netif__4 in
@@ -161,7 +161,7 @@ let tcpip_stack_direct_makev4v6__13 = lazy (
   let __icmpv4_make__10 = Lazy.force icmpv4_make__10 in
   let __udp_make__11 = Lazy.force udp_make__11 in
   let __tcp_flow_make__12 = Lazy.force tcp_flow_make__12 in
-  __os_time__1 >>= fun _os_time__1 ->
+  __unix_os_time__1 >>= fun _unix_os_time__1 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
   __netif__4 >>= fun _netif__4 ->
   __ethernet_make__5 >>= fun _ethernet_make__5 ->

--- a/test/mirage/random-xen/main.ml.expected
+++ b/test/mirage/random-xen/main.ml.expected
@@ -5,18 +5,18 @@ let return x = x
 let run x = x
 
 module Mirage_crypto_rng_mirage_make__3 =
-  Mirage_crypto_rng_mirage.Make(OS.Time)(Mclock)
+  Mirage_crypto_rng_mirage.Make(Xen_os.Time)(Mclock)
 
 module Ethernet_make__5 = Ethernet.Make(Netif)
 
-module Arp_make__6 = Arp.Make(Ethernet_make__5)(OS.Time)
+module Arp_make__6 = Arp.Make(Ethernet_make__5)(Xen_os.Time)
 
 module Static_ipv4_make__7 =
   Static_ipv4.Make(Mirage_crypto_rng_mirage_make__3)(Mclock)
   (Ethernet_make__5)(Arp_make__6)
 
 module Ipv6_make__8 = Ipv6.Make(Netif)(Ethernet_make__5)
-  (Mirage_crypto_rng_mirage_make__3)(OS.Time)(Mclock)
+  (Mirage_crypto_rng_mirage_make__3)(Xen_os.Time)(Mclock)
 
 module Tcpip_stack_direct_ipv4v6__9 =
   Tcpip_stack_direct.IPV4V6(Static_ipv4_make__7)(Ipv6_make__8)
@@ -27,12 +27,12 @@ module Udp_make__11 = Udp.Make(Tcpip_stack_direct_ipv4v6__9)
   (Mirage_crypto_rng_mirage_make__3)
 
 module Tcp_flow_make__12 = Tcp.Flow.Make(Tcpip_stack_direct_ipv4v6__9)
-  (OS.Time)(Mclock)(Mirage_crypto_rng_mirage_make__3)
+  (Xen_os.Time)(Mclock)(Mirage_crypto_rng_mirage_make__3)
 
-module Tcpip_stack_direct_makev4v6__13 = Tcpip_stack_direct.MakeV4V6(OS.Time)
-  (Mirage_crypto_rng_mirage_make__3)(Netif)(Ethernet_make__5)(Arp_make__6)
-  (Tcpip_stack_direct_ipv4v6__9)(Icmpv4_make__10)(Udp_make__11)
-  (Tcp_flow_make__12)
+module Tcpip_stack_direct_makev4v6__13 =
+  Tcpip_stack_direct.MakeV4V6(Xen_os.Time)(Mirage_crypto_rng_mirage_make__3)
+  (Netif)(Ethernet_make__5)(Arp_make__6)(Tcpip_stack_direct_ipv4v6__9)
+  (Icmpv4_make__10)(Udp_make__11)(Tcp_flow_make__12)
 
 module Conduit_mirage_tcp__14 =
   Conduit_mirage.TCP(Tcpip_stack_direct_makev4v6__13)
@@ -42,7 +42,7 @@ module Conduit_mirage_tls__15 = Conduit_mirage.TLS(Conduit_mirage_tcp__14)
 module App_make__16 = App.Make(Conduit_mirage_tls__15)
   (Mirage_crypto_rng_mirage_make__3)
 
-let os_time__1 = lazy (
+let xen_os_time__1 = lazy (
   return ()
   )
 
@@ -51,9 +51,9 @@ let mclock__2 = lazy (
   )
 
 let mirage_crypto_rng_mirage_make__3 = lazy (
-  let __os_time__1 = Lazy.force os_time__1 in
+  let __xen_os_time__1 = Lazy.force xen_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
-  __os_time__1 >>= fun _os_time__1 ->
+  __xen_os_time__1 >>= fun _xen_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
   Mirage_crypto_rng_mirage_make__3.initialize (module Mirage_crypto_rng.Fortuna)
   )
@@ -70,9 +70,9 @@ let ethernet_make__5 = lazy (
 
 let arp_make__6 = lazy (
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
-  let __os_time__1 = Lazy.force os_time__1 in
+  let __xen_os_time__1 = Lazy.force xen_os_time__1 in
   __ethernet_make__5 >>= fun _ethernet_make__5 ->
-  __os_time__1 >>= fun _os_time__1 ->
+  __xen_os_time__1 >>= fun _xen_os_time__1 ->
   Arp_make__6.connect _ethernet_make__5
   )
 
@@ -96,12 +96,12 @@ let ipv6_make__8 = lazy (
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
   let __mirage_crypto_rng_mirage_make__3 =
                                           Lazy.force mirage_crypto_rng_mirage_make__3 in
-  let __os_time__1 = Lazy.force os_time__1 in
+  let __xen_os_time__1 = Lazy.force xen_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
   __netif__4 >>= fun _netif__4 ->
   __ethernet_make__5 >>= fun _ethernet_make__5 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
-  __os_time__1 >>= fun _os_time__1 ->
+  __xen_os_time__1 >>= fun _xen_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
   Ipv6_make__8.connect  ~handle_ra:(Key_gen.accept_router_advertisements ())
                     ?cidr:(Key_gen.ipv6 ())
@@ -138,19 +138,19 @@ let udp_make__11 = lazy (
 let tcp_flow_make__12 = lazy (
   let __tcpip_stack_direct_ipv4v6__9 =
                                       Lazy.force tcpip_stack_direct_ipv4v6__9 in
-  let __os_time__1 = Lazy.force os_time__1 in
+  let __xen_os_time__1 = Lazy.force xen_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
   let __mirage_crypto_rng_mirage_make__3 =
                                           Lazy.force mirage_crypto_rng_mirage_make__3 in
   __tcpip_stack_direct_ipv4v6__9 >>= fun _tcpip_stack_direct_ipv4v6__9 ->
-  __os_time__1 >>= fun _os_time__1 ->
+  __xen_os_time__1 >>= fun _xen_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
   Tcp_flow_make__12.connect _tcpip_stack_direct_ipv4v6__9
   )
 
 let tcpip_stack_direct_makev4v6__13 = lazy (
-  let __os_time__1 = Lazy.force os_time__1 in
+  let __xen_os_time__1 = Lazy.force xen_os_time__1 in
   let __mirage_crypto_rng_mirage_make__3 =
                                           Lazy.force mirage_crypto_rng_mirage_make__3 in
   let __netif__4 = Lazy.force netif__4 in
@@ -161,7 +161,7 @@ let tcpip_stack_direct_makev4v6__13 = lazy (
   let __icmpv4_make__10 = Lazy.force icmpv4_make__10 in
   let __udp_make__11 = Lazy.force udp_make__11 in
   let __tcp_flow_make__12 = Lazy.force tcp_flow_make__12 in
-  __os_time__1 >>= fun _os_time__1 ->
+  __xen_os_time__1 >>= fun _xen_os_time__1 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
   __netif__4 >>= fun _netif__4 ->
   __ethernet_make__5 >>= fun _ethernet_make__5 ->


### PR DESCRIPTION
From the MirageOS core meeting, we decided to delete the last _relicat_ about `mirage-os-shims`. Now, a target must provide its own module `OS` and it must be named/prefixed to avoid a clash of names (and unlock the ability to compile in the same universe multiples targets).