### PR TITLE
Preview: upgrade to ocamlformat.0.21.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.20.1
+version = 0.21.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/lib/functoria/DSL.mli
+++ b/lib/functoria/DSL.mli
@@ -42,7 +42,9 @@ val ( @-> ) : 'a typ -> 'b typ -> ('a -> 'b) typ
     corresponds to prepending a parameter to the list of functor parameters. For
     example:
 
-    {[ kv_ro @-> ip @-> kv_ro ]}
+    {[
+      kv_ro @-> ip @-> kv_ro
+    ]}
 
     This describes a functor type that accepts two arguments -- a [kv_ro] and an
     [ip] device -- and returns a [kv_ro]. *)

--- a/lib/functoria/functoria.mli
+++ b/lib/functoria/functoria.mli
@@ -36,7 +36,9 @@
     with the {!Type} combinators, like the [@->] operator, which represents a
     functor arrow.
 
-    {[ let main = main "Unikernel.Main" (m @-> job) ]}
+    {[
+      let main = main "Unikernel.Main" (m @-> job)
+    ]}
 
     This declares that the functor [Unikernel.Main] takes a module of type [m]
     and returns a module of type {!module-DSL.job}. [job] has a specific meaning
@@ -90,7 +92,9 @@
 
     To register a new application, use [register]:
 
-    {[ let () = register "app" [ main $ impl ] ]}
+    {[
+      let () = register "app" [ main $ impl ]
+    ]}
 
     This function (which should only be called once) takes as argument the name
     of the application and a list of jobs. The jobs are defined using the
@@ -104,12 +108,16 @@
     time. This is done by using the {!Key} DSL, for instance to check whether
     [lang_key] is instanciated with a given string:
 
-    {[ let lang_is "s" = Key.(pure (( = ) s) $ value lang_key) ]}
+    {[
+      let lang_is "s" = Key.(pure (( = ) s) $ value lang_key)
+    ]}
 
     Then by using the {!if_impl} combinator to choose between two
     implementations depending on the value of the key:
 
-    {[ let impl = if_impl (is "fi") finnish_impl not_finnish_implementation ]} *)
+    {[
+      let impl = if_impl (is "fi") finnish_impl not_finnish_implementation
+    ]} *)
 
 module type DSL = module type of DSL
 

--- a/lib/functoria/type.mli
+++ b/lib/functoria/type.mli
@@ -29,7 +29,9 @@ val ( @-> ) : 'a t -> 'b t -> ('a -> 'b) t
     signature [y]. This corresponds to prepending a parameter to the list of
     functor parameters. For example:
 
-    {[ kv_ro @-> ip @-> kv_ro ]}
+    {[
+      kv_ro @-> ip @-> kv_ro
+    ]}
 
     This describes a functor type that accepts two arguments -- a [kv_ro] and an
     [ip] device -- and returns a [kv_ro]. *)

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -330,7 +330,9 @@ val docteur :
 
     For a Solo5 target, users must {i attach} the image as a block device:
 
-    {[ $ solo5-hvt --block:<name>=<path-to-the-image> -- unikernel.{hvt,...} ]}
+    {[
+      $ solo5-hvt --block:<name>=<path-to-the-image> -- unikernel.{hvt,...}
+    ]}
 
     For the Unix target, the program [open] the image at the beginning of the
     process. An integrity check of the image can be done via the [analyze] value
@@ -948,7 +950,9 @@ val git_ssh :
     The format of the authenticator is [SHA256:<b64-encoded-public-key>], the
     output of:
 
-    {[ $ ssh-keygen -lf <(ssh-keyscan -t rsa|ed25519 remote 2>/dev/null) ]} *)
+    {[
+      $ ssh-keygen -lf <(ssh-keyscan -t rsa|ed25519 remote 2>/dev/null)
+    ]} *)
 
 val git_http :
   ?authenticator:string option key ->


### PR DESCRIPTION
This is a preview of the formatting of your project codebase with the upcoming `ocamlformat.0.21.0`. Note that this package is not yet released in opam (so the linting/formatting task of your CI won't pass), the formatting might also change slightly in the released version as we try to integrate feedback from our users.

The changes on this project are due to:
- the separators of codeblocks `{[]}` in doc-comments are now placed on their own line, this is the new syntax agreed upon with other tools handling odoc comments.

As always, we are happy to hear your feedback!  Thank you for using ocamlformat!