### PR TITLE
Update to cmdliner 1.1.1

### DIFF
--- a/functoria-runtime.opam
+++ b/functoria-runtime.opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "1.1.0"}
   "fmt" {>= "0.8.7"}
 ]
 

--- a/functoria.opam
+++ b/functoria.opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0" | (with-test & >= "3.0.0")}
   "base-unix"
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.1"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/functoria.opam
+++ b/functoria.opam
@@ -46,6 +46,3 @@ how to apply them in order to produce a complete application.
 The main use case is mirage. See the [mirage](https://github.com/mirage/mirage)
 repository for details.
 """
-pin-depends:[
-  [ "cmdliner.1.1.0" "git+https://github.com/dbuenzli/cmdliner.git#74daf226fbacdd29862a01c85fe37c6595b374bf" ]
-]

--- a/functoria.opam
+++ b/functoria.opam
@@ -46,3 +46,6 @@ how to apply them in order to produce a complete application.
 The main use case is mirage. See the [mirage](https://github.com/mirage/mirage)
 repository for details.
 """
+pin-depends:[
+  [ "cmdliner.1.1.0" "git+https://github.com/dbuenzli/cmdliner.git#74daf226fbacdd29862a01c85fe37c6595b374bf" ]
+]

--- a/functoria.opam
+++ b/functoria.opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0" | (with-test & >= "3.0.0")}
   "base-unix"
-  "cmdliner" {>= "0.9.8" & < "1.1.0"}
+  "cmdliner" {>= "1.1.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/lib/functoria/cli.ml
+++ b/lib/functoria/cli.ml
@@ -297,19 +297,6 @@ let pp_action pp_a ppf = function
   | Help h -> Fmt.pf ppf "@[help:@ @[<2>%a@]@]" (pp_help pp_a) h
 
 (*
-let args ~with_setup context mname =
-  Term.(
-    const (fun () config_file context_file dry_run output context ->
-        { config_file; context_file; dry_run; output; context })
-    $ setup ~with_setup
-    $ config_file
-    $ context_file mname
-    $ dry_run
-    $ output
-    $ context)
-*)
-
-(*
  * Subcommand specifications
  *)
 

--- a/lib/functoria/context_cache.ml
+++ b/lib/functoria/context_cache.ml
@@ -64,8 +64,8 @@ let read file =
     with Failure e -> Action.error e
 
 let peek t term =
-  match Cmdliner.Term.eval_peek_opts ~argv:t term with
-  | Some c, _ | _, `Ok c -> Some c
+  match Cmdliner.Cmd.eval_peek_opts ~argv:t term with
+  | Some c, _ | _, Ok (`Ok c) -> Some c
   | _ ->
       Fmt.failwith "Invalid cached configuration. Please run configure again."
 
@@ -74,7 +74,7 @@ let merge t term =
     match peek t term with None -> Key.empty_context | Some c -> c
   in
   let f term = Key.merge_context ~default:cache term in
-  Cmdliner.Term.(pure f $ term)
+  Cmdliner.Term.(const f $ term)
 
 let peek_output t = Cli.peek_output t
 

--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -89,7 +89,7 @@ module Arg = struct
     Cmdliner.Arg.info ~docs ?docv ?doc ?env names
 
   let serialize_env fmt =
-    Fmt.pf fmt "(Cmdliner.Arg.env_var %a)" Serialize.string
+    Fmt.pf fmt "(Cmdliner.Cmd.Env.info %a)" Serialize.string
 
   let serialize_info fmt { docs; docv; doc; env; names } =
     Format.fprintf fmt

--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -31,7 +31,7 @@ module Arg = struct
   type 'a runtime_conv = string
 
   type 'a converter = {
-    conv : 'a Cmdliner.Arg.converter;
+    conv : 'a Cmdliner.Arg.conv;
     serialize : 'a serialize;
     runtime_conv : 'a runtime_conv;
   }
@@ -84,7 +84,7 @@ module Arg = struct
 
   let cmdliner_of_info { docs; docv; doc; env; names } =
     let env =
-      match env with Some s -> Some (Cmdliner.Arg.env_var s) | None -> None
+      match env with Some s -> Some (Cmdliner.Cmd.Env.info s) | None -> None
     in
     Cmdliner.Arg.info ~docs ?docv ?doc ?env names
 
