### PR TITLE
Lint version of some packages according to their releases

### DIFF
--- a/lib/mirage/impl/mirage_impl_block.ml
+++ b/lib/mirage/impl/mirage_impl_block.ml
@@ -68,7 +68,7 @@ let block_conf file =
     Key.match_ Key.(value target) @@ function
     | #Mirage_key.mode_xen -> xen_block_packages
     | #Mirage_key.mode_solo5 ->
-        [ package ~min:"0.6.1" ~max:"0.7.0" "mirage-block-solo5" ]
+        [ package ~min:"0.7.0" ~max:"0.8.0" "mirage-block-solo5" ]
     | #Mirage_key.mode_unix ->
         [ package ~min:"2.12.0" ~max:"3.0.0" "mirage-block-unix" ]
   in

--- a/lib/mirage/impl/mirage_impl_console.ml
+++ b/lib/mirage/impl/mirage_impl_console.ml
@@ -7,7 +7,7 @@ let console = Type.v CONSOLE
 let connect str _ m _ = Fmt.str "%s.connect %S" m str
 
 let console_unix str =
-  let packages = [ package ~min:"4.0.0" ~max:"5.0.0" "mirage-console-unix" ] in
+  let packages = [ package ~min:"5.1.0" ~max:"6.0.0" "mirage-console-unix" ] in
   impl ~packages ~connect:(connect str) "Console_unix" console
 
 let console_xen str =
@@ -15,7 +15,7 @@ let console_xen str =
   impl ~packages ~connect:(connect str) "Console_xen" console
 
 let console_solo5 str =
-  let packages = [ package ~min:"0.6.1" ~max:"0.7.0" "mirage-console-solo5" ] in
+  let packages = [ package ~min:"0.7.0" ~max:"0.8.0" "mirage-console-solo5" ] in
   impl ~packages ~connect:(connect str) "Console_solo5" console
 
 let custom_console str =

--- a/lib/mirage/impl/mirage_impl_mclock.ml
+++ b/lib/mirage/impl/mirage_impl_mclock.ml
@@ -7,7 +7,7 @@ let mclock = Type.v MCLOCK
 let default_monotonic_clock =
   let packages_v =
     Mirage_key.(if_ is_unix)
-      [ package ~min:"3.0.0" ~max:"5.0.0" "mirage-clock-unix" ]
-      [ package ~min:"3.1.0" ~max:"5.0.0" "mirage-clock-freestanding" ]
+      [ package ~min:"4.1.0" ~max:"5.0.0" "mirage-clock-unix" ]
+      [ package ~min:"4.1.0" ~max:"5.0.0" "mirage-clock-freestanding" ]
   in
   impl ~packages_v "Mclock" mclock

--- a/lib/mirage/impl/mirage_impl_network.ml
+++ b/lib/mirage/impl/mirage_impl_network.ml
@@ -16,11 +16,11 @@ let network_conf (intf : string Key.key) =
     | `Xen -> [ package ~min:"2.1.0" ~max:"3.0.0" "mirage-net-xen" ]
     | `Qubes ->
         [
-          package ~min:"2.0.0" ~max:"3.0.0" "mirage-net-xen";
+          package ~min:"2.1.0" ~max:"3.0.0" "mirage-net-xen";
           Mirage_impl_qubesdb.pkg;
         ]
     | #Mirage_key.mode_solo5 ->
-        [ package ~min:"0.6.1" ~max:"0.7.0" "mirage-net-solo5" ]
+        [ package ~min:"0.7.0" ~max:"0.8.0" "mirage-net-solo5" ]
   in
   let connect _ modname _ =
     (* @samoht: why not just use the args paramater? *)


### PR DESCRIPTION
See mirage/mirage-dev#385 which requires a `beta3` release.