### PR TITLE
Adapt to opam-monorepo 0.3.0

### DIFF
--- a/lib/functoria/cli.ml
+++ b/lib/functoria/cli.ml
@@ -31,7 +31,7 @@ let description_section = "DESCRIBE OPTIONS"
 type query_kind =
   [ `Name
   | `Packages
-  | `Opam of [ `Switch | `Monorepo ]
+  | `Opam
   | `Files
   | `Dune of [ `Config | `Build | `Project | `Workspace | `Dist ]
   | `Makefile ]
@@ -40,8 +40,7 @@ let query_kinds : (string * query_kind) list =
   [
     ("name", `Name);
     ("packages", `Packages);
-    ("monorepo.opam", `Opam `Monorepo);
-    ("switch.opam", `Opam `Switch);
+    ("opam", `Opam);
     ("files", `Files);
     ("Makefile", `Makefile);
     ("dune.config", `Dune `Config);

--- a/lib/functoria/cli.mli
+++ b/lib/functoria/cli.mli
@@ -62,7 +62,7 @@ type 'a help_args = 'a args
 type query_kind =
   [ `Name
   | `Packages
-  | `Opam of [ `Monorepo | `Switch ]
+  | `Opam
   | `Files
   | `Dune of [ `Config | `Build | `Project | `Workspace | `Dist ]
   | `Makefile ]

--- a/lib/functoria/info.mli
+++ b/lib/functoria/info.mli
@@ -42,7 +42,7 @@ val libraries : t -> string list
 val packages : t -> Package.t list
 (** [packages t] are the opam package dependencies by the project. *)
 
-val opam : Package.scope -> t -> install:Install.t -> Opam.t
+val opam : t -> install:Install.t -> Opam.t
 (** [opam scope t] is [t]'opam file to install in the [scope] context.*)
 
 val keys : t -> Key.t list

--- a/lib/functoria/makefile.ml
+++ b/lib/functoria/makefile.ml
@@ -29,7 +29,7 @@ let v ?(extra_repo = []) ~build_dir ~builder_name ~depext unikernel_opam_name =
 
 let depext_rules =
   {|
-depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
 	echo " ↳ install external dependencies for monorepo"
 	$(OPAM) monorepo depext -y -l $<
 |}
@@ -114,20 +114,20 @@ all::
 
 .PHONY: all lock install-switch pull clean depend depends build mirage-repo-add mirage-repo-rm%a
 
-$(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam%a
+$(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam%a
 	@@echo " ↳ generate lockfile for monorepo dependencies"
-	@@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l $@@ --ocaml-version $(shell ocamlc --version)%a
+	@@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@@ --ocaml-version $(shell ocamlc --version)%a
 
 lock::
-	@@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+	@@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
 
-pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
 	@@echo " ↳ fetch monorepo rependencies in the duniverse folder"
 	@@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
 
-install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
+install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
 	@@echo " ↳ opam install switch dependencies"
-	@@$(OPAM) install $< --deps-only --yes%a%a
+	@@env OPAMVAR_switch="" $(OPAM) install $< --deps-only --yes%a%a
 
 depends depend::
 	@@$(MAKE) --no-print-directory lock

--- a/lib/functoria/makefile.ml
+++ b/lib/functoria/makefile.ml
@@ -123,7 +123,7 @@ lock::
 
 pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
 	@@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-	@@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
+	@@$(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
 
 install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
 	@@echo " ↳ opam install switch dependencies"

--- a/lib/functoria/makefile.ml
+++ b/lib/functoria/makefile.ml
@@ -116,7 +116,7 @@ all::
 
 $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam%a
 	@@echo " ↳ generate lockfile for monorepo dependencies"
-	@@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@@ --ocaml-version $(shell ocamlc --version)%a
+	@@$(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@@ --ocaml-version $(shell ocamlc --version)%a
 
 lock::
 	@@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked

--- a/lib/functoria/opam.mli
+++ b/lib/functoria/opam.mli
@@ -17,14 +17,12 @@
  *)
 
 type t
-type target = [ `Switch | `Monorepo ]
 
 val v :
   ?build:string list ->
   ?install:Install.t ->
   ?depends:Package.t list ->
   ?pins:(string * string) list ->
-  target:target ->
   src:[ `Auto | `None | `Some of string ] ->
   string ->
   t

--- a/lib/functoria/package.ml
+++ b/lib/functoria/package.ml
@@ -106,15 +106,20 @@ let v ?(scope = `Monorepo) ?(build = false) ?sublibs ?libs ?min ?max ?pin
 
 let with_scope ~scope t = { t with scope }
 
-let exts_to_string ppf (min, max, build) =
+let exts_to_string ppf (min, max, build, scope) =
   let build_strs = if build then [ "build" ] else [] in
   let esc_prefix prefix e = Fmt.str "%s %S" prefix e in
   let min_strs = List.map (esc_prefix ">=") (String.Set.elements min)
   and max_strs = List.map (esc_prefix "<") (String.Set.elements max) in
   let constr_list = build_strs @ min_strs @ max_strs in
+  let constr_list =
+    match scope with
+    | `Monorepo -> "switch != \"\"" :: constr_list
+    | `Switch -> constr_list
+  in
   if List.length constr_list > 0 then
     Fmt.pf ppf " { %s }" (String.concat ~sep:" & " constr_list)
 
 let pp ?(surround = "") ppf p =
   Fmt.pf ppf "%s%s%s%a" surround p.name surround exts_to_string
-    (p.min, p.max, p.build)
+    (p.min, p.max, p.build, p.scope)

--- a/mirage.opam
+++ b/mirage.opam
@@ -29,6 +29,7 @@ depends: [
   "opam-monorepo" {>= "0.2.6"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "opam-monorepo" {>= "0.3.0" & with-test}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/mirage.opam
+++ b/mirage.opam
@@ -26,10 +26,9 @@ depends: [
   "astring"
   "logs"
   "mirage-runtime" {= version}
-  "opam-monorepo" {>= "0.2.6"}
+  "opam-monorepo" {>= "0.3.0"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
-  "opam-monorepo" {>= "0.3.0" & with-test}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/test/functoria/context/run.t
+++ b/test/functoria/context/run.t
@@ -1,26 +1,26 @@
 Query package - no target - x.context
   $ ./config.exe query package --context-file=x.context
-  "fmt"
-  "functoria-runtime"
-  "x"
+  "fmt" { switch != "" }
+  "functoria-runtime" { switch != "" }
+  "x" { switch != "" }
 
 Query package - no target - y.context
   $ ./config.exe query package --context-file=y.context
-  "fmt"
-  "functoria-runtime"
-  "y"
+  "fmt" { switch != "" }
+  "functoria-runtime" { switch != "" }
+  "y" { switch != "" }
 
 Query package - x target  - y.context
   $ ./config.exe query package -t x --context-file=y.context
-  "fmt"
-  "functoria-runtime"
-  "x"
+  "fmt" { switch != "" }
+  "functoria-runtime" { switch != "" }
+  "x" { switch != "" }
 
 Query package - y target  - x.context
   $ ./config.exe query package -t y --context-file=x.context
-  "fmt"
-  "functoria-runtime"
-  "y"
+  "fmt" { switch != "" }
+  "functoria-runtime" { switch != "" }
+  "y" { switch != "" }
 
 Describe - no target - x.context
   $ ./config.exe describe --context-file=x.context

--- a/test/functoria/e2e/build.t
+++ b/test/functoria/e2e/build.t
@@ -35,8 +35,7 @@ Build an application.
   dune-workspace.config
   key_gen.ml
   main.ml
-  noop-monorepo.opam
-  noop-switch.opam
+  noop.opam
   vote
   warn_error
   $ ./app/main.exe
@@ -84,8 +83,7 @@ Test `--output`:
   context
   dune-workspace.config
   key_gen.ml
-  noop-monorepo.opam
-  noop-switch.opam
+  noop.opam
   toto.ml
   vote
   warn_error

--- a/test/functoria/e2e/clean.t
+++ b/test/functoria/e2e/clean.t
@@ -18,8 +18,7 @@ Make sure that clean remove everything:
   dune-workspace.config
   key_gen.ml
   main.ml
-  noop-monorepo.opam
-  noop-switch.opam
+  noop.opam
   vote
   warn_error
   $ ./test.exe clean -v --file app/config.ml
@@ -66,8 +65,7 @@ Check that clean works with `--output`:
   context
   dune-workspace.config
   key_gen.ml
-  noop-monorepo.opam
-  noop-switch.opam
+  noop.opam
   toto.ml
   vote
   warn_error

--- a/test/functoria/e2e/configure.t
+++ b/test/functoria/e2e/configure.t
@@ -22,8 +22,7 @@ is passed:
                        hello=Hello World! (default),
                        vote=cat (default),
                        warn_error=false (default)
-  config.exe: [INFO] Generating: noop-switch.opam (switch.opam)
-  config.exe: [INFO] Generating: noop-monorepo.opam (monorepo.opam)
+  config.exe: [INFO] Generating: noop.opam (opam)
   config.exe: [INFO] in dir { "context" = ;
                               "config_file" = app/config.ml;
                               "output" = None;
@@ -51,8 +50,7 @@ is passed:
   dune-workspace.config
   key_gen.ml
   main.ml
-  noop-monorepo.opam
-  noop-switch.opam
+  noop.opam
   vote
   warn_error
   $ ./test.exe clean --file app/config.ml

--- a/test/functoria/e2e/describe.t
+++ b/test/functoria/e2e/describe.t
@@ -24,4 +24,4 @@ Test that `describe` works as expected:
     hello=Hello World! (default),
     vote=cat (default),
     warn_error=false (default)Libraries  fmt, functoria-runtime
-  Packages   fmt, functoria-runtime
+  Packages   fmt { switch != "" }, functoria-runtime { switch != "" }

--- a/test/functoria/help/query.t
+++ b/test/functoria/help/query.t
@@ -42,9 +42,8 @@ Help query --man-format=plain
   
          INFO (absent=packages)
              The information to query. INFO must be one of 'name', 'packages',
-             'monorepo.opam', 'switch.opam', 'files', 'Makefile',
-             'dune.config', 'dune.build', 'dune-project', 'dune-workspace' or
-             'dune.dist'
+             'opam', 'files', 'Makefile', 'dune.config', 'dune.build',
+             'dune-project', 'dune-workspace' or 'dune.dist'
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
@@ -144,9 +143,8 @@ Help query --help=plain
   
          INFO (absent=packages)
              The information to query. INFO must be one of 'name', 'packages',
-             'monorepo.opam', 'switch.opam', 'files', 'Makefile',
-             'dune.config', 'dune.build', 'dune-project', 'dune-workspace' or
-             'dune.dist'
+             'opam', 'files', 'Makefile', 'dune.config', 'dune.build',
+             'dune-project', 'dune-workspace' or 'dune.dist'
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)

--- a/test/functoria/query/run.t
+++ b/test/functoria/query/run.t
@@ -2,8 +2,8 @@ Query name
   $ ./config.exe query name
   noop
 
-Query global opam
-  $ ./config.exe query switch.opam
+Query opam file
+  $ ./config.exe query opam
   opam-version: "2.0"
   name: "noop"
   maintainer: "dummy"
@@ -27,36 +27,19 @@ Query global opam
   ]
   
   depends: [
-    
+    "dune-build-info" { switch != "" }
+    "fmt" { switch != "" }
+    "functoria-runtime" { switch != "" }
   ]
   
-
-
-Query local opam
-  $ ./config.exe query monorepo.opam
-  opam-version: "2.0"
-  name: "noop"
-  maintainer: "dummy"
-  authors: "dummy"
-  homepage: "dummy"
-  bug-reports: "dummy"
-  dev-repo: "git://dummy"
-  synopsis: "Unikernel noop - monorepo dependencies"
+  x-opam-monorepo-opam-provided: []
   
-  depends: [
-    "dune-build-info"
-    "fmt"
-    "functoria-runtime"
-  ]
-  
-  
-
 
 Query packages
   $ ./config.exe query packages
-  "dune-build-info"
-  "fmt"
-  "functoria-runtime"
+  "dune-build-info" { switch != "" }
+  "fmt" { switch != "" }
+  "functoria-runtime" { switch != "" }
 
 Query files
   $ ./config.exe query files
@@ -89,26 +72,26 @@ Query Makefile
   
   
   
-  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	echo " ↳ install external dependencies for monorepo"
   	$(OPAM) monorepo depext -y -l $<
   
   
-  $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam
+  $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
-  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   
-  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
   	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
-  	@$(OPAM) install $< --deps-only --yes
+  	@env OPAMVAR_switch="" $(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
   
   depends depend::
@@ -150,21 +133,21 @@ Query Makefile without depexts
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
-  $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam
+  $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
-  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   
-  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
   	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
-  	@$(OPAM) install $< --deps-only --yes --no-depexts
+  	@env OPAMVAR_switch="" $(OPAM) install $< --deps-only --yes --no-depexts
   
   depends depend::
   	@$(MAKE) --no-print-directory lock
@@ -206,26 +189,26 @@ Query Makefile with depext
   
   
   
-  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	echo " ↳ install external dependencies for monorepo"
   	$(OPAM) monorepo depext -y -l $<
   
   
-  $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam
+  $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
-  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   
-  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
   	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
-  	@$(OPAM) install $< --deps-only --yes
+  	@env OPAMVAR_switch="" $(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
   
   depends depend::

--- a/test/functoria/query/run.t
+++ b/test/functoria/query/run.t
@@ -87,7 +87,7 @@ Query Makefile
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
+  	@$(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
@@ -143,7 +143,7 @@ Query Makefile without depexts
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
+  	@$(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
@@ -204,7 +204,7 @@ Query Makefile with depext
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
+  	@$(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"

--- a/test/functoria/query/run.t
+++ b/test/functoria/query/run.t
@@ -80,7 +80,7 @@ Query Makefile
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
@@ -136,7 +136,7 @@ Query Makefile without depexts
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
@@ -197,7 +197,7 @@ Query Makefile with depext
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked

--- a/test/functoria/test_package.ml
+++ b/test/functoria/test_package.ml
@@ -24,11 +24,14 @@ let test_package_merge () =
 let test_package_pp () =
   let str = Fmt.to_to_string Package.pp in
   let str' = Fmt.to_to_string (Package.pp ~surround:"x") in
-  Alcotest.(check string) "pp(x)" (str x) {|foo { >= "1.0" & < "2.0" }|};
   Alcotest.(check string)
-    "pp(xy)" (str xy) {|foo { >= "0.9" & >= "1.0" & < "1.9" & < "2.0" }|};
-  Alcotest.(check string) "pp(z)" (str z) {|bar { >= "42" }|};
-  Alcotest.(check string) "pp'(x)" (str' x) {|xfoox { >= "1.0" & < "2.0" }|};
+    "pp(x)" (str x) {|foo { switch != "" & >= "1.0" & < "2.0" }|};
+  Alcotest.(check string)
+    "pp(xy)" (str xy)
+    {|foo { switch != "" & >= "0.9" & >= "1.0" & < "1.9" & < "2.0" }|};
+  Alcotest.(check string) "pp(z)" (str z) {|bar { switch != "" & >= "42" }|};
+  Alcotest.(check string)
+    "pp'(x)" (str' x) {|xfoox { switch != "" & >= "1.0" & < "2.0" }|};
   Alcotest.(check string) "pp(w)" (str w) {|foo { >= "1.0" & < "2.0" }|};
   Alcotest.(check string) "key(x)" (Package.key x) "monorepo-foo";
   Alcotest.(check string) "key(w)" (Package.key w) "switch-foo"

--- a/test/mirage/help/query.t
+++ b/test/mirage/help/query.t
@@ -107,9 +107,8 @@ Help query --man-format=plain
   
          INFO (absent=packages)
              The information to query. INFO must be one of 'name', 'packages',
-             'monorepo.opam', 'switch.opam', 'files', 'Makefile',
-             'dune.config', 'dune.build', 'dune-project', 'dune-workspace' or
-             'dune.dist'
+             'opam', 'files', 'Makefile', 'dune.config', 'dune.build',
+             'dune-project', 'dune-workspace' or 'dune.dist'
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
@@ -272,9 +271,8 @@ Help query --help=plain
   
          INFO (absent=packages)
              The information to query. INFO must be one of 'name', 'packages',
-             'monorepo.opam', 'switch.opam', 'files', 'Makefile',
-             'dune.config', 'dune.build', 'dune-project', 'dune-workspace' or
-             'dune.dist'
+             'opam', 'files', 'Makefile', 'dune.config', 'dune.build',
+             'dune-project', 'dune-workspace' or 'dune.dist'
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)

--- a/test/mirage/query/gen.ml
+++ b/test/mirage/query/gen.ml
@@ -47,8 +47,7 @@ let of_target target =
   List.iter gen
     [
       v "name" target;
-      v "monorepo.opam" target;
-      v "switch.opam" target;
+      v "opam" target;
       v "packages" target;
       v "files" target;
       v "Makefile" target;

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -70,7 +70,7 @@ Query makefile
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
+  	@$(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -63,7 +63,7 @@ Query makefile
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -55,26 +55,26 @@ Query makefile
   
   
   
-  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	echo " ↳ install external dependencies for monorepo"
   	$(OPAM) monorepo depext -y -l $<
   
   
-  $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam
+  $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
-  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   
-  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
   	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
-  	@$(OPAM) install $< --deps-only --yes
+  	@env OPAMVAR_switch="" $(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
   
   depends depend::

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -102,7 +102,7 @@ Query Makefile
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
+  	@$(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
@@ -157,7 +157,7 @@ Query Makefile without depexts
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
+  	@$(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
@@ -217,7 +217,7 @@ Query Makefile with depext
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
+  	@$(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -95,7 +95,7 @@ Query Makefile
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
@@ -150,7 +150,7 @@ Query Makefile without depexts
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
@@ -210,7 +210,7 @@ Query Makefile with depext
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -1,7 +1,7 @@
   $ export MIRAGE_DEFAULT_TARGET unix
 
-Query global opam
-  $ ./config.exe query --target hvt switch.opam
+Query opam file
+  $ ./config.exe query --target hvt opam
   opam-version: "2.0"
   name: "noop"
   maintainer: "dummy"
@@ -25,44 +25,33 @@ Query global opam
   ]
   
   depends: [
+    "lwt" { switch != "" }
     "mirage" { build & >= "4.0" & < "4.1.0" }
+    "mirage-bootvar-solo5" { switch != "" & >= "0.6.0" & < "0.7.0" }
+    "mirage-clock-solo5" { switch != "" & >= "4.2.0" & < "5.0.0" }
+    "mirage-logs" { switch != "" & >= "1.2.0" & < "2.0.0" }
+    "mirage-runtime" { switch != "" & >= "4.0" & < "4.1.0" }
+    "mirage-solo5" { switch != "" & >= "0.8.0" & < "0.9.0" }
     "ocaml" { build & >= "4.08.0" }
     "ocaml-solo5" { build & >= "0.8.0" }
     "opam-monorepo" { build & >= "0.2.6" }
   ]
   
+  x-opam-monorepo-opam-provided: ["mirage"
+  "ocaml""ocaml-solo5"
+  "opam-monorepo"]
+  
 
-Query local opam
-  $ ./config.exe query --target hvt monorepo.opam
-  opam-version: "2.0"
-  name: "noop"
-  maintainer: "dummy"
-  authors: "dummy"
-  homepage: "dummy"
-  bug-reports: "dummy"
-  dev-repo: "git://dummy"
-  synopsis: "Unikernel noop - monorepo dependencies"
-  
-  depends: [
-    "lwt"
-    "mirage-bootvar-solo5" { >= "0.6.0" & < "0.7.0" }
-    "mirage-clock-solo5" { >= "4.2.0" & < "5.0.0" }
-    "mirage-logs" { >= "1.2.0" & < "2.0.0" }
-    "mirage-runtime" { >= "4.0" & < "4.1.0" }
-    "mirage-solo5" { >= "0.8.0" & < "0.9.0" }
-  ]
-  
-  
 
 Query packages
   $ ./config.exe query --target hvt packages
-  "lwt"
+  "lwt" { switch != "" }
   "mirage" { build & >= "4.0" & < "4.1.0" }
-  "mirage-bootvar-solo5" { >= "0.6.0" & < "0.7.0" }
-  "mirage-clock-solo5" { >= "4.2.0" & < "5.0.0" }
-  "mirage-logs" { >= "1.2.0" & < "2.0.0" }
-  "mirage-runtime" { >= "4.0" & < "4.1.0" }
-  "mirage-solo5" { >= "0.8.0" & < "0.9.0" }
+  "mirage-bootvar-solo5" { switch != "" & >= "0.6.0" & < "0.7.0" }
+  "mirage-clock-solo5" { switch != "" & >= "4.2.0" & < "5.0.0" }
+  "mirage-logs" { switch != "" & >= "1.2.0" & < "2.0.0" }
+  "mirage-runtime" { switch != "" & >= "4.0" & < "4.1.0" }
+  "mirage-solo5" { switch != "" & >= "0.8.0" & < "0.9.0" }
   "ocaml" { build & >= "4.08.0" }
   "ocaml-solo5" { build & >= "0.8.0" }
   "opam-monorepo" { build & >= "0.2.6" }
@@ -98,26 +87,26 @@ Query Makefile
   
   
   
-  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	echo " ↳ install external dependencies for monorepo"
   	$(OPAM) monorepo depext -y -l $<
   
   
-  $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam
+  $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
-  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   
-  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
   	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
-  	@$(OPAM) install $< --deps-only --yes
+  	@env OPAMVAR_switch="" $(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
   
   depends depend::
@@ -158,21 +147,21 @@ Query Makefile without depexts
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
-  $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam
+  $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
-  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   
-  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
   	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
-  	@$(OPAM) install $< --deps-only --yes --no-depexts
+  	@env OPAMVAR_switch="" $(OPAM) install $< --deps-only --yes --no-depexts
   
   depends depend::
   	@$(MAKE) --no-print-directory lock
@@ -213,26 +202,26 @@ Query Makefile with depext
   
   
   
-  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	echo " ↳ install external dependencies for monorepo"
   	$(OPAM) monorepo depext -y -l $<
   
   
-  $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam
+  $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
-  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   
-  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
   	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
-  	@$(OPAM) install $< --deps-only --yes
+  	@env OPAMVAR_switch="" $(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
   
   depends depend::

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -104,7 +104,7 @@ Query Makefile
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
+  	@$(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
@@ -160,7 +160,7 @@ Query Makefile without depexts
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
+  	@$(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
@@ -221,7 +221,7 @@ Query Makefile with depext
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
-  	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
+  	@$(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -97,7 +97,7 @@ Query Makefile
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
@@ -153,7 +153,7 @@ Query Makefile without depexts
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
@@ -214,7 +214,7 @@ Query Makefile with depext
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -4,8 +4,8 @@ Query name
   $ ./config.exe query name
   noop
 
-Query global opam
-  $ ./config.exe query switch.opam
+Query opam file
+  $ ./config.exe query opam
   opam-version: "2.0"
   name: "noop"
   maintainer: "dummy"
@@ -29,45 +29,32 @@ Query global opam
   ]
   
   depends: [
+    "lwt" { switch != "" }
     "mirage" { build & >= "4.0" & < "4.1.0" }
+    "mirage-bootvar-unix" { switch != "" & >= "0.1.0" & < "0.2.0" }
+    "mirage-clock-unix" { switch != "" & >= "3.0.0" & < "5.0.0" }
+    "mirage-logs" { switch != "" & >= "1.2.0" & < "2.0.0" }
+    "mirage-runtime" { switch != "" & >= "4.0" & < "4.1.0" }
+    "mirage-unix" { switch != "" & >= "5.0.0" & < "6.0.0" }
     "ocaml" { build & >= "4.08.0" }
     "opam-monorepo" { build & >= "0.2.6" }
   ]
   
-
-
-Query local opam
-  $ ./config.exe query monorepo.opam
-  opam-version: "2.0"
-  name: "noop"
-  maintainer: "dummy"
-  authors: "dummy"
-  homepage: "dummy"
-  bug-reports: "dummy"
-  dev-repo: "git://dummy"
-  synopsis: "Unikernel noop - monorepo dependencies"
-  
-  depends: [
-    "lwt"
-    "mirage-bootvar-unix" { >= "0.1.0" & < "0.2.0" }
-    "mirage-clock-unix" { >= "3.0.0" & < "5.0.0" }
-    "mirage-logs" { >= "1.2.0" & < "2.0.0" }
-    "mirage-runtime" { >= "4.0" & < "4.1.0" }
-    "mirage-unix" { >= "5.0.0" & < "6.0.0" }
-  ]
-  
+  x-opam-monorepo-opam-provided: ["mirage"
+  "ocaml"
+  "opam-monorepo"]
   
 
 
 Query packages
   $ ./config.exe query packages
-  "lwt"
+  "lwt" { switch != "" }
   "mirage" { build & >= "4.0" & < "4.1.0" }
-  "mirage-bootvar-unix" { >= "0.1.0" & < "0.2.0" }
-  "mirage-clock-unix" { >= "3.0.0" & < "5.0.0" }
-  "mirage-logs" { >= "1.2.0" & < "2.0.0" }
-  "mirage-runtime" { >= "4.0" & < "4.1.0" }
-  "mirage-unix" { >= "5.0.0" & < "6.0.0" }
+  "mirage-bootvar-unix" { switch != "" & >= "0.1.0" & < "0.2.0" }
+  "mirage-clock-unix" { switch != "" & >= "3.0.0" & < "5.0.0" }
+  "mirage-logs" { switch != "" & >= "1.2.0" & < "2.0.0" }
+  "mirage-runtime" { switch != "" & >= "4.0" & < "4.1.0" }
+  "mirage-unix" { switch != "" & >= "5.0.0" & < "6.0.0" }
   "ocaml" { build & >= "4.08.0" }
   "opam-monorepo" { build & >= "0.2.6" }
 
@@ -102,26 +89,26 @@ Query Makefile
   
   
   
-  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	echo " ↳ install external dependencies for monorepo"
   	$(OPAM) monorepo depext -y -l $<
   
   
-  $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam
+  $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
-  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   
-  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
   	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
-  	@$(OPAM) install $< --deps-only --yes
+  	@env OPAMVAR_switch="" $(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
   
   depends depend::
@@ -163,21 +150,21 @@ Query Makefile without depexts
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
-  $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam
+  $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
-  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   
-  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
   	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
-  	@$(OPAM) install $< --deps-only --yes --no-depexts
+  	@env OPAMVAR_switch="" $(OPAM) install $< --deps-only --yes --no-depexts
   
   depends depend::
   	@$(MAKE) --no-print-directory lock
@@ -219,26 +206,26 @@ Query Makefile with depext
   
   
   
-  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  depext-lockfile: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	echo " ↳ install external dependencies for monorepo"
   	$(OPAM) monorepo depext -y -l $<
   
   
-  $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam
+  $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@$(MAKE) -s repo-add
   	@echo " ↳ generate lockfile for monorepo dependencies"
-  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME)-monorepo -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
+  	@$(OPAM) monorepo lock --build-only $(UNIKERNEL_NAME) -l $@ --ocaml-version $(shell ocamlc --version); (ret=$$?; $(MAKE) -s repo-rm && exit $$ret)
   
   lock::
-  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   
-  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-monorepo.opam.locked
+  pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo rependencies in the duniverse folder"
   	@$(OPAM) monorepo pull -l $< -r $(BUILD_DIR)
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME)-switch.opam
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
-  	@$(OPAM) install $< --deps-only --yes
+  	@env OPAMVAR_switch="" $(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
   
   depends depend::

--- a/test/opam-monorepo/dune
+++ b/test/opam-monorepo/dune
@@ -1,0 +1,6 @@
+(cram
+ (package mirage)
+ (deps
+  unikernel.opam
+  (source_tree mini-opam-overlays/)
+  (source_tree mini-opam-repository/)))

--- a/test/opam-monorepo/lock.t
+++ b/test/opam-monorepo/lock.t
@@ -1,0 +1,44 @@
+  $ opam-monorepo lock --require-cross-compile
+  ==> Using 1 locally scanned package as the target.
+  ==> Found 8 opam dependencies for the target package.
+  ==> Querying opam database for their metadata and Dune compatibility.
+  ==> Calculating exact pins for each of them.
+  ==> Wrote lockfile with 6 entries to $TESTCASE_ROOT/unikernel.opam.locked. You can now run opam monorepo pull to fetch their sources.
+
+  $ cat unikernel.opam.locked
+  opam-version: "2.0"
+  synopsis: "opam-monorepo generated lockfile"
+  maintainer: "opam-monorepo"
+  depends: [
+    "dune" {= "3.0.0"}
+    "fmt" {= "0.9.0+dune" & ?vendor}
+    "gmp" {= "6.2.9+dune" & ?vendor}
+    "mirage-runtime" {= "4.0.0" & ?vendor}
+    "ocaml-base-compiler" {= "4.13.1"}
+    "ocaml-solo5" {= "0.8.0"}
+    "solo5" {= "0.7.1"}
+    "zarith" {= "1.12+dune+mirage" & ?vendor}
+  ]
+  pin-depends: [
+    ["fmt.0.9.0+dune" "https://fmt.src"]
+    ["gmp.6.2.9+dune" "https://gmp.src"]
+    ["mirage-runtime.4.0.0" "https://mirage.src"]
+    ["ocaml-solo5.0.8.0" "https://ocaml-solo5.src"]
+    ["solo5.0.7.1" "https://solo5.src"]
+    ["zarith.1.12+dune+mirage" "https://github.com/ocaml/zarith.git"]
+  ]
+  x-opam-monorepo-duniverse-dirs: [
+    ["https://fmt.src" "fmt"]
+    ["https://github.com/ocaml/zarith.git" "zarith"]
+    ["https://gmp.src" "gmp"]
+    ["https://mirage.src" "mirage"]
+    ["https://ocaml-solo5.src" "ocaml-solo5"]
+    ["https://solo5.src" "solo5"]
+  ]
+  x-opam-monorepo-opam-provided: ["ocaml-solo5"]
+  x-opam-monorepo-opam-repositories: [
+    "file://$OPAM_MONOREPO_CWD/mini-opam-overlays"
+    "file://$OPAM_MONOREPO_CWD/mini-opam-repository"
+  ]
+  x-opam-monorepo-root-packages: ["unikernel"]
+  x-opam-monorepo-version: "0.3"

--- a/test/opam-monorepo/mini-opam-overlays/packages/fmt/fmt.0.9.0+dune/opam
+++ b/test/opam-monorepo/mini-opam-overlays/packages/fmt/fmt.0.9.0+dune/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+depends: ["dune"]
+dev-repo: "fmt"
+url {
+  src: "https://fmt.src"
+}

--- a/test/opam-monorepo/mini-opam-overlays/packages/zarith/zarith.1.12+dune+mirage/opam
+++ b/test/opam-monorepo/mini-opam-overlays/packages/zarith/zarith.1.12+dune+mirage/opam
@@ -1,0 +1,7 @@
+opam-version: "2.0"
+depends: ["dune" "gmp"]
+dev-repo: "zarith"
+url {
+  src: "https://github.com/ocaml/zarith.git"
+}
+tags: [ "cross-compile" ]

--- a/test/opam-monorepo/mini-opam-overlays/packages/zarith/zarith.1.13+dune/opam
+++ b/test/opam-monorepo/mini-opam-overlays/packages/zarith/zarith.1.13+dune/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+depends: ["dune"]
+dev-repo: "zarith"
+url {
+  src: "https://zarith.src"
+}

--- a/test/opam-monorepo/mini-opam-overlays/repo
+++ b/test/opam-monorepo/mini-opam-overlays/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/opam-monorepo/mini-opam-repository/packages/dune/dune.3.0.0/opam
+++ b/test/opam-monorepo/mini-opam-repository/packages/dune/dune.3.0.0/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+depends: ["ocaml-base-compiler"]
+dev-repo: ""
+url {
+  src: "https://mirage.src"
+}

--- a/test/opam-monorepo/mini-opam-repository/packages/gmp/gmp.6.2.9+dune/opam
+++ b/test/opam-monorepo/mini-opam-repository/packages/gmp/gmp.6.2.9+dune/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+depends: ["dune"]
+dev-repo: "gmp"
+url {
+  src: "https://gmp.src"
+}

--- a/test/opam-monorepo/mini-opam-repository/packages/mirage-runtime/mirage-runtime.4.0.0/opam
+++ b/test/opam-monorepo/mini-opam-repository/packages/mirage-runtime/mirage-runtime.4.0.0/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+depends: ["dune"]
+dev-repo: "mirage"
+url {
+  src: "https://mirage.src"
+}

--- a/test/opam-monorepo/mini-opam-repository/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
+++ b/test/opam-monorepo/mini-opam-repository/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+depends: []
+dev-repo: "base"
+url {
+  src: "https://base.src"
+}

--- a/test/opam-monorepo/mini-opam-repository/packages/ocaml-solo5/ocaml-solo5.0.8.0/opam
+++ b/test/opam-monorepo/mini-opam-repository/packages/ocaml-solo5/ocaml-solo5.0.8.0/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+depends: ["solo5"]
+dev-repo: "ocaml-solo5"
+url {
+  src: "https://ocaml-solo5.src"
+}

--- a/test/opam-monorepo/mini-opam-repository/packages/solo5/solo5.0.7.1/opam
+++ b/test/opam-monorepo/mini-opam-repository/packages/solo5/solo5.0.7.1/opam
@@ -1,0 +1,6 @@
+opam-version: "2.0"
+depends: []
+dev-repo: "solo5"
+url {
+  src: "https://solo5.src"
+}

--- a/test/opam-monorepo/mini-opam-repository/repo
+++ b/test/opam-monorepo/mini-opam-repository/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/test/opam-monorepo/unikernel.opam
+++ b/test/opam-monorepo/unikernel.opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "noop"
+maintainer: "dummy"
+authors: "dummy"
+homepage: "dummy"
+bug-reports: "dummy"
+dev-repo: "git://dummy"
+synopsis: "Unikernel noop - switch dependencies"
+description: """
+It assumes that local dependencies are already
+fetched.
+"""
+
+build: [
+[ "test" "configure"  ]
+[ "test" "build" ]
+]
+
+install: [
+[ "cp" "dist/f0.exe" "%{bin}%/f0" ]
+]
+
+depends: [
+    "ocaml-solo5"
+    "mirage-runtime"
+    "fmt"
+    "zarith"
+]
+
+x-opam-monorepo-opam-provided: [ "ocaml-solo5" ]
+
+x-opam-monorepo-opam-repositories: [
+    "file://$OPAM_MONOREPO_CWD/mini-opam-overlays"
+    "file://$OPAM_MONOREPO_CWD/mini-opam-repository"
+]


### PR DESCRIPTION
Opam-monorepo 3.0.0 has 3 changes that impacts the mirage tool:
- the `--root` option takes an absolute path for argument
- some packages can be marked as opam-installed: that means that the mirage tool can generate a single opam file that is understood both by opam and opam-monorepo
- by using the `--require-cross-compile` option, we'll be able to remove `mirage-opam-overlays` and move the mirage-specific packages (`zarith`) in `opam-overlays`

Mirage-skeleton changes: https://github.com/mirage/mirage-skeleton/pull/340