@@ -481,12 +481,12 @@ let context ?(stage = `Both) ~with_required l =
     in
     let key = Arg.to_cmdliner k.arg ~with_required in
     match k.arg.Arg.kind with
-    | Arg.Opt _ -> Cmdliner.Term.(pure f $ key $ rest)
-    | Arg.Required _ -> Cmdliner.Term.(pure f $ key $ rest)
-    | Arg.Flag -> Cmdliner.Term.(pure f $ key $ rest)
-    | Arg.Opt_all _ -> Cmdliner.Term.(pure f $ key $ rest)
+    | Arg.Opt _ -> Cmdliner.Term.(const f $ key $ rest)
+    | Arg.Required _ -> Cmdliner.Term.(const f $ key $ rest)
+    | Arg.Flag -> Cmdliner.Term.(const f $ key $ rest)
+    | Arg.Opt_all _ -> Cmdliner.Term.(const f $ key $ rest)
   in
-  Names.fold gather names (Cmdliner.Term.pure empty_context)
+  Names.fold gather names (Cmdliner.Term.const empty_context)
 
 (* {2 Code emission} *)
 

--- a/lib/functoria/key.mli
+++ b/lib/functoria/key.mli
@@ -44,7 +44,7 @@ module Arg : sig
   (** The type for argument converters. *)
 
   val conv :
-    conv:'a Cmdliner.Arg.converter ->
+    conv:'a Cmdliner.Arg.conv ->
     serialize:'a serialize ->
     runtime_conv:'a runtime_conv ->
     'a converter

--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -145,7 +145,7 @@ module Make (P : S) = struct
       | None -> config
       | Some o -> { config with info = Info.with_output config.info o }
     in
-    Cmdliner.Term.(pure f $ context)
+    Cmdliner.Term.(const f $ context)
 
   (* FIXME: describe init *)
   let describe (t : _ Cli.describe_args) =
@@ -429,8 +429,8 @@ module Make (P : S) = struct
         Key.context ~stage:`Configure ~with_required:false if_keys
       in
       let context =
-        match Cmdliner.Term.eval_peek_opts ~argv non_required_term with
-        | _, `Ok context -> context
+        match Cmdliner.Cmd.eval_peek_opts ~argv non_required_term with
+        | _, Ok (`Ok context) -> context
         | _ -> Key.empty_context
       in
       match Context_cache.peek cache non_required_term with

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -131,7 +131,7 @@ module Make (P : S) = struct
          provided by the specialized DSL. *)
       let base_keys = Engine.all_keys @@ Impl.abstract @@ P.create [] in
       Cmdliner.Term.(
-        pure (fun _ -> Action.ok ())
+        const (fun _ -> Action.ok ())
         $ Key.context base_keys ~with_required:false ~stage:`Configure)
     in
     let result =

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -74,7 +74,7 @@ let ukvm_warning =
    will be removed in a future MirageOS release. Please reconfigure using `-t \
    hvt' at your earliest convenience."
 
-let target_conv : mode Cmdliner.Arg.converter =
+let target_conv : mode Cmdliner.Arg.conv =
   let parser, printer =
     Cmdliner.Arg.enum
       [

--- a/lib_runtime/functoria/functoria_runtime.mli
+++ b/lib_runtime/functoria/functoria_runtime.mli
@@ -29,18 +29,17 @@ module Arg : sig
   (** The type for runtime command-line arguments. Similar to
       [Functoria.Key.Arg.t] but only available at runtime. *)
 
-  val opt : 'a Cmdliner.Arg.converter -> 'a -> Cmdliner.Arg.info -> 'a t
+  val opt : 'a Cmdliner.Arg.conv -> 'a -> Cmdliner.Arg.info -> 'a t
   (** [opt] is the runtime companion of [Functoria.Ky.Arg.opt]. *)
 
   val opt_all :
-    'a Cmdliner.Arg.converter -> 'a list -> Cmdliner.Arg.info -> 'a list t
+    'a Cmdliner.Arg.conv -> 'a list -> Cmdliner.Arg.info -> 'a list t
   (** [opt_all] is the runtime companion of [Functoria.Key.Arg.opt_all]. *)
 
-  val required : 'a Cmdliner.Arg.converter -> Cmdliner.Arg.info -> 'a t
+  val required : 'a Cmdliner.Arg.conv -> Cmdliner.Arg.info -> 'a t
   (** [required] is the runtime companion of [Functoria.Key.Arg.required]. *)
 
-  val key :
-    ?default:'a -> 'a Cmdliner.Arg.converter -> Cmdliner.Arg.info -> 'a t
+  val key : ?default:'a -> 'a Cmdliner.Arg.conv -> Cmdliner.Arg.info -> 'a t
   (** [key] is either {!opt} or {!required}, depending if [~default] is
       provided. *)
 

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -40,7 +40,7 @@ let set_level ~default l =
 module Arg = struct
   include Functoria_runtime.Arg
 
-  let make of_string to_string : _ Cmdliner.Arg.converter =
+  let make of_string to_string : _ Cmdliner.Arg.conv =
     let parser s =
       match of_string s with
       | Error (`Msg m) -> `Error ("Can't parse ip address: " ^ s ^ ": " ^ m)

--- a/lib_runtime/mirage/mirage_runtime.mli
+++ b/lib_runtime/mirage/mirage_runtime.mli
@@ -35,7 +35,7 @@ module Arg : sig
   val make :
     (string -> ('a, [ `Msg of string ]) result) ->
     ('a -> string) ->
-    'a Cmdliner.Arg.converter
+    'a Cmdliner.Arg.conv
   (** [make of_string pp] is the command-line argument converter using on
       [of_string] and [pp]. *)
 
@@ -48,32 +48,32 @@ module Arg : sig
     val to_string : t -> string
   end
 
-  val of_module : (module S with type t = 'a) -> 'a Cmdliner.Arg.converter
+  val of_module : (module S with type t = 'a) -> 'a Cmdliner.Arg.conv
   (** [of module (module M)] creates a command-line argyument converter from a
       module satisfying the signature {!S}. *)
 
   (** {2 Mirage command-line argument converters} *)
 
-  val ip_address : Ipaddr.t Cmdliner.Arg.converter
+  val ip_address : Ipaddr.t Cmdliner.Arg.conv
   (** [ip] converts IP address. *)
 
-  val ipv4_address : Ipaddr.V4.t Cmdliner.Arg.converter
+  val ipv4_address : Ipaddr.V4.t Cmdliner.Arg.conv
   (** [ipv4_address] converts an IPv4 address. *)
 
-  val ipv4 : Ipaddr.V4.Prefix.t Cmdliner.Arg.converter
+  val ipv4 : Ipaddr.V4.Prefix.t Cmdliner.Arg.conv
   (** [ipv4] converts ipv4/netmask to Ipaddr.V4.t * Ipaddr.V4.Prefix.t . *)
 
-  val ipv6_address : Ipaddr.V6.t Cmdliner.Arg.converter
+  val ipv6_address : Ipaddr.V6.t Cmdliner.Arg.conv
   (** [ipv6_address]converts IPv6 address. *)
 
-  val ipv6 : Ipaddr.V6.Prefix.t Cmdliner.Arg.converter
+  val ipv6 : Ipaddr.V6.Prefix.t Cmdliner.Arg.conv
   (**[ipv6] converts IPv6 prefixes. *)
 
-  val log_threshold : log_threshold Cmdliner.Arg.converter
+  val log_threshold : log_threshold Cmdliner.Arg.conv
   (** [log_threshold] converts log reporter threshold. *)
 
   val allocation_policy :
-    [ `Next_fit | `First_fit | `Best_fit ] Cmdliner.Arg.converter
+    [ `Next_fit | `First_fit | `Best_fit ] Cmdliner.Arg.conv
   (** [allocation_policy] converts allocation policy. *)
 end
 

--- a/test/functoria/e2e/configure.t
+++ b/test/functoria/e2e/configure.t
@@ -82,4 +82,4 @@ Check that `test help configure` works when no config.ml file is present.
 
   $ ./test.exe configure --help=plain > h0
   $ ./help.exe show h0 SYNOPSIS | xargs
-  test configure [OPTION]...
+  test configure [OPTION]…

--- a/test/functoria/e2e/dune
+++ b/test/functoria/e2e/dune
@@ -14,7 +14,8 @@
   help.exe
   (source_tree app)
   (source_tree lib)
-  (package functoria))
+  (package functoria)
+  (package functoria-runtime))
  (enabled_if
   (<> %{architecture} "i386"))
  (package functoria))

--- a/test/functoria/e2e/help.t
+++ b/test/functoria/e2e/help.t
@@ -10,7 +10,7 @@ Test that the help command works without config file:
          test-help - Display help about test commands.
   
   SYNOPSIS
-         test help [OPTION]... [TOPIC]
+         test help [--man-format=FMT] [OPTION]… [TOPIC]
   
   DESCRIPTION
          Prints help.
@@ -68,23 +68,19 @@ Test that the help command works without config file:
              The topic to get help on.
   
   OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
          --man-format=FMT (absent=pager)
-             Show output in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
+             Show output in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -94,14 +90,31 @@ Test that the help command works without config file:
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         help exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of help:
   
          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
+  
+  SEE ALSO
+         test(1)
   
 
 
@@ -112,7 +125,7 @@ As well as the default command:
          test - The test application builder
   
   SYNOPSIS
-         test COMMAND ...
+         test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -122,37 +135,37 @@ As well as the default command:
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build
+         build [OPTION]… 
              Build a test application.
   
-         clean
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure
+         configure [OPTION]… 
              Configure a test application.
   
-         describe
+         describe [OPTION]… 
              Describe a test application.
   
-         help
+         help [--man-format=FMT] [OPTION]… [TOPIC]
              Display help about test commands.
   
-         query
+         query [OPTION]… [INFO]
              Query information about the test application.
-  
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -162,6 +175,23 @@ As well as the default command:
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         test exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   

--- a/test/functoria/e2e/help.t
+++ b/test/functoria/e2e/help.t
@@ -135,16 +135,16 @@ As well as the default command:
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]…
+         build [OPTION]… 
              Build a test application.
   
-         clean [OPTION]…
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure [OPTION]…
+         configure [OPTION]… 
              Configure a test application.
   
-         describe [OPTION]…
+         describe [OPTION]… 
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -162,6 +162,11 @@ As well as the default command:
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
   
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
   
@@ -172,6 +177,9 @@ As well as the default command:
          --verbosity=LEVEL (absent=warning)
              Be more or less verbose. LEVEL must be one of quiet, error,
              warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
   
          --version
              Show version information.

--- a/test/functoria/e2e/help.t
+++ b/test/functoria/e2e/help.t
@@ -135,16 +135,16 @@ As well as the default command:
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]… 
+         build [OPTION]…
              Build a test application.
   
-         clean [OPTION]… 
+         clean [OPTION]…
              Clean the files produced by test for a given application.
   
-         configure [OPTION]… 
+         configure [OPTION]…
              Configure a test application.
   
-         describe [OPTION]… 
+         describe [OPTION]…
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -162,11 +162,6 @@ As well as the default command:
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
   
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of auto,
-             pager, groff or plain. With auto, the format is pager or plain
-             whenever the TERM env var is dumb or undefined.
-  
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
   
@@ -177,9 +172,6 @@ As well as the default command:
          --verbosity=LEVEL (absent=warning)
              Be more or less verbose. LEVEL must be one of quiet, error,
              warning, info or debug. Takes over -v.
-  
-         --version
-             Show version information.
   
          --version
              Show version information.

--- a/test/functoria/errors/run.t
+++ b/test/functoria/errors/run.t
@@ -26,10 +26,10 @@ Clean does not fail
 Help does not fail
   $ ./test.exe help --man-format=plain
   NAME
-         test - The test application builder
+         test-test - The test application builder
   
   SYNOPSIS
-         test COMMAND ...
+         test test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -39,37 +39,32 @@ Help does not fail
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build
+         build [OPTION]… 
              Build a test application.
   
-         clean
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure
+         configure [OPTION]… 
              Configure a test application.
   
-         describe
+         describe [OPTION]… 
              Describe a test application.
   
-         help
+         help [--man-format=FMT] [OPTION]… [TOPIC]
              Display help about test commands.
   
-         query
+         query [OPTION]… [INFO]
              Query information about the test application.
-  
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -79,6 +74,23 @@ Help does not fail
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         test exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   

--- a/test/functoria/errors/run.t
+++ b/test/functoria/errors/run.t
@@ -26,10 +26,10 @@ Clean does not fail
 Help does not fail
   $ ./test.exe help --man-format=plain
   NAME
-         test-test - The test application builder
+         test - The test application builder
   
   SYNOPSIS
-         test test [COMMAND] …
+         test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -39,16 +39,16 @@ Help does not fail
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]… 
+         build [OPTION]…
              Build a test application.
   
-         clean [OPTION]… 
+         clean [OPTION]…
              Clean the files produced by test for a given application.
   
-         configure [OPTION]… 
+         configure [OPTION]…
              Configure a test application.
   
-         describe [OPTION]… 
+         describe [OPTION]…
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -90,7 +90,4 @@ Help does not fail
          124 on command line parsing errors.
   
          125 on unexpected internal errors (bugs).
-  
-  SEE ALSO
-         test(1)
   

--- a/test/functoria/errors/run.t
+++ b/test/functoria/errors/run.t
@@ -26,10 +26,10 @@ Clean does not fail
 Help does not fail
   $ ./test.exe help --man-format=plain
   NAME
-         test - The test application builder
+         test-test - The test application builder
   
   SYNOPSIS
-         test [COMMAND] …
+         test test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -39,16 +39,16 @@ Help does not fail
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]…
+         build [OPTION]… 
              Build a test application.
   
-         clean [OPTION]…
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure [OPTION]…
+         configure [OPTION]… 
              Configure a test application.
   
-         describe [OPTION]…
+         describe [OPTION]… 
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -90,4 +90,7 @@ Help does not fail
          124 on command line parsing errors.
   
          125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   

--- a/test/functoria/help/build.t
+++ b/test/functoria/help/build.t
@@ -4,7 +4,7 @@ Help build --man-format=plain
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]... 
+         test build [OPTION]… 
   
   DESCRIPTION
          Build a test application.
