### PR TITLE
Mirage_runtim: allow more log levels

### DIFF
--- a/lib/mirage/impl/mirage_impl_reporter.ml
+++ b/lib/mirage/impl/mirage_impl_reporter.ml
@@ -8,11 +8,12 @@ type reporter = job
 let reporter = job
 
 let pp_level ppf = function
-  | Logs.Error -> Fmt.string ppf "Logs.Error"
-  | Logs.Warning -> Fmt.string ppf "Logs.Warning"
-  | Logs.Info -> Fmt.string ppf "Logs.Info"
-  | Logs.Debug -> Fmt.string ppf "Logs.Debug"
-  | Logs.App -> Fmt.string ppf "Logs.App"
+  | Some Logs.Error -> Fmt.string ppf "(Some Logs.Error)"
+  | Some Logs.Warning -> Fmt.string ppf "(Some Logs.Warning)"
+  | Some Logs.Info -> Fmt.string ppf "(Some Logs.Info)"
+  | Some Logs.Debug -> Fmt.string ppf "(Some Logs.Debug)"
+  | Some Logs.App -> Fmt.string ppf "(Some Logs.App)"
+  | None -> Fmt.string ppf "None"
 
 let mirage_log ?ring_size ~default () =
   let logs = Key.logs in
@@ -31,7 +32,7 @@ let mirage_log ?ring_size ~default () =
   impl ~packages ~keys ~connect "Mirage_logs.Make" (pclock @-> reporter)
 
 let default_reporter ?(clock = default_posix_clock) ?ring_size
-    ?(level = Logs.Info) () =
+    ?(level = Some Logs.Info) () =
   mirage_log ?ring_size ~default:level () $ clock
 
 let no_reporter =

--- a/lib/mirage/impl/mirage_impl_reporter.mli
+++ b/lib/mirage/impl/mirage_impl_reporter.mli
@@ -5,7 +5,7 @@ val reporter : reporter Functoria.typ
 val default_reporter :
   ?clock:Mirage_impl_pclock.pclock Functoria.impl ->
   ?ring_size:int ->
-  ?level:Logs.level ->
+  ?level:Logs.level option ->
   unit ->
   reporter Functoria.impl
 

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -194,7 +194,7 @@ val reporter : reporter typ
 val default_reporter :
   ?clock:pclock impl ->
   ?ring_size:int ->
-  ?level:Logs.level ->
+  ?level:Logs.level option ->
   unit ->
   reporter impl
 (** [default_reporter ?clock ?level ()] is the log reporter that prints log

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -444,11 +444,12 @@ let syslog_hostname default =
   create_simple ~doc ~default Arg.string "syslog-hostname"
 
 let pp_level ppf = function
-  | Logs.Error -> Fmt.string ppf "Logs.Error"
-  | Logs.Warning -> Fmt.string ppf "Logs.Warning"
-  | Logs.Info -> Fmt.string ppf "Logs.Info"
-  | Logs.Debug -> Fmt.string ppf "Logs.Debug"
-  | Logs.App -> Fmt.string ppf "Logs.App"
+  | Some Logs.Error -> Fmt.string ppf "Some Logs.Error"
+  | Some Logs.Warning -> Fmt.string ppf "Some Logs.Warning"
+  | Some Logs.Info -> Fmt.string ppf "Some Logs.Info"
+  | Some Logs.Debug -> Fmt.string ppf "Some Logs.Debug"
+  | Some Logs.App -> Fmt.string ppf "Some Logs.App"
+  | None -> Fmt.string ppf "None"
 
 let pp_pattern ppf = function
   | `All -> Fmt.string ppf "`All"

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -82,15 +82,12 @@ module Arg = struct
       | Some Logs.Debug -> "debug"
       | None -> "quiet"
     in
-    let map f = function
-      | `Ok x -> `Ok (f x)
-      | `Error _ as e -> e
-    in
+    let map f = function `Ok x -> `Ok (f x) | `Error _ as e -> e in
     let parser str =
       match String.split_on_char ':' str with
-      | [ _ ] -> map (fun l -> `All, l) (level_of_string str)
-      | [ "*"; lvl ] -> map (fun l ->`All, l) (level_of_string lvl)
-      | [ src; lvl ] -> map (fun l -> `Src src, l) (level_of_string lvl)
+      | [ _ ] -> map (fun l -> (`All, l)) (level_of_string str)
+      | [ "*"; lvl ] -> map (fun l -> (`All, l)) (level_of_string lvl)
+      | [ src; lvl ] -> map (fun l -> (`Src src, l)) (level_of_string lvl)
       | _ -> `Error ("Can't parse log threshold: " ^ str)
     in
     let serialize ppf = function

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type log_threshold = [ `All | `Src of string ] * Logs.level
+type log_threshold = [ `All | `Src of string ] * Logs.level option
 
 let set_level ~default l =
   let srcs = Logs.Src.list () in
@@ -22,14 +22,14 @@ let set_level ~default l =
     try snd @@ List.find (function `All, _ -> true | _ -> false) l
     with Not_found -> default
   in
