### PR TITLE
Add tcpv4v6_of_stackv4v6

### DIFF
--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -197,6 +197,19 @@ let static_ipv4v6_stack = Mirage_impl_stack.static_ipv4v6_stack
 let direct_stackv4v6 = Mirage_impl_stack.direct_stackv4v6
 let socket_stackv4v6 = Mirage_impl_stack.socket_stackv4v6
 
+let tcpv4v6_of_stackv4v6 v =
+  let impl =
+    let packages =
+      [ package "tcpip" ~sublibs:[ "stack-direct" ] ~min:"7.1.0" ]
+    in
+    let connect _ modname = function
+      | [ stackv4v6 ] -> Fmt.str {ocaml|%s.connect %s|ocaml} modname stackv4v6
+      | _ -> assert false
+    in
+    impl ~packages ~connect "Tcpip_stack_direct.TCPV4V6" (stackv4v6 @-> tcpv4v6)
+  in
+  impl $ v
+
 type conduit = Mirage_impl_conduit.conduit
 
 let conduit = Mirage_impl_conduit.conduit

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -687,6 +687,10 @@ val generic_stackv4v6 :
     If a key is not provided, it uses {!Key.net} (with the [group] argument) to
     create it. *)
 
+val tcpv4v6_of_stackv4v6 : stackv4v6 impl -> tcpv4v6 impl
+(** [tcpv4v6 stackv4v6] is an helper to extract the TCP/IP stack regardless the
+    UDP/IP stack expected by some {i devices} such as protocols. *)
+
 (** {2 Resolver configuration} *)
 
 type resolver


### PR DESCRIPTION
Related to mirage/mirage-tcpip#474. It helps us to start to implement protocols which expects only a TCP/IP stack. By this way, it easy to:
1) implement protocols regardless the UDP/IP stack
2) have an easy switch between `mirage-tcpip` which provides a full-stack and `utcp` which provides only a `Tcpip.Tcp.S`