@@ -32,19 +32,14 @@ Help build --man-format=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -54,8 +49,25 @@ Help build --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         build exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   
 
 Help build --help=plain
@@ -64,7 +76,7 @@ Help build --help=plain
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]... 
+         test build [OPTION]… 
   
   DESCRIPTION
          Build a test application.
@@ -92,19 +104,14 @@ Help build --help=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -114,8 +121,25 @@ Help build --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         build exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   
 
 No difference

--- a/test/functoria/help/build.t
+++ b/test/functoria/help/build.t
@@ -4,7 +4,7 @@ Help build --man-format=plain
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]… 
+         test build [OPTION]…
   
   DESCRIPTION
          Build a test application.
@@ -76,7 +76,7 @@ Help build --help=plain
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]… 
+         test build [OPTION]…
   
   DESCRIPTION
          Build a test application.

--- a/test/functoria/help/build.t
+++ b/test/functoria/help/build.t
@@ -4,7 +4,7 @@ Help build --man-format=plain
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]…
+         test build [OPTION]… 
   
   DESCRIPTION
          Build a test application.
@@ -76,7 +76,7 @@ Help build --help=plain
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]…
+         test build [OPTION]… 
   
   DESCRIPTION
          Build a test application.

--- a/test/functoria/help/clean.t
+++ b/test/functoria/help/clean.t
@@ -4,7 +4,7 @@ Help clean --man-format=plain
          test-clean - Clean the files produced by test for a given application.
   
   SYNOPSIS
-         test clean [OPTION]... 
+         test clean [OPTION]… 
   
   DESCRIPTION
          Clean the files produced by test for a given application.
@@ -32,19 +32,14 @@ Help clean --man-format=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -54,8 +49,25 @@ Help clean --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         clean exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   
 
 Help clean --help=plain
@@ -64,7 +76,7 @@ Help clean --help=plain
          test-clean - Clean the files produced by test for a given application.
   
   SYNOPSIS
-         test clean [OPTION]... 
+         test clean [OPTION]… 
   
   DESCRIPTION
          Clean the files produced by test for a given application.
@@ -92,19 +104,14 @@ Help clean --help=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -114,8 +121,25 @@ Help clean --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         clean exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   
 
 No difference

--- a/test/functoria/help/clean.t
+++ b/test/functoria/help/clean.t
@@ -4,7 +4,7 @@ Help clean --man-format=plain
          test-clean - Clean the files produced by test for a given application.
   
   SYNOPSIS
-         test clean [OPTION]…
+         test clean [OPTION]… 
   
   DESCRIPTION
          Clean the files produced by test for a given application.
@@ -76,7 +76,7 @@ Help clean --help=plain
          test-clean - Clean the files produced by test for a given application.
   
   SYNOPSIS
-         test clean [OPTION]…
+         test clean [OPTION]… 
   
   DESCRIPTION
          Clean the files produced by test for a given application.

--- a/test/functoria/help/clean.t
+++ b/test/functoria/help/clean.t
@@ -4,7 +4,7 @@ Help clean --man-format=plain
          test-clean - Clean the files produced by test for a given application.
   
   SYNOPSIS
-         test clean [OPTION]… 
+         test clean [OPTION]…
   
   DESCRIPTION
          Clean the files produced by test for a given application.
@@ -76,7 +76,7 @@ Help clean --help=plain
          test-clean - Clean the files produced by test for a given application.
   
   SYNOPSIS
-         test clean [OPTION]… 
+         test clean [OPTION]…
   
   DESCRIPTION
          Clean the files produced by test for a given application.

--- a/test/functoria/help/configure-o.t
+++ b/test/functoria/help/configure-o.t
@@ -4,7 +4,7 @@ Help configure -o --man-format=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]... 
+         test configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh test application.
@@ -49,19 +49,14 @@ Help configure -o --man-format=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -71,14 +66,31 @@ Help configure -o --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         configure exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of configure:
   
          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
+  
+  SEE ALSO
+         test(1)
   
 
 Help configure -o --help=plain
@@ -87,7 +99,7 @@ Help configure -o --help=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]... 
+         test configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh test application.
@@ -132,19 +144,14 @@ Help configure -o --help=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -154,14 +161,31 @@ Help configure -o --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         configure exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of configure:
   
          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
+  
+  SEE ALSO
+         test(1)
   
 
 No difference

--- a/test/functoria/help/configure-o.t
+++ b/test/functoria/help/configure-o.t
@@ -4,7 +4,7 @@ Help configure -o --man-format=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]… 
+         test configure [OPTION]…
   
   DESCRIPTION
          The configure command initializes a fresh test application.
@@ -99,7 +99,7 @@ Help configure -o --help=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]… 
+         test configure [OPTION]…
   
   DESCRIPTION
          The configure command initializes a fresh test application.

--- a/test/functoria/help/configure-o.t
+++ b/test/functoria/help/configure-o.t
@@ -4,7 +4,7 @@ Help configure -o --man-format=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]…
+         test configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh test application.
@@ -99,7 +99,7 @@ Help configure -o --help=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]…
+         test configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh test application.

--- a/test/functoria/help/configure.t
+++ b/test/functoria/help/configure.t
@@ -4,7 +4,7 @@ Help configure --man-format=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]... 
+         test configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh test application.
@@ -49,19 +49,14 @@ Help configure --man-format=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -71,14 +66,31 @@ Help configure --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         configure exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of configure:
   
          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
+  
+  SEE ALSO
+         test(1)
   
 
 Configure help --help=plain
@@ -87,7 +99,7 @@ Configure help --help=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]... 
+         test configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh test application.
@@ -132,19 +144,14 @@ Configure help --help=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -154,14 +161,31 @@ Configure help --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         configure exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of configure:
   
          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
+  
+  SEE ALSO
+         test(1)
   
 
 No difference

--- a/test/functoria/help/configure.t
+++ b/test/functoria/help/configure.t
@@ -4,7 +4,7 @@ Help configure --man-format=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]… 
+         test configure [OPTION]…
   
   DESCRIPTION
          The configure command initializes a fresh test application.
@@ -99,7 +99,7 @@ Configure help --help=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]… 
+         test configure [OPTION]…
   
   DESCRIPTION
          The configure command initializes a fresh test application.

--- a/test/functoria/help/configure.t
+++ b/test/functoria/help/configure.t
@@ -4,7 +4,7 @@ Help configure --man-format=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]…
+         test configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh test application.
@@ -99,7 +99,7 @@ Configure help --help=plain
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]…
+         test configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh test application.

