### PR TITLE
mirage.mli: fix the chamelon example invocation

### DIFF
--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -389,7 +389,7 @@ val chamelon :
 
     {[
       $ dd if=/dev/zero if=db.img bs=1M count=1
-      $ chamelon format 512 db.img
+      $ chamelon format db.img 512
     ]} *)
 
 (** {2 Filesystem} *)


### PR DESCRIPTION
the command line utility expects the file name first, the block size as second
argument.