### PR TITLE
Improve functoria cli

### DIFF
--- a/lib/functoria/cli.mli
+++ b/lib/functoria/cli.mli
@@ -29,10 +29,14 @@ type 'a args = {
 }
 (** The type for global arguments. *)
 
-val peek_args : ?with_setup:bool -> mname:string -> string array -> unit args
+val default_args : unit args
+
+val peek_args :
+  ?with_setup:bool -> mname:string -> string array -> unit args option
 (** [peek_args ?with_setup argv] parses the global command-line arguments. If
     [with_setup] is set (by default it is), interprets [-v] and [--color] to
-    set-up the terminal configuration as a side-effect. *)
+    set-up the terminal configuration as a side-effect. Returns None if global
+    command-line arguments are invalid. *)
 
 val peek_output : string array -> string option
 (** [peek_full_eval argv] reads the [--output] option from [argv]; the return
@@ -131,7 +135,9 @@ val eval :
     help when either the 'help' subcommand or no subcommand is specified. *)
 
 type 'a result =
-  [ `Ok of 'a action | `Error of 'a args * [ `Exn | `Parse | `Term ] | `Version ]
+  [ `Ok of 'a action
+  | `Error of 'a args option * [ `Exn | `Parse | `Term ]
+  | `Version ]
 (** Similar to [Cmdliner.Term.result] but help is folded into [`Ok] and errors
     also carry global command-line parameters. *)
 