--- a/test/functoria/help/describe.t
+++ b/test/functoria/help/describe.t
@@ -4,7 +4,7 @@ Help describe --man-format=plain
          test-describe - Describe a test application.
   
   SYNOPSIS
-         test describe [OPTION]... 
+         test describe [OPTION]… 
   
   DESCRIPTION
          The describe command describes the configuration of a test
@@ -64,19 +64,14 @@ Help describe --man-format=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -86,8 +81,25 @@ Help describe --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         describe exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   
 
 Help describe --help=plain
@@ -96,7 +108,7 @@ Help describe --help=plain
          test-describe - Describe a test application.
   
   SYNOPSIS
-         test describe [OPTION]... 
+         test describe [OPTION]… 
   
   DESCRIPTION
          The describe command describes the configuration of a test
@@ -156,19 +168,14 @@ Help describe --help=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -178,8 +185,25 @@ Help describe --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         describe exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   
 
 No difference

--- a/test/functoria/help/describe.t
+++ b/test/functoria/help/describe.t
@@ -4,7 +4,7 @@ Help describe --man-format=plain
          test-describe - Describe a test application.
   
   SYNOPSIS
-         test describe [OPTION]…
+         test describe [OPTION]… 
   
   DESCRIPTION
          The describe command describes the configuration of a test
@@ -108,7 +108,7 @@ Help describe --help=plain
          test-describe - Describe a test application.
   
   SYNOPSIS
-         test describe [OPTION]…
+         test describe [OPTION]… 
   
   DESCRIPTION
          The describe command describes the configuration of a test

--- a/test/functoria/help/describe.t
+++ b/test/functoria/help/describe.t
@@ -4,7 +4,7 @@ Help describe --man-format=plain
          test-describe - Describe a test application.
   
   SYNOPSIS
-         test describe [OPTION]… 
+         test describe [OPTION]…
   
   DESCRIPTION
          The describe command describes the configuration of a test
@@ -108,7 +108,7 @@ Help describe --help=plain
          test-describe - Describe a test application.
   
   SYNOPSIS
-         test describe [OPTION]… 
+         test describe [OPTION]…
   
   DESCRIPTION
          The describe command describes the configuration of a test

--- a/test/functoria/help/query.t
+++ b/test/functoria/help/query.t
@@ -4,7 +4,7 @@ Help query --man-format=plain
          test-query - Query information about the test application.
   
   SYNOPSIS
-         test query [OPTION]... [INFO]
+         test query [OPTION]… [INFO]
   
   DESCRIPTION
          The query command queries information about the test application.
@@ -41,10 +41,10 @@ Help query --man-format=plain
              Name of the output file.
   
          INFO (absent=packages)
-             The information to query. INFO must be one of `name', `packages',
-             `monorepo.opam', `switch.opam', `files', `Makefile',
-             `dune.config', `dune.build', `dune-project', `dune-workspace' or
-             `dune.dist'
+             The information to query. INFO must be one of 'name', 'packages',
+             'monorepo.opam', 'switch.opam', 'files', 'Makefile',
+             'dune.config', 'dune.build', 'dune-project', 'dune-workspace' or
+             'dune.dist'
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
@@ -56,19 +56,14 @@ Help query --man-format=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -78,14 +73,31 @@ Help query --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         query exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of query:
   
          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
+  
+  SEE ALSO
+         test(1)
   
 
 Help query --help=plain
@@ -94,7 +106,7 @@ Help query --help=plain
          test-query - Query information about the test application.
   
   SYNOPSIS
-         test query [OPTION]... [INFO]
+         test query [OPTION]… [INFO]
   
   DESCRIPTION
          The query command queries information about the test application.
@@ -131,10 +143,10 @@ Help query --help=plain
              Name of the output file.
   
          INFO (absent=packages)
-             The information to query. INFO must be one of `name', `packages',
-             `monorepo.opam', `switch.opam', `files', `Makefile',
-             `dune.config', `dune.build', `dune-project', `dune-workspace' or
-             `dune.dist'
+             The information to query. INFO must be one of 'name', 'packages',
+             'monorepo.opam', 'switch.opam', 'files', 'Makefile',
+             'dune.config', 'dune.build', 'dune-project', 'dune-workspace' or
+             'dune.dist'
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
@@ -146,19 +158,14 @@ Help query --help=plain
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -168,14 +175,31 @@ Help query --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         query exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of query:
   
          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
+  
+  SEE ALSO
+         test(1)
   
 
 No difference

--- a/test/functoria/lib/run.t
+++ b/test/functoria/lib/run.t
@@ -3,62 +3,62 @@ Configure
   [1]
 
   $ cat configure.err
-  test: too many arguments, don't know what to do with `a', `b', `c'
-  Usage: test configure [OPTION]... 
-  Try `test configure --help' or `test --help' for more information.
+  test: too many arguments, don't know what to do with 'a', 'b', 'c'
+  Usage: test configure [OPTION]… 
+  Try 'test configure --help' or 'test --help' for more information.
 
 Build
   $ ./config.exe build a b c 2> build.err
   [1]
 
   $ cat build.err
-  test: too many arguments, don't know what to do with `a', `b', `c'
-  Usage: test build [OPTION]... 
-  Try `test build --help' or `test --help' for more information.
+  test: too many arguments, don't know what to do with 'a', 'b', 'c'
+  Usage: test build [OPTION]… 
+  Try 'test build --help' or 'test --help' for more information.
 
 Clean
   $ ./config.exe clean a b c 2> clean.err
   [1]
 
   $ cat clean.err
-  test: too many arguments, don't know what to do with `a', `b', `c'
-  Usage: test clean [OPTION]... 
-  Try `test clean --help' or `test --help' for more information.
+  test: too many arguments, don't know what to do with 'a', 'b', 'c'
+  Usage: test clean [OPTION]… 
+  Try 'test clean --help' or 'test --help' for more information.
 
 Query
   $ ./config.exe query a b c 2> query.err
   [1]
 
   $ cat query.err
-  test: too many arguments, don't know what to do with `b', `c'
-  Usage: test query [OPTION]... [INFO]
-  Try `test query --help' or `test --help' for more information.
+  test: too many arguments, don't know what to do with 'b', 'c'
+  Usage: test query [OPTION]… [INFO]
+  Try 'test query --help' or 'test --help' for more information.
 
 Describe
   $ ./config.exe describe a b c 2> describe.err
   [1]
 
   $ cat describe.err
-  test: too many arguments, don't know what to do with `a', `b', `c'
-  Usage: test describe [OPTION]... 
-  Try `test describe --help' or `test --help' for more information.
+  test: too many arguments, don't know what to do with 'a', 'b', 'c'
+  Usage: test describe [OPTION]… 
+  Try 'test describe --help' or 'test --help' for more information.
 
 Help
   $ ./config.exe help a b c 2> help.err
   [1]
 
   $ cat help.err
-  test: too many arguments, don't know what to do with `b', `c'
-  Usage: test help [OPTION]... [TOPIC]
-  Try `test help --help' or `test --help' for more information.
+  test: too many arguments, don't know what to do with 'b', 'c'
+  Usage: test help [--man-format=FMT] [OPTION]… [TOPIC]
+  Try 'test help --help' or 'test --help' for more information.
 
 Simple help
   $ ./config.exe help --man-format=plain 2> simple-help.err
   NAME
-         test - The test application builder
+         test-test - The test application builder
   
   SYNOPSIS
-         test COMMAND ...
+         test test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -68,37 +68,32 @@ Simple help
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build
+         build [OPTION]… 
              Build a test application.
   
-         clean
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure
+         configure [OPTION]… 
              Configure a test application.
   
-         describe
+         describe [OPTION]… 
              Describe a test application.
   
-         help
+         help [--man-format=FMT] [OPTION]… [TOPIC]
              Display help about test commands.
   
-         query
+         query [OPTION]… [INFO]
              Query information about the test application.
-  
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -108,8 +103,25 @@ Simple help
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         test exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   
 
   $ cat simple-help.err
@@ -120,7 +132,7 @@ Help configure
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]... 
+         test configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh test application.
@@ -162,19 +174,14 @@ Help configure
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -184,14 +191,31 @@ Help configure
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         configure exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of configure:
   
          MIRAGE_EXTRA_REPOS
              See option --extra-repos.
