### PR TITLE
Allow to specify version of pinned packages

### DIFF
--- a/lib/functoria/DSL.mli
+++ b/lib/functoria/DSL.mli
@@ -108,6 +108,7 @@ val package :
   ?min:string ->
   ?max:string ->
   ?pin:string ->
+  ?pin_version:string ->
   string ->
   package
 (** Same as {!Functoria.Package.val-v} *)

--- a/lib/functoria/info.ml
+++ b/lib/functoria/info.ml
@@ -55,10 +55,7 @@ let libraries t = libraries (packages t)
 
 let pins packages =
   List.fold_left
-    (fun acc p ->
-      match Package.pin p with
-      | None -> acc
-      | Some u -> (Package.name p, u) :: acc)
+    (fun acc p -> match Package.pin p with None -> acc | Some u -> u :: acc)
     [] packages
 
 let keys t = Key.Set.elements t.keys

--- a/lib/functoria/opam.ml
+++ b/lib/functoria/opam.ml
@@ -157,9 +157,7 @@ let pp_packages ppf packages =
 let pp_pins ppf = function
   | [] -> ()
   | pins ->
-      let pp_pin ppf (package, url) =
-        Fmt.pf ppf "[\"%s.dev\" %S]" package url
-      in
+      let pp_pin ppf (package, url) = Fmt.pf ppf "[\"%s\" %S]" package url in
       Fmt.pf ppf "@.pin-depends: [ @[<hv>%a@]@ ]@."
         Fmt.(list ~sep:(any "@ ") pp_pin)
         pins

--- a/lib/functoria/package.mli
+++ b/lib/functoria/package.mli
@@ -35,6 +35,7 @@ val v :
   ?min:string ->
   ?max:string ->
   ?pin:string ->
+  ?pin_version:string ->
   string ->
   t
 (** [v ~scope ~build ~sublibs ~libs ~min ~max ~pin opam] is a [package]. [Build]
@@ -46,8 +47,8 @@ val v :
     leads to an invalid argument. Version constraints are given as [min]
     (inclusive) and [max] (exclusive). If [pin] is provided, a
     {{:https://opam.ocaml.org/doc/Manual.html#opamfield-pin-depends}
-    pin-depends} is generated. [~scope] specifies the installation location of
-    the package. *)
+    pin-depends} is generated, [pin_version] is ["dev"] by default. [~scope]
+    specifies the installation location of the package. *)
 
 val with_scope : scope:scope -> t -> t
 (** [with_scope t] returns t with chosen installation location.*)
@@ -61,8 +62,8 @@ val key : t -> string
 val scope : t -> scope
 (** [scope t] is [t]'s installation scope. *)
 
-val pin : t -> string option
-(** [pin t] is [Some r] iff [t] is pinned to the repository [r]. *)
+val pin : t -> (string * string) option
+(** [pin t] is [Some (name_version, r)] iff [t] is pinned to the repository [r]. *)
 
 val build_dependency : t -> bool
 (** [build_dependency t] is [true] iff [t] is a build-time dependency. *)


### PR DESCRIPTION
The `dev` version string that is added by default can mess with opam's version comparison.
For example `ppx_deriving_yaml` now requires `yaml < 3.0.1` but `yaml.dev` is considered higher than `yaml.3.0.1`.

This fixes the build of `mirage-www`: https://github.com/Julow/mirage-www/commit/8aad99becaf47ecbf78de37dd8748d264248a610
The `pin-depends` field is changed to:

```
pin-depends: [ ["yaml.3.0.0" "git+https://github.com/TheLortex/ocaml-yaml.git#7e1f117645ea10fbec2bd3dbbf0d8f581cce891f"]
]
```