### PR TITLE
Fix Makefile generation to work with beta versions of the compiler

### DIFF
--- a/lib/functoria/makefile.ml
+++ b/lib/functoria/makefile.ml
@@ -116,7 +116,7 @@ all::
 
 $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam%a
 	@@echo " ↳ generate lockfile for monorepo dependencies"
-	@@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@@ --ocaml-version $(shell ocamlc --version)%a
+	@@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo lock --require-cross-compile --build-only $(UNIKERNEL_NAME) -l $@@ --ocaml-version $(shell ocamlc --version | sed 's/~.*//' | sed 's/\+.*//')%a
 
 lock::
 	@@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked


### PR DESCRIPTION
I'm not sure it's the best solution but it seems to work at least (though opam-monorepo does not work with OCaml 5.0 for some reason)

A cleaner solution would be for opam-monorepo to do that instead but i don't know its code source or the purpose of this `--ocaml-version` argument so i'll let this exercise to the people who know.