### PR TITLE
Fix dune version in dune-project

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.8)
+(lang dune 2.9)
 (name mirage)
 (cram enable)


### PR DESCRIPTION
Otherwise, we get:

```
- File "test/functoria/e2e/dune", line 18, characters 11-28:
- 18 |   (package functoria-runtime))
-                 ^^^^^^^^^^^^^^^^^
- Error: Dependency on an installed package requires at least (lang dune 2.9)
- (cd _build/default/test/functoria && ./test.exe)
```

When running the e2e tests.