### PR TITLE
Fix minimal version required for mirage{,-runtime}

### DIFF
--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -321,7 +321,7 @@ let run t = %s.Main.run t ; exit 0|ocaml}
     let keys = Key.[ v target; v warn_error; v target_debug ] in
     let packages_v =
       (* XXX: use %%VERSION_NUM%% here instead of hardcoding a version? *)
-      let min = "4.0.0" and max = "4.1.0" in
+      let min = "4.0" and max = "4.1.0" in
       let common =
         [
           package ~scope:`Switch ~build:true ~min:"4.08.0" "ocaml";

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -25,7 +25,7 @@ Query global opam
   ]
   
   depends: [
-    "mirage" { build & >= "4.0.0" & < "4.1.0" }
+    "mirage" { build & >= "4.0" & < "4.1.0" }
     "ocaml" { build & >= "4.08.0" }
     "ocaml-freestanding" { build & >= "0.7.0" }
     "opam-monorepo" { build & >= "0.2.6" }
@@ -48,7 +48,7 @@ Query local opam
     "mirage-bootvar-solo5" { >= "0.6.0" & < "0.7.0" }
     "mirage-clock-freestanding" { >= "3.1.0" & < "5.0.0" }
     "mirage-logs" { >= "1.2.0" & < "2.0.0" }
-    "mirage-runtime" { >= "4.0.0" & < "4.1.0" }
+    "mirage-runtime" { >= "4.0" & < "4.1.0" }
     "mirage-solo5" { >= "0.7.0" & < "0.8.0" }
   ]
   
@@ -57,11 +57,11 @@ Query local opam
 Query packages
   $ ./config.exe query --target hvt packages
   "lwt"
-  "mirage" { build & >= "4.0.0" & < "4.1.0" }
+  "mirage" { build & >= "4.0" & < "4.1.0" }
   "mirage-bootvar-solo5" { >= "0.6.0" & < "0.7.0" }
   "mirage-clock-freestanding" { >= "3.1.0" & < "5.0.0" }
   "mirage-logs" { >= "1.2.0" & < "2.0.0" }
-  "mirage-runtime" { >= "4.0.0" & < "4.1.0" }
+  "mirage-runtime" { >= "4.0" & < "4.1.0" }
   "mirage-solo5" { >= "0.7.0" & < "0.8.0" }
   "ocaml" { build & >= "4.08.0" }
   "ocaml-freestanding" { build & >= "0.7.0" }

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -29,7 +29,7 @@ Query global opam
   ]
   
   depends: [
-    "mirage" { build & >= "4.0.0" & < "4.1.0" }
+    "mirage" { build & >= "4.0" & < "4.1.0" }
     "ocaml" { build & >= "4.08.0" }
     "opam-monorepo" { build & >= "0.2.6" }
   ]
@@ -52,7 +52,7 @@ Query local opam
     "mirage-bootvar-unix" { >= "0.1.0" & < "0.2.0" }
     "mirage-clock-unix" { >= "3.0.0" & < "5.0.0" }
     "mirage-logs" { >= "1.2.0" & < "2.0.0" }
-    "mirage-runtime" { >= "4.0.0" & < "4.1.0" }
+    "mirage-runtime" { >= "4.0" & < "4.1.0" }
     "mirage-unix" { >= "5.0.0" & < "6.0.0" }
   ]
   
@@ -62,11 +62,11 @@ Query local opam
 Query packages
   $ ./config.exe query packages
   "lwt"
-  "mirage" { build & >= "4.0.0" & < "4.1.0" }
+  "mirage" { build & >= "4.0" & < "4.1.0" }
   "mirage-bootvar-unix" { >= "0.1.0" & < "0.2.0" }
   "mirage-clock-unix" { >= "3.0.0" & < "5.0.0" }
   "mirage-logs" { >= "1.2.0" & < "2.0.0" }
-  "mirage-runtime" { >= "4.0.0" & < "4.1.0" }
+  "mirage-runtime" { >= "4.0" & < "4.1.0" }
   "mirage-unix" { >= "5.0.0" & < "6.0.0" }
   "ocaml" { build & >= "4.08.0" }
   "opam-monorepo" { build & >= "0.2.6" }


### PR DESCRIPTION
According to OPAM and for a beta release, the minimal version
must be 4.0 instead of 4.0.0. Indeed, OPAM concludes that
4.0.0~beta1 < 4.0.0 (but 4.0.0~beta1 > 4.0).

Try to fix mirage/mirage-dev#381