### PR TITLE
adapt to new released mirage-xen & mirage-solo5

### DIFF
--- a/lib/mirage/target/solo5.ml
+++ b/lib/mirage/target/solo5.ml
@@ -13,7 +13,10 @@ type t = [ solo5_target | xen_target ]
 let cast = function #t as t -> t | _ -> invalid_arg "not a solo5 target."
 
 let build_packages =
-  [ Functoria.package ~min:"0.8.1" ~scope:`Switch ~build:true "ocaml-solo5" ]
+  [
+    Functoria.package ~min:"0.8.1" ~max:"0.9.0" ~scope:`Switch ~build:true
+      "ocaml-solo5";
+  ]
 
 let runtime_packages target =
   match target with

--- a/lib/mirage/target/solo5.ml
+++ b/lib/mirage/target/solo5.ml
@@ -13,13 +13,13 @@ type t = [ solo5_target | xen_target ]
 let cast = function #t as t -> t | _ -> invalid_arg "not a solo5 target."
 
 let build_packages =
-  [ Functoria.package ~min:"0.8.0" ~scope:`Switch ~build:true "ocaml-solo5" ]
+  [ Functoria.package ~min:"0.8.1" ~scope:`Switch ~build:true "ocaml-solo5" ]
 
 let runtime_packages target =
   match target with
   | #solo5_target ->
-      [ Functoria.package ~min:"0.8.0" ~max:"0.9.0" "mirage-solo5" ]
-  | #xen_target -> [ Functoria.package ~min:"7.1.0" ~max:"8.0.0" "mirage-xen" ]
+      [ Functoria.package ~min:"0.9.0" ~max:"0.10.0" "mirage-solo5" ]
+  | #xen_target -> [ Functoria.package ~min:"8.0.0" ~max:"9.0.0" "mirage-xen" ]
 
 let packages target = build_packages @ runtime_packages target
 let context_name _i = "solo5"

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -32,7 +32,7 @@ Query opam file
     "mirage-runtime" { ?monorepo & >= "4.1.0" & < "4.2.0" }
     "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
     "ocaml" { build & >= "4.08.0" }
-    "ocaml-solo5" { build & >= "0.8.1" }
+    "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
     "opam-monorepo" { build & >= "0.3.1" }
   ]
   
@@ -52,7 +52,7 @@ Query packages
   "mirage-runtime" { ?monorepo & >= "4.1.0" & < "4.2.0" }
   "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
   "ocaml" { build & >= "4.08.0" }
-  "ocaml-solo5" { build & >= "0.8.1" }
+  "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
   "opam-monorepo" { build & >= "0.3.1" }
 
 Query files

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -30,9 +30,9 @@ Query opam file
     "mirage-clock-solo5" { ?monorepo & >= "4.2.0" & < "5.0.0" }
     "mirage-logs" { ?monorepo & >= "1.2.0" & < "2.0.0" }
     "mirage-runtime" { ?monorepo & >= "4.1.0" & < "4.2.0" }
-    "mirage-solo5" { ?monorepo & >= "0.8.0" & < "0.9.0" }
+    "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
     "ocaml" { build & >= "4.08.0" }
-    "ocaml-solo5" { build & >= "0.8.0" }
+    "ocaml-solo5" { build & >= "0.8.1" }
     "opam-monorepo" { build & >= "0.3.1" }
   ]
   
@@ -50,9 +50,9 @@ Query packages
   "mirage-clock-solo5" { ?monorepo & >= "4.2.0" & < "5.0.0" }
   "mirage-logs" { ?monorepo & >= "1.2.0" & < "2.0.0" }
   "mirage-runtime" { ?monorepo & >= "4.1.0" & < "4.2.0" }
-  "mirage-solo5" { ?monorepo & >= "0.8.0" & < "0.9.0" }
+  "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
   "ocaml" { build & >= "4.08.0" }
-  "ocaml-solo5" { build & >= "0.8.0" }
+  "ocaml-solo5" { build & >= "0.8.1" }
   "opam-monorepo" { build & >= "0.3.1" }
 
 Query files


### PR DESCRIPTION
require ocaml-solo5 0.8.1 and mirage-solo5 0.9.0 and mirage-xen 8.0.0

as discussed in https://github.com/mirage/mirage-xen/pull/48

this PR may need to wait for https://github.com/ocaml/opam-repository/pull/21860 and https://github.com/ocaml/opam-repository/pull/21861