### PR TITLE
Use the same flags as dune

### DIFF
--- a/lib/mirage/target/mirage_dune.ml
+++ b/lib/mirage/target/mirage_dune.ml
@@ -1,18 +1,6 @@
-open Functoria
-module Key = Mirage_key
 open Mirage_impl_misc
 
-let flags i =
-  let ctx = Info.context i in
-  let warn_error = Key.(get ctx warn_error) in
-  [
-    "-g";
-    "-w";
-    "+A-4-41-42-44";
-    "-bin-annot";
-    "-strict-sequence";
-    "-principal";
-    "-safe-string";
-  ]
-  @ (if warn_error then [ "-warn-error"; "+1..49" ] else [])
-  @ if terminal () then [ "-color"; "always" ] else []
+let flags _ =
+  (* Disable "70 [missing-mli] Missing interface file." as we are only
+     generating .ml files currently. *)
+  [ "-w"; "-70" ] @ if terminal () then [ "-color"; "always" ] else []

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -14,8 +14,7 @@ Query unikernel dune
      mirage-runtime mirage-unix)
    (link_flags (-thread))
    (modules (:standard \ config))
-   (flags -g -w +A-4-41-42-44 -bin-annot -strict-sequence -principal
-     -safe-string)
+   (flags -w -70)
    (enabled_if (= %{context_name} "default"))
   )
 
@@ -109,8 +108,7 @@ Query unikernel dune (hvt)
    (modes (native exe))
    (libraries lwt mirage-bootvar-solo5 mirage-clock-freestanding mirage-logs
      mirage-runtime mirage-solo5)
-   (link_flags -g -w +A-4-41-42-44 -bin-annot -strict-sequence -principal
-     -safe-string -cclib "-z solo5-abi=hvt")
+   (link_flags -w -70 -cclib "-z solo5-abi=hvt")
    (modules (:standard \ config manifest))
    (foreign_stubs (language c) (names manifest))
   )

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -260,8 +260,7 @@ Query unikernel dune
    (modes (native exe))
    (libraries lwt mirage-bootvar-solo5 mirage-clock-freestanding mirage-logs
      mirage-runtime mirage-solo5)
-   (link_flags -g -w +A-4-41-42-44 -bin-annot -strict-sequence -principal
-     -safe-string -cclib "-z solo5-abi=hvt")
+   (link_flags -w -70 -cclib "-z solo5-abi=hvt")
    (modules (:standard \ config manifest))
    (foreign_stubs (language c) (names manifest))
   )

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -273,8 +273,7 @@ Query unikernel dune
      mirage-runtime mirage-unix)
    (link_flags (-thread))
    (modules (:standard \ config))
-   (flags -g -w +A-4-41-42-44 -bin-annot -strict-sequence -principal
-     -safe-string)
+   (flags -w -70)
    (enabled_if (= %{context_name} "default"))
   )
 


### PR DESCRIPTION
Only disable "[missing-mli] Missing interface file." as we are generating
a lot of .ml files without the associated mli files.

Replaces #1313