### PR TITLE
Update to Resolver_mirage changes

### DIFF
--- a/lib/functoria/install.mli
+++ b/lib/functoria/install.mli
@@ -35,7 +35,7 @@ val pp_opam : ?subdir:Fpath.t -> unit -> t Fmt.t
 (** Print the opam rules to install [t]. If [~subdir] is provided, this will be
     used as prefix (i.e. if your unikernel is in the "tutorial/hello/"
     subdirectory (which is passed as [~subdir], the install instructions will
-    use "cp tutorial/hello/dist/hello.hvt %{bin}%/hello.hvt"). *)
+    use [cp tutorial/hello/dist/hello.hvt %{bin}%/hello.hvt]). *)
 
 val dune :
   context_name_for_bin:string -> context_name_for_etc:string -> t -> Dune.t

--- a/lib/mirage/impl/mirage_impl_conduit.ml
+++ b/lib/mirage/impl/mirage_impl_conduit.ml
@@ -6,7 +6,7 @@ open Mirage_impl_random
 type conduit = Conduit
 
 let conduit = Type.v Conduit
-let pkg = package ~min:"5.1.0" ~max:"6.0.0" "conduit-mirage"
+let pkg = package ~min:"6.0.0" ~max:"7.0.0" "conduit-mirage"
 
 let tcp =
   let packages = [ pkg ] in

--- a/lib/mirage/impl/mirage_impl_resolver.ml
+++ b/lib/mirage/impl/mirage_impl_resolver.ml
@@ -16,7 +16,7 @@ let resolver_unix_system =
     Key.(if_ is_unix)
       [
         Mirage_impl_conduit.pkg;
-        package ~min:"4.0.0" ~max:"6.0.0" "conduit-lwt-unix";
+        package ~min:"4.0.0" ~max:"7.0.0" "conduit-lwt-unix";
       ]
       []
   in

--- a/lib/mirage/impl/mirage_impl_resolver.ml
+++ b/lib/mirage/impl/mirage_impl_resolver.ml
@@ -35,17 +35,16 @@ let resolver_dns_conf ~ns =
     | [ _r; _t; _m; _p; stack ] ->
         Fmt.str
           "let nameservers = %a in@;\
-           let res = %s.v ?nameservers %s in@;\
-           let () = match res with Ok _ -> () | Error (`Msg e) -> invalid_arg e in@;
-           Lwt.return res@;"
+           match %s.v ?nameservers %s with@;\
+           | Ok _ as r -> Lwt.return r@;\
+           | Error (`Msg e) -> invalid_arg e in@;"
           pp_key ns modname stack
     | _ -> failwith (connect_err "resolver" 3)
   in
   impl ~packages ~keys ~connect "Resolver_mirage.Make"
     (random @-> time @-> mclock @-> pclock @-> stackv4v6 @-> resolver)
 
-let resolver_dns ?ns ?(time = default_time)
-    ?(mclock = default_monotonic_clock) ?(pclock = default_posix_clock)
-    ?(random = default_random) stack =
+let resolver_dns ?ns ?(time = default_time) ?(mclock = default_monotonic_clock)
+    ?(pclock = default_posix_clock) ?(random = default_random) stack =
   let ns = Key.resolver ?default:ns () in
   resolver_dns_conf ~ns $ random $ time $ mclock $ pclock $ stack

--- a/lib/mirage/impl/mirage_impl_resolver.ml
+++ b/lib/mirage/impl/mirage_impl_resolver.ml
@@ -37,7 +37,7 @@ let resolver_dns_conf ~ns =
           "let nameservers = %a in@;\
            match %s.v ?nameservers %s with@;\
            | Ok _ as r -> Lwt.return r@;\
-           | Error (`Msg e) -> invalid_arg e in@;"
+           | Error (`Msg e) -> invalid_arg e@;"
           pp_key ns modname stack
     | _ -> failwith (connect_err "resolver" 3)
   in

--- a/lib/mirage/impl/mirage_impl_resolver.ml
+++ b/lib/mirage/impl/mirage_impl_resolver.ml
@@ -36,7 +36,7 @@ let resolver_dns_conf ~ns =
         Fmt.str
           "let nameservers = %a in@;\
            match %s.v ?nameservers %s with@;\
-           | Ok _ as r -> Lwt.return r@;\
+           | Ok r -> Lwt.return r@;\
            | Error (`Msg e) -> invalid_arg e@;"
           pp_key ns modname stack
     | _ -> failwith (connect_err "resolver" 3)

--- a/lib/mirage/impl/mirage_impl_resolver.mli
+++ b/lib/mirage/impl/mirage_impl_resolver.mli
@@ -9,8 +9,7 @@ open Mirage_impl_time
 val resolver : resolver typ
 
 val resolver_dns :
-  ?ns:Ipaddr.t ->
-  ?ns_port:int ->
+  ?ns:string list ->
   ?time:time impl ->
   ?mclock:mclock impl ->
   ?pclock:pclock impl ->

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -590,8 +590,7 @@ type resolver
 val resolver : resolver typ
 
 val resolver_dns :
-  ?ns:Ipaddr.t ->
-  ?ns_port:int ->
+  ?ns:string list ->
   ?time:time impl ->
   ?mclock:mclock impl ->
   ?pclock:pclock impl ->

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -412,11 +412,7 @@ let ipv6_only ?group () =
 
 let resolver ?default () =
   let doc = Fmt.str "DNS resolver (default to anycast.censurfridns.dk)" in
-  create_simple ~doc ~default Arg.(some ip_address) "resolver"
-
-let resolver_port ?(default = 53) () =
-  let doc = Fmt.str "DNS resolver port" in
-  create_simple ~doc ~default Arg.int "resolver-port"
+  create_simple ~doc ~default Arg.(some (list string)) "resolver"
 
 let syslog default =
   let doc = Fmt.str "syslog server" in

--- a/lib/mirage/mirage_key.mli
+++ b/lib/mirage/mirage_key.mli
@@ -157,11 +157,8 @@ val ipv4_only : ?group:string -> unit -> bool key
 val ipv6_only : ?group:string -> unit -> bool key
 (** An option for dual stack to only use IPv6. *)
 
-val resolver : ?default:Ipaddr.t -> unit -> Ipaddr.t option key
-(** The address of the DNS resolver to use. *)
-
-val resolver_port : ?default:int -> unit -> int key
-(** The port of the DNS resolver. *)
+val resolver : ?default:string list -> unit -> string list option key
+(** The address of the DNS resolver to use. See $REFERENCE for format. *)
 
 val syslog : Ipaddr.t option -> Ipaddr.t option key
 (** The address to send syslog frames to. *)


### PR DESCRIPTION
The parsing of nameserver list is delayed until runtime due to ease of creation of tls authenticator with ca-certs available. Also allow specifying multiple nameservers. The `resolver` and `resolver-port` keys are melded into one key `resolver` that also supports specifying TLS nameservers. The (complicated) format should be documented.

- [x] Depends on https://github.com/mirage/ocaml-conduit/pull/415,
- [ ] The format is documented.

