### PR TITLE
Build non-executable artifacts in the host context

### DIFF
--- a/lib/functoria/install.ml
+++ b/lib/functoria/install.ml
@@ -69,12 +69,18 @@ let promote_artifact ~context_name ~src ~dst =
     Fpath.pp dst context_name Fpath.pp
     Fpath.(v ".." // src)
 
-let dune ~context_name t =
+let dune ~context_name_for_bin ~context_name_for_etc t =
   let bin_rules =
-    List.map (fun (src, dst) -> promote_artifact ~context_name ~src ~dst) t.bin
+    List.map
+      (fun (src, dst) ->
+        promote_artifact ~context_name:context_name_for_bin ~src ~dst)
+      t.bin
   in
   let etc_rules =
-    List.map (fun etc -> promote_artifact ~context_name ~src:etc ~dst:etc) t.etc
+    List.map
+      (fun etc ->
+        promote_artifact ~context_name:context_name_for_etc ~src:etc ~dst:etc)
+      t.etc
   in
   Dune.v (bin_rules @ etc_rules)
 

--- a/lib/functoria/install.mli
+++ b/lib/functoria/install.mli
@@ -20,7 +20,7 @@ type t
 
 val v : ?bin:(Fpath.t * Fpath.t) list -> ?etc:Fpath.t list -> unit -> t
 (** [v ~bin:\[(src,dst),...\] ~etc ()] is the installation of [src] as [dst] as
-    binary files, and [etc] as configuration. *)
+    binary files, and [etc] as configuration/artifact. *)
 
 val union : t -> t -> t
 (** [union a b] merge to sets of installation rules. *)
@@ -34,9 +34,12 @@ val pp : t Fmt.t
 val pp_opam : t Fmt.t
 (** Print the opam rules to install [t] *)
 
