### PR TITLE
Add `docteur` device

### DIFF
--- a/lib/mirage/impl/mirage_impl_block.ml
+++ b/lib/mirage/impl/mirage_impl_block.ml
@@ -177,7 +177,7 @@ let docteur_unix (mode : mode) disk analyze remote =
       (Key.v disk)
   in
   let keys = [ Key.v disk; Key.v analyze ] in
-  let packages = [ package "docteur-unix" ] in
+  let packages = [ package "docteur-unix" ~min:"0.0.3" ] in
   impl ~keys ~packages ~dune ~install ~configure ~connect
     (Fmt.str "Docteur_unix.%a" pp_mode mode)
     ro
@@ -218,7 +218,7 @@ let docteur_solo5 (mode : mode) disk analyze remote =
       (Key.v disk)
   in
   let keys = [ Key.v disk; Key.v analyze ] in
-  let packages = [ package "docteur-solo5" ] in
+  let packages = [ package "docteur-solo5" ~min:"0.0.3" ] in
   impl ~keys ~packages ~dune ~install ~configure ~connect
     (Fmt.str "Docteur_solo5.%a" pp_mode mode)
     ro

--- a/lib/mirage/impl/mirage_impl_block.mli
+++ b/lib/mirage/impl/mirage_impl_block.mli
@@ -15,6 +15,13 @@ val block_of_xenstore_id : string -> block Functoria.impl
 val block_of_file : string -> block Functoria.impl
 val block_conf : string -> block Functoria.device
 
+val docteur :
+  ?mode:[ `Fast | `Light ] ->
+  ?disk:string Functoria.Key.key ->
+  ?analyze:bool Functoria.Key.key ->
+  string ->
+  Mirage_impl_kv.ro Functoria.impl
+
 type block_t = { filename : string; number : int }
 
 val all_blocks : (string, block_t) Hashtbl.t

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -76,6 +76,9 @@ let kv_rw = Mirage_impl_kv.rw
 let direct_kv_rw = Mirage_impl_kv.direct_kv_rw
 let kv_rw_mem = Mirage_impl_kv.mem_kv_rw
 
+let docteur ?mode ?disk ?analyze remote =
+  Mirage_impl_block.docteur ?mode ?disk ?analyze remote
+
 type block = Mirage_impl_block.block
 
 let block = Mirage_impl_block.block

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -294,6 +294,28 @@ val generic_kv_ro :
 
     If no key is provided, it uses {!Key.kv_ro} to create a new one. *)
 
+val docteur :
+  ?mode:[ `Fast | `Light ] ->
+  ?disk:string Key.key ->
+  ?analyze:bool Key.key ->
+  string ->
+  kv_ro impl
+(** [docteur ?mode ?disk ?analyze remote] creates a Docteur image which can be
+    used by the produced {i unikernel} as an external block-device. It permits
+    to attach a read-only file-system. [analyze] checks the integrity of the
+    given block-device at the boot-time (it can take a time). It's possible to
+    use the file-system into 2 modes:
+
+    - [`Light] an access requires that we reconstruct the path to the requested
+      object. That mostly means that we probably need to extract few objects
+      before the extraction of the requested one. This choice does not require a
+      huge usage of memory but it can be slower is deep in your filesystem
+    - [`Fast] reconstructs the layout of your file-system at the boot time (so
+      it can take a time). Then, if the user wants a specific file, we ensure
+      that only the requested object is extracted. However, depending on your
+      image, this mode can require a huge amount of memory to keep the structure
+      of your file-system. *)
+
 type kv_rw
 (** Abstract type for read-write key/value store. *)
 


### PR DESCRIPTION
`docteur` is close to be released. May be a good time to add it into our `mirage-skeleton`. This PR is a draft to have review about documentation. Currently, the workflow is simple:
- the user decide what he/she wants to download (it can be a remote Git repository or `file://path/`)
- the device (as `tar_archive`) makes the image _via_ dune
- we install the image (`disk` by default - Solo5 does not like `.`) into the `dist/` directory
- from `unix`, a simple launch is enough (the block device will `open "disk"` by itself)
- from `solo5`, we must pass `--block:disk=<path-to-the-disk-file>`