### PR TITLE
The timeout argument of the dns-client device must be an optional int64

### DIFF
--- a/lib/mirage/impl/mirage_impl_dns.ml
+++ b/lib/mirage/impl/mirage_impl_dns.ml
@@ -29,7 +29,7 @@ let generic_dns_client timeout nameservers =
         let pp_timeout ppf = function
           | None -> ()
           | Some timeout ->
-              Fmt.pf ppf "~timeout:%a " Key.serialize_call (Key.v timeout)
+              Fmt.pf ppf "?timeout:%a " Key.serialize_call (Key.v timeout)
         in
         Fmt.str {ocaml|%s.connect ~nameservers:%a %a%s|ocaml} modname
           pp_nameservers nameservers pp_timeout timeout stackv4v6

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -719,7 +719,7 @@ type dns_client
 val dns_client : dns_client typ
 
 val generic_dns_client :
-  ?timeout:int64 key ->
+  ?timeout:int64 option key ->
   ?nameservers:string list key ->
   ?random:random impl ->
   ?time:time impl ->


### PR DESCRIPTION
It's a more user-friendly interface where the user don't need to give a default value of the timeout if he/she wants to define a `timeout` command-line argument.