### PR TITLE
Fix tests with opam-monorepo.0.3.2

### DIFF
--- a/mirage.opam
+++ b/mirage.opam
@@ -26,7 +26,7 @@ depends: [
   "astring"
   "logs"
   "mirage-runtime" {= version}
-  "opam-monorepo" {>= "0.3.0"}
+  "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
 ]

--- a/test/opam-monorepo/lock.t
+++ b/test/opam-monorepo/lock.t
@@ -3,7 +3,7 @@
   ==> Found 8 opam dependencies for the target package.
   ==> Querying opam database for their metadata and Dune compatibility.
   ==> Calculating exact pins for each of them.
-  ==> Wrote lockfile with 6 entries to $TESTCASE_ROOT/unikernel.opam.locked. You can now run opam monorepo pull to fetch their sources.
+  ==> Wrote lockfile with 4 entries to $TESTCASE_ROOT/unikernel.opam.locked. You can now run opam monorepo pull to fetch their sources.
 
   $ cat unikernel.opam.locked
   opam-version: "2.0"
@@ -23,17 +23,14 @@
     ["fmt.0.9.0+dune" "https://fmt.src"]
     ["gmp.6.2.9+dune" "https://gmp.src"]
     ["mirage-runtime.4.0.0" "https://mirage.src"]
-    ["ocaml-solo5.0.8.0" "https://ocaml-solo5.src"]
-    ["solo5.0.7.1" "https://solo5.src"]
     ["zarith.1.12+dune+mirage" "https://github.com/ocaml/zarith.git"]
   ]
+  x-opam-monorepo-cli-args: ["--require-cross-compile"]
   x-opam-monorepo-duniverse-dirs: [
     ["https://fmt.src" "fmt"]
     ["https://github.com/ocaml/zarith.git" "zarith"]
     ["https://gmp.src" "gmp"]
     ["https://mirage.src" "mirage"]
-    ["https://ocaml-solo5.src" "ocaml-solo5"]
-    ["https://solo5.src" "solo5"]
   ]
   x-opam-monorepo-opam-provided: ["ocaml-solo5"]
   x-opam-monorepo-opam-repositories: [


### PR DESCRIPTION
A simple `dune promote` with `opam-monorepo.0.3.2` (probably related with #1327)