+  
+  SEE ALSO
+         test(1)
   
 
   $ cat configure.err
@@ -201,17 +225,17 @@ Configure help
   [1]
 
   $ cat configure-help.err
-  test: too many arguments, don't know what to do with `help'
-  Usage: test configure [OPTION]... 
-  Try `test configure --help' or `test --help' for more information.
+  test: too many arguments, don't know what to do with 'help'
+  Usage: test configure [OPTION]… 
+  Try 'test configure --help' or 'test --help' for more information.
 
 Help no config
   $ ./config.exe help --file=empty/config.ml --man-format=plain 2> help-no-config.err
   NAME
-         test - The test application builder
+         test-test - The test application builder
   
   SYNOPSIS
-         test COMMAND ...
+         test test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -221,37 +245,32 @@ Help no config
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build
+         build [OPTION]… 
              Build a test application.
   
-         clean
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure
+         configure [OPTION]… 
              Configure a test application.
   
-         describe
+         describe [OPTION]… 
              Describe a test application.
   
-         help
+         help [--man-format=FMT] [OPTION]… [TOPIC]
              Display help about test commands.
   
-         query
+         query [OPTION]… [INFO]
              Query information about the test application.
-  
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -261,8 +280,25 @@ Help no config
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         test exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   
   $ cat help-no-config.err
 
@@ -271,9 +307,9 @@ Help no config with bad arguments
   [1]
 
   $ cat help-no-config-args.err
-  test: too many arguments, don't know what to do with `b', `c'
-  Usage: test help [OPTION]... [TOPIC]
-  Try `test help --help' or `test --help' for more information.
+  test: too many arguments, don't know what to do with 'b', 'c'
+  Usage: test help [--man-format=FMT] [OPTION]… [TOPIC]
+  Try 'test help --help' or 'test --help' for more information.
 
 Build help no config with bad arguments
   $ ./config.exe build --help=plain --file=empty/config.ml a b c 2> build-help-no-config-args.err
@@ -281,7 +317,7 @@ Build help no config with bad arguments
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]... 
+         test build [OPTION]… 
   
   DESCRIPTION
          Build a test application.
@@ -306,19 +342,14 @@ Build help no config with bad arguments
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -328,8 +359,25 @@ Build help no config with bad arguments
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         build exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   
   $ cat build-help-no-config-args.err
 
@@ -342,9 +390,9 @@ Ambiguous
   [1]
 
   $ cat ambiguous.err