-  Logs.set_level (Some default);
+  Logs.set_level default;
   List.iter
     (function
       | `All, _ -> ()
       | `Src src, level -> (
           try
             let s = List.find (fun s -> Logs.Src.name s = src) srcs in
-            Logs.Src.set_level s (Some level)
+            Logs.Src.set_level s level
           with Not_found ->
             Fmt.(pf stdout)
               "%a %s is not a valid log source.\n%!"
@@ -65,27 +65,32 @@ module Arg = struct
   let ipv6 = of_module (module Ipaddr.V6.Prefix)
 
   let log_threshold =
-    let enum =
-      [
-        ("error", Logs.Error);
-        ("warning", Logs.Warning);
-        ("info", Logs.Info);
-        ("debug", Logs.Debug);
-      ]
+    let level_of_string = function
+      | "app" -> `Ok (Some Logs.App)
+      | "error" -> `Ok (Some Logs.Error)
+      | "warning" -> `Ok (Some Logs.Warning)
+      | "info" -> `Ok (Some Logs.Info)
+      | "debug" -> `Ok (Some Logs.Debug)
+      | "quiet" -> `Ok None
+      | l -> `Error (l ^ " is not a valid log level")
     in
-    let level_of_string x =
-      try List.assoc x enum
-      with Not_found -> Fmt.kstr failwith "%s is not a valid log level" x
+    let string_of_level = function
+      | Some Logs.App -> "app"
+      | Some Logs.Error -> "error"
+      | Some Logs.Warning -> "warning"
+      | Some Logs.Info -> "info"
+      | Some Logs.Debug -> "debug"
+      | None -> "quiet"
     in
-    let string_of_level x =
-      try fst @@ List.find (fun (_, y) -> x = y) enum
-      with Not_found -> "warning"
+    let map f = function
+      | `Ok x -> `Ok (f x)
+      | `Error _ as e -> e
     in
     let parser str =
       match String.split_on_char ':' str with
-      | [ _ ] -> `Ok (`All, level_of_string str)
-      | [ "*"; lvl ] -> `Ok (`All, level_of_string lvl)
-      | [ src; lvl ] -> `Ok (`Src src, level_of_string lvl)
+      | [ _ ] -> map (fun l -> `All, l) (level_of_string str)
+      | [ "*"; lvl ] -> map (fun l ->`All, l) (level_of_string lvl)
+      | [ src; lvl ] -> map (fun l -> `Src src, l) (level_of_string lvl)
       | _ -> `Error ("Can't parse log threshold: " ^ str)
     in
     let serialize ppf = function

--- a/lib_runtime/mirage/mirage_runtime.mli
+++ b/lib_runtime/mirage/mirage_runtime.mli
@@ -20,10 +20,10 @@
 
 (** {2 Log thresholds} *)
 
-type log_threshold = [ `All | `Src of string ] * Logs.level
+type log_threshold = [ `All | `Src of string ] * Logs.level option
 (** The type for log threshold. *)
 
-val set_level : default:Logs.level -> log_threshold list -> unit
+val set_level : default:Logs.level option -> log_threshold list -> unit
 (** [set_level ~default l] set the log levels needed to have all of the log
     sources appearing in [l] be used. *)
 

--- a/lib_runtime/mirage/mirage_runtime.mli
+++ b/lib_runtime/mirage/mirage_runtime.mli
@@ -21,7 +21,7 @@
 (** {2 Log thresholds} *)
 
 type log_threshold = [ `All | `Src of string ] * Logs.level option
-(** The type for log threshold. *)
+(** The type for log threshold. A log level of [None] disables logging. *)
 
 val set_level : default:Logs.level option -> log_threshold list -> unit
 (** [set_level ~default l] set the log levels needed to have all of the log


### PR DESCRIPTION
Also does not raise exceptions on unknown log levels.

Addresses #1273 and #1274

This is a breaking change. Most of it can be achieved in a non-breaking way also.