### PR TITLE
Replace 'echo -e' with 'printf' in makefiles

### DIFF
--- a/lib/functoria/makefile.ml
+++ b/lib/functoria/makefile.ml
@@ -53,7 +53,8 @@ let opam_repo_add_rule extra =
 let opam_repo_remove_rule extra =
   let buf = Buffer.create 0x100 in
   let ppf = Format.formatter_of_buffer buf in
-  Fmt.pf ppf {|repo-rm:
+  Fmt.pf ppf
+    {|repo-rm:
 	@@printf "\e[2mremoving overlay repository %a\e[0m\n"
 |}
     Fmt.(brackets (list ~sep:(any ", ") (using fst string)))

--- a/lib/functoria/makefile.ml
+++ b/lib/functoria/makefile.ml
@@ -39,7 +39,7 @@ let opam_repo_add_rule extra =
   let ppf = Format.formatter_of_buffer buf in
   Fmt.pf ppf
     {|repo-add:
-	@@echo -e "\e[2musing overlay repository mirage: %a \e[0m"
+	@@printf "\e[2musing overlay repository mirage: %a \e[0m\n"
 |}
     Fmt.(brackets (list ~sep:(any ", ") (using fst string)))
     extra;
@@ -54,7 +54,7 @@ let opam_repo_remove_rule extra =
   let buf = Buffer.create 0x100 in
   let ppf = Format.formatter_of_buffer buf in
   Fmt.pf ppf {|repo-rm:
-	@@echo -e "\e[2mremoving overlay repository %a\e[0m"
+	@@printf "\e[2mremoving overlay repository %a\e[0m\n"
 |}
     Fmt.(brackets (list ~sep:(any ", ") (using fst string)))
     extra;

--- a/test/functoria/query/run.t
+++ b/test/functoria/query/run.t
@@ -67,13 +67,13 @@ Query Makefile
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@echo -e "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m"
+  	@printf "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@echo -e "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m"
+  	@printf "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
@@ -129,13 +129,13 @@ Query Makefile without depexts
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm
   
   repo-add:
-  	@echo -e "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m"
+  	@printf "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@echo -e "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m"
+  	@printf "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
@@ -184,13 +184,13 @@ Query Makefile with depext
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@echo -e "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m"
+  	@printf "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@echo -e "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m"
+  	@printf "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -43,13 +43,13 @@ Query makefile
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@echo -e "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m"
+  	@printf "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@echo -e "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m"
+  	@printf "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -82,13 +82,13 @@ Query Makefile
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@echo -e "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m"
+  	@printf "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@echo -e "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m"
+  	@printf "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
@@ -143,13 +143,13 @@ Query Makefile without depexts
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm
   
   repo-add:
-  	@echo -e "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m"
+  	@printf "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@echo -e "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m"
+  	@printf "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
@@ -197,13 +197,13 @@ Query Makefile with depext
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@echo -e "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m"
+  	@printf "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@echo -e "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m"
+  	@printf "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -84,13 +84,13 @@ Query Makefile
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@echo -e "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m"
+  	@printf "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@echo -e "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m"
+  	@printf "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
@@ -146,13 +146,13 @@ Query Makefile without depexts
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm
   
   repo-add:
-  	@echo -e "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m"
+  	@printf "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@echo -e "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m"
+  	@printf "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
@@ -201,13 +201,13 @@ Query Makefile with depext
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@echo -e "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m"
+  	@printf "\e[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \e[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@echo -e "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m"
+  	@printf "\e[2mremoving overlay repository [opam-overlays, mirage-overlays]\e[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
   	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   


### PR DESCRIPTION
On macos, echo does not have a -e flag, which results in the -e and ansi escape sequences being printed literally. The printf command handles ansi escape sequences by default.