-  test: command `c' ambiguous and could be either `clean' or `configure'
-  Usage: test COMMAND ...
-  Try `test --help' for more information.
+  test: command 'c' ambiguous and could be either 'clean' or 'configure'
+  Usage: test [COMMAND] …
+  Try 'test --help' for more information.
 
 Default
   $ ./config.exe 2> default.err
@@ -352,7 +400,7 @@ Default
          test - The test application builder
   
   SYNOPSIS
-         test COMMAND ...
+         test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -362,37 +410,37 @@ Default
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build
+         build [OPTION]… 
              Build a test application.
   
-         clean
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure
+         configure [OPTION]… 
              Configure a test application.
   
-         describe
+         describe [OPTION]… 
              Describe a test application.
   
-         help
+         help [--man-format=FMT] [OPTION]… [TOPIC]
              Display help about test commands.
   
-         query
+         query [OPTION]… [INFO]
              Query information about the test application.
-  
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -402,8 +450,25 @@ Default
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         test exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
 
   $ cat default.err

--- a/test/functoria/lib/run.t
+++ b/test/functoria/lib/run.t
@@ -4,7 +4,7 @@ Configure
 
   $ cat configure.err
   test: too many arguments, don't know what to do with 'a', 'b', 'c'
-  Usage: test configure [OPTION]… 
+  Usage: test configure [OPTION]…
   Try 'test configure --help' or 'test --help' for more information.
 
 Build
@@ -13,7 +13,7 @@ Build
 
   $ cat build.err
   test: too many arguments, don't know what to do with 'a', 'b', 'c'
-  Usage: test build [OPTION]… 
+  Usage: test build [OPTION]…
   Try 'test build --help' or 'test --help' for more information.
 
 Clean
@@ -22,7 +22,7 @@ Clean
 
   $ cat clean.err
   test: too many arguments, don't know what to do with 'a', 'b', 'c'
-  Usage: test clean [OPTION]… 
+  Usage: test clean [OPTION]…
   Try 'test clean --help' or 'test --help' for more information.
 
 Query
@@ -40,7 +40,7 @@ Describe
 
   $ cat describe.err
   test: too many arguments, don't know what to do with 'a', 'b', 'c'
-  Usage: test describe [OPTION]… 
+  Usage: test describe [OPTION]…
   Try 'test describe --help' or 'test --help' for more information.
 
 Help
@@ -55,10 +55,10 @@ Help
 Simple help
   $ ./config.exe help --man-format=plain 2> simple-help.err
   NAME
-         test-test - The test application builder
+         test - The test application builder
   
   SYNOPSIS
-         test test [COMMAND] …
+         test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -68,16 +68,16 @@ Simple help
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]… 
+         build [OPTION]…
              Build a test application.
   
-         clean [OPTION]… 
+         clean [OPTION]…
              Clean the files produced by test for a given application.
   
-         configure [OPTION]… 
+         configure [OPTION]…
              Configure a test application.
   
-         describe [OPTION]… 
+         describe [OPTION]…
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -120,9 +120,6 @@ Simple help
   
          125 on unexpected internal errors (bugs).
   
-  SEE ALSO
-         test(1)
-  
 
   $ cat simple-help.err
 
@@ -132,7 +129,7 @@ Help configure
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]… 
+         test configure [OPTION]…
   
   DESCRIPTION
          The configure command initializes a fresh test application.
@@ -226,16 +223,16 @@ Configure help
 
   $ cat configure-help.err
   test: too many arguments, don't know what to do with 'help'
-  Usage: test configure [OPTION]… 
+  Usage: test configure [OPTION]…
   Try 'test configure --help' or 'test --help' for more information.
 
 Help no config
   $ ./config.exe help --file=empty/config.ml --man-format=plain 2> help-no-config.err
   NAME
-         test-test - The test application builder
+         test - The test application builder
   
   SYNOPSIS
-         test test [COMMAND] …
+         test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -245,16 +242,16 @@ Help no config
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]… 
+         build [OPTION]…
              Build a test application.
   
-         clean [OPTION]… 
+         clean [OPTION]…
              Clean the files produced by test for a given application.
   
-         configure [OPTION]… 
+         configure [OPTION]…
              Configure a test application.
   
-         describe [OPTION]… 
+         describe [OPTION]…
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -297,9 +294,6 @@ Help no config
   
          125 on unexpected internal errors (bugs).
   
-  SEE ALSO
-         test(1)
-  
   $ cat help-no-config.err
 
 Help no config with bad arguments
@@ -317,7 +311,7 @@ Build help no config with bad arguments
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]… 
+         test build [OPTION]…
   
   DESCRIPTION
          Build a test application.
@@ -410,16 +404,16 @@ Default
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]… 
+         build [OPTION]…
              Build a test application.
   
-         clean [OPTION]… 
+         clean [OPTION]…
              Clean the files produced by test for a given application.
   
-         configure [OPTION]… 
+         configure [OPTION]…
              Configure a test application.
   
-         describe [OPTION]… 
+         describe [OPTION]…
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -437,11 +431,6 @@ Default
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
   
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of auto,
-             pager, groff or plain. With auto, the format is pager or plain
-             whenever the TERM env var is dumb or undefined.
-  
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
   
@@ -452,9 +441,6 @@ Default
          --verbosity=LEVEL (absent=warning)
              Be more or less verbose. LEVEL must be one of quiet, error,
              warning, info or debug. Takes over -v.
-  
-         --version
-             Show version information.
   
          --version
              Show version information.

--- a/test/functoria/lib/run.t
+++ b/test/functoria/lib/run.t
@@ -4,7 +4,7 @@ Configure
 
   $ cat configure.err
   test: too many arguments, don't know what to do with 'a', 'b', 'c'
-  Usage: test configure [OPTION]…
+  Usage: test configure [OPTION]… 
   Try 'test configure --help' or 'test --help' for more information.
 
 Build
@@ -13,7 +13,7 @@ Build
 
   $ cat build.err
   test: too many arguments, don't know what to do with 'a', 'b', 'c'
-  Usage: test build [OPTION]…
+  Usage: test build [OPTION]… 
   Try 'test build --help' or 'test --help' for more information.
 
 Clean
@@ -22,7 +22,7 @@ Clean
 
   $ cat clean.err
   test: too many arguments, don't know what to do with 'a', 'b', 'c'
-  Usage: test clean [OPTION]…
+  Usage: test clean [OPTION]… 
   Try 'test clean --help' or 'test --help' for more information.
 
 Query
@@ -40,7 +40,7 @@ Describe
 
   $ cat describe.err
   test: too many arguments, don't know what to do with 'a', 'b', 'c'
-  Usage: test describe [OPTION]…
+  Usage: test describe [OPTION]… 
   Try 'test describe --help' or 'test --help' for more information.
 
 Help
@@ -55,10 +55,10 @@ Help
 Simple help
   $ ./config.exe help --man-format=plain 2> simple-help.err
   NAME
-         test - The test application builder
+         test-test - The test application builder
   
   SYNOPSIS
-         test [COMMAND] …
+         test test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -68,16 +68,16 @@ Simple help
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]…
+         build [OPTION]… 
              Build a test application.
   
-         clean [OPTION]…
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure [OPTION]…
+         configure [OPTION]… 
              Configure a test application.
   
-         describe [OPTION]…
+         describe [OPTION]… 
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -120,6 +120,9 @@ Simple help
   
          125 on unexpected internal errors (bugs).
   
+  SEE ALSO
+         test(1)
+  
 
   $ cat simple-help.err
 
@@ -129,7 +132,7 @@ Help configure
          test-configure - Configure a test application.
   
   SYNOPSIS
-         test configure [OPTION]…
+         test configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh test application.
@@ -223,16 +226,16 @@ Configure help
 
   $ cat configure-help.err
   test: too many arguments, don't know what to do with 'help'
-  Usage: test configure [OPTION]…
+  Usage: test configure [OPTION]… 
   Try 'test configure --help' or 'test --help' for more information.
 
 Help no config
   $ ./config.exe help --file=empty/config.ml --man-format=plain 2> help-no-config.err
   NAME
-         test - The test application builder
+         test-test - The test application builder
   
   SYNOPSIS
-         test [COMMAND] …
+         test test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -242,16 +245,16 @@ Help no config
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]…
+         build [OPTION]… 
              Build a test application.
   
-         clean [OPTION]…
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure [OPTION]…
+         configure [OPTION]… 
              Configure a test application.
   
-         describe [OPTION]…
+         describe [OPTION]… 
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -294,6 +297,9 @@ Help no config
   
          125 on unexpected internal errors (bugs).
   
+  SEE ALSO
+         test(1)
+  
   $ cat help-no-config.err
 
 Help no config with bad arguments
@@ -311,7 +317,7 @@ Build help no config with bad arguments
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]…
+         test build [OPTION]… 
   
   DESCRIPTION
          Build a test application.
@@ -404,16 +410,16 @@ Default
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]…
+         build [OPTION]… 
              Build a test application.
   
-         clean [OPTION]…
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure [OPTION]…
+         configure [OPTION]… 
              Configure a test application.
   
-         describe [OPTION]…
+         describe [OPTION]… 
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -431,6 +437,11 @@ Default
              pager, groff or plain. With auto, the format is pager or plain
              whenever the TERM env var is dumb or undefined.
   
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
   
@@ -441,6 +452,9 @@ Default
          --verbosity=LEVEL (absent=warning)
              Be more or less verbose. LEVEL must be one of quiet, error,
              warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
   
          --version
              Show version information.

--- a/test/functoria/test_cli.ml
+++ b/test/functoria/test_cli.ml
@@ -20,7 +20,7 @@ let test_configure () =
   let extra_term =
     Cmdliner.(
       Term.(
-        pure (fun xyz cde -> (xyz, cde))
+        const (fun xyz cde -> (xyz, cde))
         $ Arg.(value (flag (info [ "x"; "xyz" ])))
         $ Arg.(value (flag (info [ "c"; "cde" ])))))
   in
@@ -57,7 +57,7 @@ let test_describe () =
   let extra_term =
     Cmdliner.(
       Term.(
-        pure (fun xyz cde -> (xyz, cde))
+        const (fun xyz cde -> (xyz, cde))
         $ Arg.(value (flag (info [ "x"; "xyz" ])))
         $ Arg.(value (flag (info [ "c"; "cde" ])))))
   in
@@ -97,7 +97,7 @@ let test_build () =
   let extra_term =
     Cmdliner.(
       Term.(
-        pure (fun xyz cde -> (xyz, cde))
+        const (fun xyz cde -> (xyz, cde))
         $ Arg.(value (flag (info [ "x"; "xyz" ])))
         $ Arg.(value (flag (info [ "c"; "cde" ])))))
   in
@@ -123,7 +123,7 @@ let test_clean () =
   let extra_term =
     Cmdliner.(
       Term.(
-        pure (fun xyz cde -> (xyz, cde))
+        const (fun xyz cde -> (xyz, cde))
         $ Arg.(value (flag (info [ "x"; "xyz" ])))
         $ Arg.(value (flag (info [ "c"; "cde" ])))))
   in
@@ -149,7 +149,7 @@ let test_help () =
   let extra_term =
     Cmdliner.(
       Term.(
-        pure (fun xyz cde -> (xyz, cde))
+        const (fun xyz cde -> (xyz, cde))
         $ Arg.(value (flag (info [ "x"; "xyz" ])))
         $ Arg.(value (flag (info [ "c"; "cde" ])))))
   in
@@ -166,7 +166,7 @@ let test_default () =
   let extra_term =
     Cmdliner.(
       Term.(
-        pure (fun xyz cde -> (xyz, cde))
+        const (fun xyz cde -> (xyz, cde))
         $ Arg.(value (flag (info [ "x"; "xyz" ])))
         $ Arg.(value (flag (info [ "c"; "cde" ])))))
   in

--- a/test/functoria/tool/run.t
+++ b/test/functoria/tool/run.t
@@ -202,10 +202,10 @@ Configure help
 Help no config
   $ ./test.exe help --file=empty/config.ml --man-format=plain 2> help-no-config.err
   NAME
-         test - The test application builder
+         test-test - The test application builder
   
   SYNOPSIS
-         test COMMAND ...
+         test test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -215,37 +215,32 @@ Help no config
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build
+         build [OPTION]… 
              Build a test application.
   
-         clean
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure
+         configure [OPTION]… 
              Configure a test application.
   
-         describe
+         describe [OPTION]… 
              Describe a test application.
   
-         help
+         help [--man-format=FMT] [OPTION]… [TOPIC]
              Display help about test commands.
   
-         query
+         query [OPTION]… [INFO]
              Query information about the test application.
-  
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -255,8 +250,25 @@ Help no config
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         test exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   
   $ cat help-no-config.err
   * Is_file? empty/config.ml -> false
@@ -265,9 +277,9 @@ Help no config with bad arguments
   $ ./test.exe help --file=empty/config.ml a b c 2> help-no-config-args.err
 
   $ cat help-no-config-args.err
-  test: too many arguments, don't know what to do with `b', `c'
-  Usage: test help [OPTION]... [TOPIC]
-  Try `test help --help' or `test --help' for more information.
+  test: too many arguments, don't know what to do with 'b', 'c'
+  Usage: test help [--man-format=FMT] [OPTION]… [TOPIC]
+  Try 'test help --help' or 'test --help' for more information.
   * Is_file? empty/config.ml -> false
   configuration file empty/config.ml missing
   (exit 1)
@@ -278,7 +290,7 @@ Build help no config with bad arguments
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]... 
+         test build [OPTION]… 
   
   DESCRIPTION
          Build a test application.
@@ -303,19 +315,14 @@ Build help no config with bad arguments
          --warn-error=BOOL (absent=false)
              Enable -warn-error when compiling OCaml sources. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -325,8 +332,25 @@ Build help no config with bad arguments
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         build exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  SEE ALSO
+         test(1)
   
   $ cat build-help-no-config-args.err
   * Is_file? empty/config.ml -> false

