### PR TITLE
Rename ocaml-freestanding to ocaml-solo5

### DIFF
--- a/lib/mirage/impl/mirage_impl_block.ml
+++ b/lib/mirage/impl/mirage_impl_block.ml
@@ -69,7 +69,7 @@ let block_conf file =
     Key.match_ Key.(value target) @@ function
     | #Mirage_key.mode_xen -> xen_block_packages
     | #Mirage_key.mode_solo5 ->
-        [ package ~min:"0.7.0" ~max:"0.8.0" "mirage-block-solo5" ]
+        [ package ~min:"0.8.0" ~max:"0.9.0" "mirage-block-solo5" ]
     | #Mirage_key.mode_unix ->
         [ package ~min:"2.12.0" ~max:"3.0.0" "mirage-block-unix" ]
   in

--- a/lib/mirage/impl/mirage_impl_console.ml
+++ b/lib/mirage/impl/mirage_impl_console.ml
@@ -15,7 +15,7 @@ let console_xen str =
   impl ~packages ~connect:(connect str) "Console_xen" console
 
 let console_solo5 str =
-  let packages = [ package ~min:"0.7.0" ~max:"0.8.0" "mirage-console-solo5" ] in
+  let packages = [ package ~min:"0.8.0" ~max:"0.9.0" "mirage-console-solo5" ] in
   impl ~packages ~connect:(connect str) "Console_solo5" console
 
 let custom_console str =

--- a/lib/mirage/impl/mirage_impl_mclock.ml
+++ b/lib/mirage/impl/mirage_impl_mclock.ml
@@ -8,6 +8,6 @@ let default_monotonic_clock =
   let packages_v =
     Mirage_key.(if_ is_unix)
       [ package ~min:"4.1.0" ~max:"5.0.0" "mirage-clock-unix" ]
-      [ package ~min:"4.1.0" ~max:"5.0.0" "mirage-clock-freestanding" ]
+      [ package ~min:"4.2.0" ~max:"5.0.0" "mirage-clock-solo5" ]
   in
   impl ~packages_v "Mclock" mclock

--- a/lib/mirage/impl/mirage_impl_network.ml
+++ b/lib/mirage/impl/mirage_impl_network.ml
@@ -20,7 +20,7 @@ let network_conf (intf : string Key.key) =
           Mirage_impl_qubesdb.pkg;
         ]
     | #Mirage_key.mode_solo5 ->
-        [ package ~min:"0.7.0" ~max:"0.8.0" "mirage-net-solo5" ]
+        [ package ~min:"0.8.0" ~max:"0.9.0" "mirage-net-solo5" ]
   in
   let connect _ modname _ =
     (* @samoht: why not just use the args paramater? *)

--- a/lib/mirage/impl/mirage_impl_pclock.ml
+++ b/lib/mirage/impl/mirage_impl_pclock.ml
@@ -8,6 +8,6 @@ let default_posix_clock =
   let packages_v =
     Mirage_key.(if_ is_unix)
       [ package ~min:"3.0.0" ~max:"5.0.0" "mirage-clock-unix" ]
-      [ package ~min:"3.1.0" ~max:"5.0.0" "mirage-clock-freestanding" ]
+      [ package ~min:"4.2.0" ~max:"5.0.0" "mirage-clock-solo5" ]
   in
   impl ~packages_v "Pclock" pclock

--- a/lib/mirage/target/solo5.ml
+++ b/lib/mirage/target/solo5.ml
@@ -13,10 +13,7 @@ type t = [ solo5_target | xen_target ]
 let cast = function #t as t -> t | _ -> invalid_arg "not a solo5 target."
 
 let build_packages =
-  [
-    Functoria.package ~min:"0.7.0" ~scope:`Switch ~build:true
-      "ocaml-freestanding";
-  ]
+  [ Functoria.package ~min:"0.8.0" ~scope:`Switch ~build:true "ocaml-solo5" ]
 
 let runtime_packages target =
   match target with

--- a/lib/mirage/target/solo5.ml
+++ b/lib/mirage/target/solo5.ml
@@ -18,7 +18,7 @@ let build_packages =
 let runtime_packages target =
   match target with
   | #solo5_target ->
-      [ Functoria.package ~min:"0.7.0" ~max:"0.8.0" "mirage-solo5" ]
+      [ Functoria.package ~min:"0.8.0" ~max:"0.9.0" "mirage-solo5" ]
   | #xen_target -> [ Functoria.package ~min:"7.0.0" ~max:"8.0.0" "mirage-xen" ]
 
 let packages target = build_packages @ runtime_packages target

--- a/lib/mirage/target/solo5.ml
+++ b/lib/mirage/target/solo5.ml
@@ -22,9 +22,9 @@ let runtime_packages target =
   | #xen_target -> [ Functoria.package ~min:"7.0.0" ~max:"8.0.0" "mirage-xen" ]
 
 let packages target = build_packages @ runtime_packages target
-let context_name _i = "freestanding"
+let context_name _i = "solo5"
 
-(* OCaml freestanding build context. *)
+(* OCaml solo5 build context. *)
 let build_context ?build_dir:_ i =
   let profile_release = Dune.stanza "(profile release)" in
   let build_context =
