### PR TITLE
Fix the pull step when the build directory is custom

### DIFF
--- a/lib/functoria/makefile.ml
+++ b/lib/functoria/makefile.ml
@@ -123,7 +123,7 @@ lock::
 
 pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
 	@@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-	@@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l $<
+	@@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
 
 install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
 	@@echo " ↳ opam install switch dependencies"

--- a/test/functoria/query/run.t
+++ b/test/functoria/query/run.t
@@ -104,7 +104,7 @@ Query Makefile
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l $<
+  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
   	@echo " ↳ opam install switch dependencies"
@@ -160,7 +160,7 @@ Query Makefile without depexts
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l $<
+  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
   	@echo " ↳ opam install switch dependencies"
@@ -221,7 +221,7 @@ Query Makefile with depext
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l $<
+  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
   	@echo " ↳ opam install switch dependencies"

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -71,7 +71,7 @@ Query makefile
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l $<
+  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
   	@echo " ↳ opam install switch dependencies"

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -113,7 +113,7 @@ Query Makefile
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l $<
+  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
   	@echo " ↳ opam install switch dependencies"
@@ -168,7 +168,7 @@ Query Makefile without depexts
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l $<
+  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
   	@echo " ↳ opam install switch dependencies"
@@ -228,7 +228,7 @@ Query Makefile with depext
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l $<
+  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
   	@echo " ↳ opam install switch dependencies"

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -117,7 +117,7 @@ Query Makefile
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l $<
+  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
   	@echo " ↳ opam install switch dependencies"
@@ -173,7 +173,7 @@ Query Makefile without depexts
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l $<
+  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
   	@echo " ↳ opam install switch dependencies"
@@ -234,7 +234,7 @@ Query Makefile with depext
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@cd $(BUILD_DIR) && $(OPAM) monorepo pull -l $<
+  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
   	@echo " ↳ opam install switch dependencies"


### PR DESCRIPTION
The generated makefile rule was wrong, it was cd-ing into the build directory
thus making the location of the lock file incorrect (as it is relative to the
makefile position). Instead, we use the --root / -r option of opam-monorepo
to fetch the duniverse folder inside the build directory, without having to cd
into it.