### PR TITLE
Check that the package name respects opam conventions

### DIFF
--- a/lib/functoria/package.ml
+++ b/lib/functoria/package.ml
@@ -69,8 +69,20 @@ let merge a b =
         let empty = String.Set.empty in
         Some { name; build; scope; libs; min = empty; max = empty; pin }
 
+let package_name_is_valid name =
+  let has_letter = String.exists Char.Ascii.is_letter name in
+  let only_allowed_chars =
+    String.for_all
+      (function
+        | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> true | _ -> false)
+      name
+  in
+  only_allowed_chars && has_letter
+
 let v ?(scope = `Monorepo) ?(build = false) ?sublibs ?libs ?min ?max ?pin
     ?(pin_version = "dev") name =
+  if not (package_name_is_valid name) then
+    Fmt.invalid_arg "package name %S is invalid" name;
   let libs =
     match (sublibs, libs) with
     | None, None -> [ name ]

--- a/test/functoria/test_package.ml
+++ b/test/functoria/test_package.ml
@@ -33,5 +33,19 @@ let test_package_pp () =
   Alcotest.(check string) "key(x)" (Package.key x) "monorepo-foo";
   Alcotest.(check string) "key(w)" (Package.key w) "switch-foo"
 
+let test_invalid_package_names () =
+  let check_name_is_invalid name =
+    Alcotest.check_raises name
+      (Invalid_argument (Fmt.str "package name %S is invalid" name))
+      (fun () -> Package.v name |> ignore)
+  in
+  check_name_is_invalid "bar.subfoo";
+  check_name_is_invalid "000";
+  check_name_is_invalid "é"
+
 let suite =
-  [ ("merge", `Quick, test_package_merge); ("pp", `Quick, test_package_pp) ]
+  [
+    ("merge", `Quick, test_package_merge);
+    ("pp", `Quick, test_package_pp);
+    ("invalid names", `Quick, test_invalid_package_names);
+  ]


### PR DESCRIPTION
A fix for https://github.com/mirage/mirage/issues/1287

So this way, an invalid package name yields `Invalid_argument` at configure-time. We could add a hint (for example if there is a dot in the name) but at least the error is not propagated to opam-monorepo !