### PR TITLE
generated opam file: also run depext-lockfile

### DIFF
--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -153,7 +153,7 @@ module Make (P : S) = struct
         Fmt.(option ~none:(any "") (any " " ++ string))
         opts,
       (fun sub ->
-        Fmt.str {|make %a"lock" "pull"|}
+        Fmt.str {|make %a"lock" "depext-lockfile" "pull"|}
           Fmt.(option ~none:(any "") (any "\"-C" ++ Fpath.pp ++ any "\" "))
           sub),
       (fun sub unikernel ->

--- a/test/functoria/query/run.t
+++ b/test/functoria/query/run.t
@@ -32,7 +32,7 @@ Query opam file
   
   x-mirage-configure: ["sh" "-exc" "test configure --no-extra-repo"]
   
-  x-mirage-pre-build: [make "lock" "pull"]
+  x-mirage-pre-build: [make "lock" "depext-lockfile" "pull"]
   
   x-mirage-extra-repo: [
   ["opam-overlays" "https://github.com/dune-universe/opam-overlays.git"]

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -37,7 +37,7 @@ Query opam file
   
   x-mirage-configure: ["sh" "-exc" "mirage configure --target hvt --no-extra-repo"]
   
-  x-mirage-pre-build: [make "lock" "pull"]
+  x-mirage-pre-build: [make "lock" "depext-lockfile" "pull"]
   
   x-mirage-extra-repo: [
   ["opam-overlays" "https://github.com/dune-universe/opam-overlays.git"]

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -40,7 +40,7 @@ Query opam file
   
   x-mirage-configure: ["sh" "-exc" "mirage configure --no-extra-repo"]
   
-  x-mirage-pre-build: [make "lock" "pull"]
+  x-mirage-pre-build: [make "lock" "depext-lockfile" "pull"]
   
   x-mirage-extra-repo: [
   ["opam-overlays" "https://github.com/dune-universe/opam-overlays.git"]


### PR DESCRIPTION
this is useful so that the packages used via opam-monorepo to build the
unikernel have their external dependencies fulfilled.

please anyone (@samoht @dinosaure @TheLortex) who's interested in reviewing do a quick review -- with this change, I can finally compile (using orb) the static-website-tls example (well, https://github.com/mirage/ocaml-gmp/pull/15 is needed as well).

best and enjoy your holidays :)