--- a/lib/functoria/context_cache.ml
+++ b/lib/functoria/context_cache.ml
@@ -66,8 +66,7 @@ let read file =
 let peek t term =
   match Cmdliner.Cmd.eval_peek_opts ~argv:t term with
   | Some c, _ | _, Ok (`Ok c) -> Some c
-  | _ ->
-      Fmt.failwith "Invalid cached configuration. Please run configure again."
+  | _ -> None
 
 let merge t term =
   let cache =

--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -505,7 +505,11 @@ module Make (P : S) = struct
        and root directory. *)
     let argv = Sys.argv in
     (* TODO: do not are parse the command-line twice *)
-    let args = Cli.peek_args ~with_setup:true ~mname:P.name argv in
+    let args =
+      (* tool.ml made sure that global arguments are correctly parsed before
+         running config.exe*)
+      Cli.peek_args ~with_setup:true ~mname:P.name argv |> Option.get
+    in
     let config_file = config_file args in
     let run () =
       let configure_cmd, pre_build_cmd, lock_location, build_cmd =

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -237,9 +237,15 @@ module Make (P : S) = struct
     | `Version ->
         Log.info (fun l -> l "version");
         Fmt.pr "%s\n%!" P.version
-    | `Error (t, _) ->
+    | `Error (Some t, _) ->
         Log.info (fun l -> l "error: %a" (Cli.pp_args pp_unit) t);
         run t @@ error t ?ppf:help_ppf ?err_ppf argv
+    | `Error (None, _) ->
+        let action =
+          handle_parse_args_no_config ?help_ppf ?err_ppf (`Msg "") argv
+        in
+        let args = Cli.default_args in
+        action_run args action |> exit_err args
     | `Ok t -> (
         Log.info (fun l -> l "run: %a" (Cli.pp_action pp_unit) t);
         let run = run (Cli.args t) in

--- a/test/functoria/context/config.ml
+++ b/test/functoria/context/config.ml
@@ -4,9 +4,21 @@ open Functoria
 let x = Impl.v ~packages:[ package "x" ] "X" job
 let y = Impl.v ~packages:[ package "y" ] "Y" job
 
-let target =
-  let doc = Key.Arg.info ~doc:"Target." [ "t" ] in
-  Key.(create "target" Arg.(opt string "x" doc))
+let target_conv : _ Cmdliner.Arg.conv =
+  let parser, printer = Cmdliner.Arg.enum [ ("y", `Y); ("x", `X) ] in
+  (parser, printer)
 
-let main = match_impl (Key.value target) ~default:y [ ("x", x) ]
+let target_serialize ppf = function
+  | `Y -> Fmt.pf ppf "`Y"
+  | `X -> Fmt.pf ppf "`X"
+
+let target =
+  let conv' =
+    Key.Arg.conv ~conv:target_conv ~runtime_conv:"target"
+      ~serialize:target_serialize
+  in
+  let doc = Key.Arg.info ~doc:"Target." [ "t" ] in
+  Key.(create "target" Arg.(opt conv' `X doc))
+
+let main = match_impl (Key.value target) ~default:y [ (`X, x) ]
 let () = register ~src:`None "noop" [ main ]

--- a/test/functoria/context/dune
+++ b/test/functoria/context/dune
@@ -4,4 +4,4 @@
 
 (cram
  (package functoria)
- (deps ./config.exe x.context y.context))
+ (deps ./config.exe x.context y.context z.context))

--- a/test/functoria/context/run.t
+++ b/test/functoria/context/run.t
@@ -52,5 +52,7 @@ Describe - y target  - x.context
 
 Bad context cache
   $ ./config.exe configure -t nonexistent --context-file=z.context
-  Fatal error: exception Failure("Invalid cached configuration. Please run configure again.")
-  [2]
+  test: option '-t': invalid value 'nonexistent', expected either 'y' or 'x'
+  Usage: test configure [OPTION]…
+  Try 'test configure --help' or 'test --help' for more information.
+  [1]

--- a/test/functoria/context/run.t
+++ b/test/functoria/context/run.t
@@ -49,3 +49,8 @@ Describe - y target  - x.context
   Keys       target=y,
              vote=cat (default),
              warn_error=false (default)
+
+Bad context cache
+  $ ./config.exe configure -t nonexistent --context-file=z.context
+  Fatal error: exception Failure("Invalid cached configuration. Please run configure again.")
+  [2]

--- a/test/functoria/context/z.context
+++ b/test/functoria/context/z.context
@@ -1,0 +1,2 @@
+-t
+nonexistent

--- a/test/functoria/tool/run.t
+++ b/test/functoria/tool/run.t
@@ -395,3 +395,8 @@ Default
              ./test/dune-workspace.config' (ok)
   * Is_file? test/context -> false
   * Run_cmd_cli '_build/default/./config.exe --dry-run' (ok)
+
+Parsing error in global arguments
+  $ ./test.exe -f
+  Fatal error: exception File "lib/functoria/cli.ml", line 467, characters 9-15: Assertion failed
+  [2]

--- a/test/functoria/tool/run.t
+++ b/test/functoria/tool/run.t
@@ -397,6 +397,16 @@ Default
   * Run_cmd_cli '_build/default/./config.exe --dry-run' (ok)
 
 Parsing error in global arguments
-  $ ./test.exe -f
-  Fatal error: exception File "lib/functoria/cli.ml", line 467, characters 9-15: Assertion failed
-  [2]
+  $ ./test.exe -o
+  test: unknown option '-o'.
+        unknown option '--dry-run'.
+  Usage: test [COMMAND] …
+  Try 'test --help' for more information.
+  [1]
+
+Parsing error in global arguments, with subcommand
+  $ ./test.exe configure -o
+  test: option '-o' needs an argument
+  Usage: test configure [OPTION]…
+  Try 'test configure --help' or 'test --help' for more information.
+  [1]


### PR DESCRIPTION
The two commits are fixing two separate issues:

## Context cache: don't fail if configuration is invalid

Fixes https://github.com/mirage/mirage/issues/1344

Basically, the tool can create an invalid context cache file if the command is wrong, as a parse error will still trigger re-execution of the `config.exe`. However this `config.exe` will call into `Context_cache.peek` which will then fail with `Invalid cached configuration. Please run configure again.`. The fix is to simply let `peek` return `None` in that situation. 

Another solution might be to let `config.exe` store arguments the context cache only after verifying that it is valid. That means a bit of refactoring as the tool is currently the one in charge of it.

## handle the situation when global arguments have a parse error

Currently, there's an `assert false` in `Cli.peek_args`:
```ocaml
let peek_args ?(with_setup = false) ~mname argv =
   let args =
     Subcommands.T.args { with_setup; mname; context = Term.const () }
   in
   match Cmd.eval_peek_opts ~argv args with
   | _, Ok (`Ok b) | Some b, _ -> b
   | _ -> assert false
```

This means that incorrectly using global configuration options lead to an assertion failure. (`mirage configure -f` without argument for example). This PR changes the function to return an `option` type, so that in `Tool.run_with_argv` it can detect that situation, and display the parse error instead of failing.