-val dune : context_name:string -> t -> Dune.t
-(** [dune ~context_name ()] is the dune rules to promote installed files back in
-    the source tree. *)
+val dune :
+  context_name_for_bin:string -> context_name_for_etc:string -> t -> Dune.t
+(** [dune ~context_name_for_bin ~context_name_for_etc ()] is the dune rules to
+    promote installed files back in the source tree. A context-name is required
+    for [bin] and [etc] artifacts. The first one should be the cross-compiler
+    context and the second one should be the host's compiler context. *)
 
 val dump : t Fmt.t
 (** Dump installation rules. *)

--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -242,7 +242,8 @@ module Make (P : S) = struct
     | `Dune `Dist ->
         let install = Key.eval (Info.context info) (Engine.install info jobs) in
         Fmt.pr "%a\n%!" Dune.pp
-          (Install.dune ~context_name:(P.context_name info) install)
+          (Install.dune ~context_name_for_bin:(P.context_name info)
+             ~context_name_for_etc:"default" install)
 
   (* Configuration step. *)
 
@@ -301,7 +302,8 @@ module Make (P : S) = struct
             Key.eval (Info.context info) (Engine.install info jobs)
           in
           Fmt.str "%a\n" Dune.pp
-            (Install.dune ~context_name:(P.context_name info) install)
+            (Install.dune ~context_name_for_bin:(P.context_name info)
+               ~context_name_for_etc:"default" install)
     in
     Filegen.write file contents
 

--- a/lib/mirage/impl/mirage_impl_block.mli
+++ b/lib/mirage/impl/mirage_impl_block.mli
@@ -20,6 +20,7 @@ val docteur :
   ?disk:string Functoria.Key.key ->
   ?analyze:bool Functoria.Key.key ->
   ?branch:string ->
+  ?extra_deps:string list ->
   string ->
   Mirage_impl_kv.ro Functoria.impl
 

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -76,8 +76,8 @@ let kv_rw = Mirage_impl_kv.rw
 let direct_kv_rw = Mirage_impl_kv.direct_kv_rw
 let kv_rw_mem = Mirage_impl_kv.mem_kv_rw
 
-let docteur ?mode ?disk ?analyze ?branch remote =
-  Mirage_impl_block.docteur ?mode ?disk ?analyze ?branch remote
+let docteur ?mode ?disk ?analyze ?branch ?extra_deps remote =
+  Mirage_impl_block.docteur ?mode ?disk ?analyze ?branch ?extra_deps remote
 
 type block = Mirage_impl_block.block
 

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -299,6 +299,7 @@ val docteur :
   ?disk:string Key.key ->
   ?analyze:bool Key.key ->
   ?branch:string ->
+  ?extra_deps:string list ->
   string ->
   kv_ro impl
 (** [docteur ?mode ?disk ?analyze remote] is a read-only, key-value store
@@ -323,6 +324,9 @@ val docteur :
     If you use a simple directory, it can be a relative from your unikernel
     project ([relativize://directory]) or an absolute path
     ([file://home/user/directory]).
+
+    If a required file is produced by a [dune] rule, you must notice it via the
+    [extra_deps] argument.
 
     For a Solo5 target, users must {i attach} the image as a block device:
 

--- a/lib/mirage/target/solo5.ml
+++ b/lib/mirage/target/solo5.ml
@@ -167,19 +167,7 @@ let main i =
     (Fpath.rem_ext (Fpath.base (Info.config_file i)))
 
 let subdir name s = Dune.stanzaf "(subdir %s\n %a)\n" name Dune.pp (Dune.v s)
-
-let alias_override i =
-  Dune.stanzaf
-    {|
-  (alias
-  (name default)
-  (enabled_if (= %%{context_name} "%s"))
-  (deps (alias_rec all))
-  )
-|}
-    (context_name i)
-
-let dune i = [ main i; manifest i; rename i; alias_override i ]
+let dune i = [ main i; manifest i; rename i ]
 
 let install i =
   let target = Info.get i Key.target in

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -125,12 +125,6 @@ Query unikernel dune (hvt)
    (deps main.exe)
    (action
     (copy main.exe %{target})))
-  
-  (alias
-    (name default)
-    (enabled_if (= %{context_name} "solo5"))
-    (deps (alias_rec all))
-    )
 
 Query dist dune (hvt)
   $ ./config_dash_in_name.exe query --target hvt dune.dist

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -277,12 +277,6 @@ Query unikernel dune
    (deps main.exe)
    (action
     (copy main.exe %{target})))
-  
-  (alias
-    (name default)
-    (enabled_if (= %{context_name} "solo5"))
-    (deps (alias_rec all))
-    )
 
 Query configuration dune
   $ ./config.exe query --target hvt dune.config


### PR DESCRIPTION
A context is needed to explain this PR and it's related to #1323.

The goal is to let the user to define some JS files which will be produced by `js_of_ocaml`. Then, a block-device should be generated to the user which includes JS files. A concrete example is [pasteur](https://github.com/dinosaure/pasteur) where the JS script comes from an OCaml code - by this way, we are able to make a website only in OCaml 🚀 .

However, I encountered several problems specially about the "cross-compilation" context. Indeed, it's a non-sense to let the user to fetch and compile `js_of_ocaml` into our (current) Solo5 context. From such situation, we must precise that some artifacts needed for our unikernel (such as block-device) must be buildable only into the default context/with the host compiler.

This PR has 3 commits:
- One is about the deletion of `(alias ...` for the Solo5 target which restrict `dune` to build only what is possible to build _via_  the `solo5` context. If we want to be able to build everything even if we have **multiple** contexts, we must let `dune` to build **everything**. The commit explain another solution which was a no-go due to the disability to pre-compute final artifacts.
- The second is about the context specialization of some artifacts which are installable as `etc` files (configuration files, artifacts). With this patch, only `bin` (such as our `unikernel`) need the cross-compilation context. `etc` objects will require the default context and they will use the host compiler
- The last commit is more specific about `docteur` where we needs to add an `extra_deps` argument to notice to `dune` that, even if a file into the directory `dir/` can be produced, it is really needed to craft the our `docteur` image.

Finally, with this PR, I'm able to describe a complex compilation pipeline which includes `js_of_ocaml`!