### PR TITLE
require conduit 5.1.0+ (which does not result in an exception if the TLS handshake fals on the server side)

### DIFF
--- a/lib/mirage/impl/mirage_impl_conduit.ml
+++ b/lib/mirage/impl/mirage_impl_conduit.ml
@@ -6,7 +6,7 @@ open Mirage_impl_random
 type conduit = Conduit
 
 let conduit = Type.v Conduit
-let pkg = package ~min:"5.0.0" ~max:"6.0.0" "conduit-mirage"
+let pkg = package ~min:"5.1.0" ~max:"6.0.0" "conduit-mirage"
 
 let tcp =
   let packages = [ pkg ] in


### PR DESCRIPTION
see #1036 for further details