--- a/test/functoria/tool/run.t
+++ b/test/functoria/tool/run.t
@@ -202,10 +202,10 @@ Configure help
 Help no config
   $ ./test.exe help --file=empty/config.ml --man-format=plain 2> help-no-config.err
   NAME
-         test-test - The test application builder
+         test - The test application builder
   
   SYNOPSIS
-         test test [COMMAND] …
+         test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -215,16 +215,16 @@ Help no config
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]… 
+         build [OPTION]…
              Build a test application.
   
-         clean [OPTION]… 
+         clean [OPTION]…
              Clean the files produced by test for a given application.
   
-         configure [OPTION]… 
+         configure [OPTION]…
              Configure a test application.
   
-         describe [OPTION]… 
+         describe [OPTION]…
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -267,9 +267,6 @@ Help no config
   
          125 on unexpected internal errors (bugs).
   
-  SEE ALSO
-         test(1)
-  
   $ cat help-no-config.err
   * Is_file? empty/config.ml -> false
 
@@ -290,7 +287,7 @@ Build help no config with bad arguments
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]… 
+         test build [OPTION]…
   
   DESCRIPTION
          Build a test application.

--- a/test/functoria/tool/run.t
+++ b/test/functoria/tool/run.t
@@ -202,10 +202,10 @@ Configure help
 Help no config
   $ ./test.exe help --file=empty/config.ml --man-format=plain 2> help-no-config.err
   NAME
-         test - The test application builder
+         test-test - The test application builder
   
   SYNOPSIS
-         test [COMMAND] …
+         test test [COMMAND] …
   
   DESCRIPTION
          The test application builder. It glues together a set of libraries and
@@ -215,16 +215,16 @@ Help no config
          Use test help <command> for more information on a specific command.
   
   COMMANDS
-         build [OPTION]…
+         build [OPTION]… 
              Build a test application.
   
-         clean [OPTION]…
+         clean [OPTION]… 
              Clean the files produced by test for a given application.
   
-         configure [OPTION]…
+         configure [OPTION]… 
              Configure a test application.
   
-         describe [OPTION]…
+         describe [OPTION]… 
              Describe a test application.
   
          help [--man-format=FMT] [OPTION]… [TOPIC]
@@ -267,6 +267,9 @@ Help no config
   
          125 on unexpected internal errors (bugs).
   
+  SEE ALSO
+         test(1)
+  
   $ cat help-no-config.err
   * Is_file? empty/config.ml -> false
 
@@ -287,7 +290,7 @@ Build help no config with bad arguments
          test-build - Build a test application.
   
   SYNOPSIS
-         test build [OPTION]…
+         test build [OPTION]… 
   
   DESCRIPTION
          Build a test application.

--- a/test/mirage/action/test.ml
+++ b/test/mirage/action/test.ml
@@ -1,13 +1,13 @@
 open Mirage
 
 let context_singleton key value =
-  let info = Cmdliner.Term.info "" in
+  let info = Cmdliner.Cmd.info "" in
   let term =
     Key.context ~with_required:false (Key.Set.singleton @@ Key.v key)
   in
   let argv = [| "mirage"; "--target"; value |] in
-  match Cmdliner.Term.eval ~argv (term, info) with
-  | `Ok x -> x
+  match Cmdliner.Cmd.eval_value ~argv (Cmdliner.Cmd.v info term) with
+  | Ok (`Ok x) -> x
   | _ -> assert false
 
 let print_banner s =

--- a/test/mirage/help/build.t
+++ b/test/mirage/help/build.t
@@ -6,7 +6,7 @@ Help build --man-format=plain
          mirage-build - Build a mirage application.
   
   SYNOPSIS
-         mirage build [OPTION]... 
+         mirage build [OPTION]… 
   
   DESCRIPTION
          Build a mirage application.
@@ -97,19 +97,14 @@ Help build --man-format=plain
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -119,8 +114,22 @@ Help build --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         build exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of build:
@@ -130,6 +139,9 @@ Help build --man-format=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 Help build --help=plain
@@ -138,7 +150,7 @@ Help build --help=plain
          mirage-build - Build a mirage application.
   
   SYNOPSIS
-         mirage build [OPTION]... 
+         mirage build [OPTION]… 
   
   DESCRIPTION
          Build a mirage application.
@@ -229,19 +241,14 @@ Help build --help=plain
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -251,8 +258,22 @@ Help build --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         build exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of build:
@@ -262,6 +283,9 @@ Help build --help=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 No difference

--- a/test/mirage/help/build.t
+++ b/test/mirage/help/build.t
@@ -6,7 +6,7 @@ Help build --man-format=plain
          mirage-build - Build a mirage application.
   
   SYNOPSIS
-         mirage build [OPTION]… 
+         mirage build [OPTION]…
   
   DESCRIPTION
          Build a mirage application.
@@ -150,7 +150,7 @@ Help build --help=plain
          mirage-build - Build a mirage application.
   
   SYNOPSIS
-         mirage build [OPTION]… 
+         mirage build [OPTION]…
   
   DESCRIPTION
          Build a mirage application.

--- a/test/mirage/help/build.t
+++ b/test/mirage/help/build.t
@@ -6,7 +6,7 @@ Help build --man-format=plain
          mirage-build - Build a mirage application.
   
   SYNOPSIS
-         mirage build [OPTION]…
+         mirage build [OPTION]… 
   
   DESCRIPTION
          Build a mirage application.
@@ -150,7 +150,7 @@ Help build --help=plain
          mirage-build - Build a mirage application.
   
   SYNOPSIS
-         mirage build [OPTION]…
+         mirage build [OPTION]… 
   
   DESCRIPTION
          Build a mirage application.

--- a/test/mirage/help/clean.t
+++ b/test/mirage/help/clean.t
@@ -7,7 +7,7 @@ Help clean --man-format=plain
          application.
   
   SYNOPSIS
-         mirage clean [OPTION]... 
+         mirage clean [OPTION]… 
   
   DESCRIPTION
          Clean the files produced by mirage for a given application.
@@ -98,19 +98,14 @@ Help clean --man-format=plain
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -120,8 +115,22 @@ Help clean --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         clean exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of clean:
@@ -131,6 +140,9 @@ Help clean --man-format=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 Help clean --help=plain
@@ -140,7 +152,7 @@ Help clean --help=plain
          application.
   
   SYNOPSIS
-         mirage clean [OPTION]... 
+         mirage clean [OPTION]… 
   
   DESCRIPTION
          Clean the files produced by mirage for a given application.
@@ -231,19 +243,14 @@ Help clean --help=plain
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -253,8 +260,22 @@ Help clean --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         clean exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of clean:
@@ -264,6 +285,9 @@ Help clean --help=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 No difference

--- a/test/mirage/help/clean.t
+++ b/test/mirage/help/clean.t
@@ -7,7 +7,7 @@ Help clean --man-format=plain
          application.
   
   SYNOPSIS
-         mirage clean [OPTION]…
+         mirage clean [OPTION]… 
   
   DESCRIPTION
          Clean the files produced by mirage for a given application.
@@ -152,7 +152,7 @@ Help clean --help=plain
          application.
   
   SYNOPSIS
-         mirage clean [OPTION]…
+         mirage clean [OPTION]… 
   
   DESCRIPTION
          Clean the files produced by mirage for a given application.

--- a/test/mirage/help/clean.t
+++ b/test/mirage/help/clean.t
@@ -7,7 +7,7 @@ Help clean --man-format=plain
          application.
   
   SYNOPSIS
-         mirage clean [OPTION]… 
+         mirage clean [OPTION]…
   
   DESCRIPTION
          Clean the files produced by mirage for a given application.
@@ -152,7 +152,7 @@ Help clean --help=plain
          application.
   
   SYNOPSIS
-         mirage clean [OPTION]… 
+         mirage clean [OPTION]…
   
   DESCRIPTION
          Clean the files produced by mirage for a given application.

--- a/test/mirage/help/configure-o.t
+++ b/test/mirage/help/configure-o.t
@@ -6,7 +6,7 @@ Help configure -o --man-format=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]... 
+         mirage configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.
@@ -114,19 +114,14 @@ Help configure -o --man-format=plain
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -136,8 +131,22 @@ Help configure -o --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         configure exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of configure:
@@ -150,6 +159,9 @@ Help configure -o --man-format=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 Help configure -o --help=plain
@@ -158,7 +170,7 @@ Help configure -o --help=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]... 
+         mirage configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.
@@ -266,19 +278,14 @@ Help configure -o --help=plain
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -288,8 +295,22 @@ Help configure -o --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         configure exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of configure:
@@ -302,6 +323,9 @@ Help configure -o --help=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 No difference