@@ -33,7 +33,7 @@ let build_context ?build_dir:_ i =
   (context (default
   (name %s)
   (host default)
-  (toolchain freestanding)
+  (toolchain solo5)
   (disable_dynamically_linked_foreign_archives true)
   ))
   |}

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -104,10 +104,10 @@ Query unikernel dune (hvt)
   (copy_files ./config/*)
   
   (executable
-   (enabled_if (= %{context_name} "freestanding"))
+   (enabled_if (= %{context_name} "solo5"))
    (name main)
    (modes (native exe))
-   (libraries lwt mirage-bootvar-solo5 mirage-clock-freestanding mirage-logs
+   (libraries lwt mirage-bootvar-solo5 mirage-clock-solo5 mirage-logs
      mirage-runtime mirage-solo5)
    (link_flags -g -w +A-4-41-42-44 -bin-annot -strict-sequence -principal
      -safe-string -cclib "-z solo5-abi=hvt")
@@ -123,14 +123,14 @@ Query unikernel dune (hvt)
   
   (rule
    (target noop-functor.v0.hvt)
-   (enabled_if (= %{context_name} "freestanding"))
+   (enabled_if (= %{context_name} "solo5"))
    (deps main.exe)
    (action
     (copy main.exe %{target})))
   
   (alias
     (name default)
-    (enabled_if (= %{context_name} "freestanding"))
+    (enabled_if (= %{context_name} "solo5"))
     (deps (alias_rec all))
     )
 
@@ -139,7 +139,7 @@ Query dist dune (hvt)
   (rule
    (mode (promote (until-clean)))
    (target noop-functor.v0.hvt)
-   (enabled_if (= %{context_name} "freestanding"))
+   (enabled_if (= %{context_name} "solo5"))
    (action
     (copy ../noop-functor.v0.hvt %{target}))
   )

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -27,7 +27,7 @@ Query global opam
   depends: [
     "mirage" { build & >= "4.0" & < "4.1.0" }
     "ocaml" { build & >= "4.08.0" }
-    "ocaml-freestanding" { build & >= "0.7.0" }
+    "ocaml-solo5" { build & >= "0.8.0" }
     "opam-monorepo" { build & >= "0.2.6" }
   ]
   
@@ -64,7 +64,7 @@ Query packages
   "mirage-runtime" { >= "4.0" & < "4.1.0" }
   "mirage-solo5" { >= "0.7.0" & < "0.8.0" }
   "ocaml" { build & >= "4.08.0" }
-  "ocaml-freestanding" { build & >= "0.7.0" }
+  "ocaml-solo5" { build & >= "0.8.0" }
   "opam-monorepo" { build & >= "0.2.6" }
 
 Query files

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -46,10 +46,10 @@ Query local opam
   depends: [
     "lwt"
     "mirage-bootvar-solo5" { >= "0.6.0" & < "0.7.0" }
-    "mirage-clock-freestanding" { >= "3.1.0" & < "5.0.0" }
+    "mirage-clock-solo5" { >= "4.2.0" & < "5.0.0" }
     "mirage-logs" { >= "1.2.0" & < "2.0.0" }
     "mirage-runtime" { >= "4.0" & < "4.1.0" }
-    "mirage-solo5" { >= "0.7.0" & < "0.8.0" }
+    "mirage-solo5" { >= "0.8.0" & < "0.9.0" }
   ]
   
   
@@ -59,10 +59,10 @@ Query packages
   "lwt"
   "mirage" { build & >= "4.0" & < "4.1.0" }
   "mirage-bootvar-solo5" { >= "0.6.0" & < "0.7.0" }
-  "mirage-clock-freestanding" { >= "3.1.0" & < "5.0.0" }
+  "mirage-clock-solo5" { >= "4.2.0" & < "5.0.0" }
   "mirage-logs" { >= "1.2.0" & < "2.0.0" }
   "mirage-runtime" { >= "4.0" & < "4.1.0" }
-  "mirage-solo5" { >= "0.7.0" & < "0.8.0" }
+  "mirage-solo5" { >= "0.8.0" & < "0.9.0" }
   "ocaml" { build & >= "4.08.0" }
   "ocaml-solo5" { build & >= "0.8.0" }
   "opam-monorepo" { build & >= "0.2.6" }
@@ -255,10 +255,10 @@ Query unikernel dune
   (copy_files ./config/*)
   
   (executable
-   (enabled_if (= %{context_name} "freestanding"))
+   (enabled_if (= %{context_name} "solo5"))
    (name main)
    (modes (native exe))
-   (libraries lwt mirage-bootvar-solo5 mirage-clock-freestanding mirage-logs
+   (libraries lwt mirage-bootvar-solo5 mirage-clock-solo5 mirage-logs
      mirage-runtime mirage-solo5)
    (link_flags -g -w +A-4-41-42-44 -bin-annot -strict-sequence -principal
      -safe-string -cclib "-z solo5-abi=hvt")
@@ -274,14 +274,14 @@ Query unikernel dune
   
   (rule
    (target noop.hvt)
-   (enabled_if (= %{context_name} "freestanding"))
+   (enabled_if (= %{context_name} "solo5"))
    (deps main.exe)
    (action
     (copy main.exe %{target})))
   
   (alias
     (name default)
-    (enabled_if (= %{context_name} "freestanding"))
+    (enabled_if (= %{context_name} "solo5"))
     (deps (alias_rec all))
     )
 
@@ -315,8 +315,8 @@ Query dune-workspace
   (profile release)
   
   (context (default
-    (name freestanding)
+    (name solo5)
     (host default)
-    (toolchain freestanding)
+    (toolchain solo5)
     (disable_dynamically_linked_foreign_archives true)
     ))


### PR DESCRIPTION
Assume that `ocaml-solo5.0.8.0` is released (which should be just a GitHub rename), this PR wants to fix #1294. The rename can be quick or _clean_: indeed, we have several things which takes the `freestanding` name (such as the `dune`'s context, `ocamlfind`'s toolchain). What should be the best for us according to our deadline (/cc @mirage/core)?

_to test with_ https://github.com/mirage/mirage-dev/pull/387