### PR TITLE
Add a new device to be able to easily start an HTTP (including ALPN) server

### DIFF
--- a/lib/mirage/impl/mirage_impl_http.ml
+++ b/lib/mirage/impl/mirage_impl_http.ml
@@ -3,6 +3,7 @@ open Mirage_impl_pclock
 open Mirage_impl_misc
 open Mirage_impl_conduit
 open Mirage_impl_resolver
+open Mirage_impl_tcp
 
 type http = HTTP
 
@@ -41,3 +42,20 @@ let httpaf_server conduit =
   let extra_deps = [ dep conduit ] in
   impl ~packages ~connect:(connect "httpaf") ~extra_deps
     "Httpaf_mirage.Server_with_conduit" http
+
+type http_server = HTTP_server
+
+let http_server = Type.v HTTP_server
+
+let paf_server port =
+  let connect _ modname = function
+    | [ tcpv4v6 ] ->
+        Fmt.str {ocaml|%s.init ~port:%a %s|ocaml} modname Key.serialize_call
+          (Key.v port) tcpv4v6
+    | _ -> assert false
+  in
+  let packages =
+    [ package "paf" ~sublibs:[ "mirage" ] ~min:"0.3.0" ~max:"0.4.0" ]
+  in
+  let keys = [ Key.v port ] in
+  impl ~connect ~packages ~keys "Paf_mirage.Make" (tcpv4v6 @-> http_server)

--- a/lib/mirage/impl/mirage_impl_http.mli
+++ b/lib/mirage/impl/mirage_impl_http.mli
@@ -15,3 +15,10 @@ val cohttp_client :
   Mirage_impl_resolver.resolver impl ->
   Mirage_impl_conduit.conduit impl ->
   http_client impl
+
+type http_server
+
+val http_server : http_server typ
+
+val paf_server :
+  int Mirage_key.key -> (Mirage_impl_tcp.tcpv4v6 -> http_server) impl

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -240,6 +240,11 @@ type http_client = Mirage_impl_http.http_client
 let http_client = Mirage_impl_http.http_client
 let cohttp_client = Mirage_impl_http.cohttp_client
 
+type http_server = Mirage_impl_http.http_server
+
+let http_server = Mirage_impl_http.http_server
+let paf_server ~port tcpv4v6 = Mirage_impl_http.paf_server port $ tcpv4v6
+
 type argv = Functoria.argv
 
 let argv = Functoria.argv

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -751,6 +751,55 @@ val cohttp_client :
   ?pclock:pclock impl -> resolver impl -> conduit impl -> http_client impl
 (** [cohttp_server] starts a Cohttp server. *)
 
+type http_server
+
+val http_server : http_server typ
+
+val paf_server : port:int key -> tcpv4v6 impl -> http_server impl
+(** [paf_server ~port tcpv4v6] creates an instance which will start to
+    {i listen} on the given [port]. With this instance and the produced module
+    [HTTP_server], the user can initiate:
+
+    - a simple HTTP server
+    - a simple HTTPS server (with a TLS configuration)
+    - a simple ALPN ([http/1.1] & [h2]) server with TLS
+
+    This is a simple example of how to launch an HTTP server: {b unikernel.ml}
+
+    {[
+      module Make (HTTP_server : Paf_mirage.S) = struct
+        let error_handler (ipaddr, port) ?request error send =
+          ...
+
+        let request_handler
+          : HTTP_server.TCP.flow -> Ipaddr.t * int -> Httpaf.Reqd.t -> unit
+          = fun socket (ipaddr, port) reqd ->
+            ...
+
+        let start http_server =
+          let service = HTTP_service ~error_handler request_handler in
+          let `Initialized thread = HTTP_server.serve service http_server in
+          thread
+      end
+    ]}
+
+    {b config.ml}
+
+    {[
+      open Mirage
+
+      let port =
+        let doc =
+          Key.Arg.info ~doc:"Port of the HTTP service." [ "p"; "port" ]
+        in
+        Key.(create "port" Arg.(opt int 8080 doc))
+
+      let main = foreign "Unikernel.Make" (http_server @-> job)
+      let stackv4v6 = generic_stackv4v6 default_network
+      let http_server = http_server ~port (tcpv4v6_of_stackv4v6 stackv4v6)
+      let () = register "main" [ main $ http_server ]
+    ]} *)
+
 (** {2 Argv configuration} *)
 
 type argv = Functoria.argv


### PR DESCRIPTION
https://mirage.io starts to use it and we continue to improve the support of HTTP, HTTPS and ALPN through the `paf.mirage` package. Several people asks to have an easy way to start an HTTP service without too much complexities (mainly about composition of functors). This new device helps the end-user to start from nothing a simple HTTP server and he/she is able to switch to an HTTP with TLS server or, moreover, an ALPN server which handles `http/1.1` and `h2` protocols through TLS.

A documentation was added to show a minimal example of how to make a HTTP server. Probably, we can improve the example with a simple "Hello World!".