--- a/test/mirage/help/configure-o.t
+++ b/test/mirage/help/configure-o.t
@@ -6,7 +6,7 @@ Help configure -o --man-format=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]…
+         mirage configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.
@@ -170,7 +170,7 @@ Help configure -o --help=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]…
+         mirage configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.

--- a/test/mirage/help/configure-o.t
+++ b/test/mirage/help/configure-o.t
@@ -6,7 +6,7 @@ Help configure -o --man-format=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]… 
+         mirage configure [OPTION]…
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.
@@ -170,7 +170,7 @@ Help configure -o --help=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]… 
+         mirage configure [OPTION]…
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.

--- a/test/mirage/help/configure.t
+++ b/test/mirage/help/configure.t
@@ -6,7 +6,7 @@ Help configure --man-format=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]... 
+         mirage configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.
@@ -114,19 +114,14 @@ Help configure --man-format=plain
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -136,8 +131,22 @@ Help configure --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         configure exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of configure:
@@ -150,6 +159,9 @@ Help configure --man-format=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 Configure help --help=plain
@@ -158,7 +170,7 @@ Configure help --help=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]... 
+         mirage configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.
@@ -266,19 +278,14 @@ Configure help --help=plain
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -288,8 +295,22 @@ Configure help --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         configure exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of configure:
@@ -302,6 +323,9 @@ Configure help --help=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 No difference

--- a/test/mirage/help/configure.t
+++ b/test/mirage/help/configure.t
@@ -6,7 +6,7 @@ Help configure --man-format=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]… 
+         mirage configure [OPTION]…
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.
@@ -170,7 +170,7 @@ Configure help --help=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]… 
+         mirage configure [OPTION]…
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.

--- a/test/mirage/help/configure.t
+++ b/test/mirage/help/configure.t
@@ -6,7 +6,7 @@ Help configure --man-format=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]…
+         mirage configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.
@@ -170,7 +170,7 @@ Configure help --help=plain
          mirage-configure - Configure a mirage application.
   
   SYNOPSIS
-         mirage configure [OPTION]…
+         mirage configure [OPTION]… 
   
   DESCRIPTION
          The configure command initializes a fresh mirage application.

--- a/test/mirage/help/describe.t
+++ b/test/mirage/help/describe.t
@@ -6,7 +6,7 @@ Help describe --man-format=plain
          mirage-describe - Describe a mirage application.
   
   SYNOPSIS
-         mirage describe [OPTION]... 
+         mirage describe [OPTION]… 
   
   DESCRIPTION
          The describe command describes the configuration of a mirage
@@ -129,19 +129,14 @@ Help describe --man-format=plain
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -151,8 +146,22 @@ Help describe --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         describe exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of describe:
@@ -162,6 +171,9 @@ Help describe --man-format=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 Help describe --help=plain
@@ -170,7 +182,7 @@ Help describe --help=plain
          mirage-describe - Describe a mirage application.
   
   SYNOPSIS
-         mirage describe [OPTION]... 
+         mirage describe [OPTION]… 
   
   DESCRIPTION
          The describe command describes the configuration of a mirage
@@ -293,19 +305,14 @@ Help describe --help=plain
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -315,8 +322,22 @@ Help describe --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         describe exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of describe:
@@ -326,6 +347,9 @@ Help describe --help=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 No difference

--- a/test/mirage/help/describe.t
+++ b/test/mirage/help/describe.t
@@ -6,7 +6,7 @@ Help describe --man-format=plain
          mirage-describe - Describe a mirage application.
   
   SYNOPSIS
-         mirage describe [OPTION]… 
+         mirage describe [OPTION]…
   
   DESCRIPTION
          The describe command describes the configuration of a mirage
@@ -182,7 +182,7 @@ Help describe --help=plain
          mirage-describe - Describe a mirage application.
   
   SYNOPSIS
-         mirage describe [OPTION]… 
+         mirage describe [OPTION]…
   
   DESCRIPTION
          The describe command describes the configuration of a mirage

--- a/test/mirage/help/describe.t
+++ b/test/mirage/help/describe.t
@@ -6,7 +6,7 @@ Help describe --man-format=plain
          mirage-describe - Describe a mirage application.
   
   SYNOPSIS
-         mirage describe [OPTION]…
+         mirage describe [OPTION]… 
   
   DESCRIPTION
          The describe command describes the configuration of a mirage
@@ -182,7 +182,7 @@ Help describe --help=plain
          mirage-describe - Describe a mirage application.
   
   SYNOPSIS
-         mirage describe [OPTION]…
+         mirage describe [OPTION]… 
   
   DESCRIPTION
          The describe command describes the configuration of a mirage

--- a/test/mirage/help/query.t
+++ b/test/mirage/help/query.t
@@ -6,7 +6,7 @@ Help query --man-format=plain
          mirage-query - Query information about the mirage application.
   
   SYNOPSIS
-         mirage query [OPTION]... [INFO]
+         mirage query [OPTION]… [INFO]
   
   DESCRIPTION
          The query command queries information about the mirage application.
@@ -112,28 +112,23 @@ Help query --man-format=plain
              Name of the output file.
   
          INFO (absent=packages)
-             The information to query. INFO must be one of `name', `packages',
-             `monorepo.opam', `switch.opam', `files', `Makefile',
-             `dune.config', `dune.build', `dune-project', `dune-workspace' or
-             `dune.dist'
+             The information to query. INFO must be one of 'name', 'packages',
+             'monorepo.opam', 'switch.opam', 'files', 'Makefile',
+             'dune.config', 'dune.build', 'dune-project', 'dune-workspace' or
+             'dune.dist'
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -143,8 +138,22 @@ Help query --man-format=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         query exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of query:
@@ -157,6 +166,9 @@ Help query --man-format=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 Help query --help=plain
@@ -165,7 +177,7 @@ Help query --help=plain
          mirage-query - Query information about the mirage application.
   
   SYNOPSIS
-         mirage query [OPTION]... [INFO]
+         mirage query [OPTION]… [INFO]
   
   DESCRIPTION
          The query command queries information about the mirage application.
@@ -271,28 +283,23 @@ Help query --help=plain
              Name of the output file.
   
          INFO (absent=packages)
-             The information to query. INFO must be one of `name', `packages',
-             `monorepo.opam', `switch.opam', `files', `Makefile',
-             `dune.config', `dune.build', `dune-project', `dune-workspace' or
-             `dune.dist'
+             The information to query. INFO must be one of 'name', 'packages',
+             'monorepo.opam', 'switch.opam', 'files', 'Makefile',
+             'dune.config', 'dune.build', 'dune-project', 'dune-workspace' or
+             'dune.dist'
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
              How to say hello. 
   
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
-             Colorize the output. WHEN must be one of `auto', `always' or
-             `never'.
+             Colorize the output. WHEN must be one of auto, always or never.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
   
          -q, --quiet
              Be quiet. Takes over -v and --verbosity.
@@ -302,8 +309,22 @@ Help query --help=plain
              more.
   
          --verbosity=LEVEL (absent=warning)
-             Be more or less verbose. LEVEL must be one of `quiet', `error',
-             `warning', `info' or `debug'. Takes over -v.
+             Be more or less verbose. LEVEL must be one of quiet, error,
+             warning, info or debug. Takes over -v.
+  
+         --version
+             Show version information.
+  
+  EXIT STATUS
+         query exits with the following status:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
   
   ENVIRONMENT
          These environment variables affect the execution of query:
@@ -316,6 +337,9 @@ Help query --help=plain
   
          MODE
              See option --target.
+  
+  SEE ALSO
+         mirage(1)
   
 
 No difference


### PR DESCRIPTION
/cc @dbuenzli  I'm not sure if I've done the "right thing" so your feedback would be great! 

`Cmd.eval_value` seems to be a bit more complex than the previous `eval` but that's manageable. The main change is that peek/eval do not work on the same types anymore (as it's not possible to extract a `'a Term.t` from `'a Cmd` due to grouping). The rest is pretty straitghforward.

Something very minor is that the man pages seem to generate a bit more whitespace than before. Not sure what changed (maybe just a side-effect of changes in `Fmt`)?