### PR TITLE
Introduce an ALPN client and Mimic

### DIFF
--- a/lib/mirage/impl/mirage_impl_git.ml
+++ b/lib/mirage/impl/mirage_impl_git.ml
@@ -2,7 +2,10 @@ open Functoria
 open Mirage_impl_time
 open Mirage_impl_mclock
 open Mirage_impl_pclock
+open Mirage_impl_stack
 open Mirage_impl_tcp
+open Mirage_impl_dns
+open Mirage_impl_happy_eyeballs
 open Mirage_impl_mimic
 
 type git_client = Git_client
@@ -18,6 +21,16 @@ let git_merge_clients =
   in
   impl ~packages ~connect "Mimic.Merge"
     (git_client @-> git_client @-> git_client)
+
+let git_happy_eyeballs =
+  let packages = [ package "mimic-happy-eyeballs" ~min:"0.0.5" ] in
+  let connect _ modname = function
+    | [ _stackv4v6; _dns_client; happy_eyeballs ] ->
+        Fmt.str {ocaml|%s.connect %s|ocaml} modname happy_eyeballs
+    | _ -> assert false
+  in
+  impl ~packages ~connect "Mimic_happy_eyeballs.Make"
+    (stackv4v6 @-> dns_client @-> happy_eyeballs @-> mimic)
 
 let git_tcp =
   let packages =

--- a/lib/mirage/impl/mirage_impl_git.ml
+++ b/lib/mirage/impl/mirage_impl_git.ml
@@ -2,10 +2,8 @@ open Functoria
 open Mirage_impl_time
 open Mirage_impl_mclock
 open Mirage_impl_pclock
-open Mirage_impl_stack
 open Mirage_impl_tcp
-open Mirage_impl_dns
-open Mirage_impl_happy_eyeballs
+open Mirage_impl_mimic
 
 type git_client = Git_client
 
@@ -21,16 +19,6 @@ let git_merge_clients =
   impl ~packages ~connect "Mimic.Merge"
     (git_client @-> git_client @-> git_client)
 
-let git_happy_eyeballs =
-  let packages = [ package "mimic-happy-eyeballs" ~min:"0.0.5" ] in
-  let connect _ modname = function
-    | [ _stackv4v6; _dns_client; happy_eyeballs ] ->
-        Fmt.str {ocaml|%s.connect %s|ocaml} modname happy_eyeballs
-    | _ -> assert false
-  in
-  impl ~packages ~connect "Mimic_happy_eyeballs.Make"
-    (stackv4v6 @-> dns_client @-> happy_eyeballs @-> git_client)
-
 let git_tcp =
   let packages =
     [ package "git-mirage" ~sublibs:[ "tcp" ] ~min:"3.10.0" ~max:"3.11.0" ]
@@ -40,7 +28,7 @@ let git_tcp =
     | _ -> assert false
   in
   impl ~packages ~connect "Git_mirage_tcp.Make"
-    (tcpv4v6 @-> git_client @-> git_client)
+    (tcpv4v6 @-> mimic @-> git_client)
 
 let git_ssh ?authenticator key =
   let packages =
@@ -66,7 +54,7 @@ let git_ssh ?authenticator key =
     | None -> [ Key.v key ]
   in
   impl ~packages ~connect ~keys "Git_mirage_ssh.Make"
-    (mclock @-> tcpv4v6 @-> time @-> git_client @-> git_client)
+    (mclock @-> tcpv4v6 @-> time @-> mimic @-> git_client)
 
 let git_http ?authenticator headers =
   let packages =
@@ -104,4 +92,4 @@ let git_http ?authenticator headers =
     | _ -> assert false
   in
   impl ~packages ~connect ~keys "Git_mirage_http.Make"
-    (pclock @-> tcpv4v6 @-> git_client @-> git_client)
+    (pclock @-> tcpv4v6 @-> mimic @-> git_client)

--- a/lib/mirage/impl/mirage_impl_http.ml
+++ b/lib/mirage/impl/mirage_impl_http.ml
@@ -4,6 +4,7 @@ open Mirage_impl_misc
 open Mirage_impl_conduit
 open Mirage_impl_resolver
 open Mirage_impl_tcp
+open Mirage_impl_mimic
 
 type http = HTTP
 
@@ -59,3 +60,17 @@ let paf_server port =
   in
   let keys = [ Key.v port ] in
   impl ~connect ~packages ~keys "Paf_mirage.Make" (tcpv4v6 @-> http_server)
+
+type alpn_client = ALPN_client
+
+let alpn_client = Type.v ALPN_client
+
+let paf_client =
+  let packages = [ package "http-mirage-client" ~min:"0.0.1" ~max:"0.1.0" ] in
+  let connect _ modname = function
+    | [ _pclock; _tcpv4v6; ctx ] ->
+        Fmt.str {ocaml|%s.connect %s|ocaml} modname ctx
+    | _ -> assert false
+  in
+  impl ~connect ~packages "Http_mirage_client.Make"
+    (pclock @-> tcpv4v6 @-> mimic @-> alpn_client)

--- a/lib/mirage/impl/mirage_impl_http.mli
+++ b/lib/mirage/impl/mirage_impl_http.mli
@@ -22,3 +22,14 @@ val http_server : http_server typ
 
 val paf_server :
   int Mirage_key.key -> (Mirage_impl_tcp.tcpv4v6 -> http_server) impl
+
+type alpn_client
+
+val alpn_client : alpn_client typ
+
+val paf_client :
+  (Mirage_impl_pclock.pclock ->
+  Mirage_impl_tcp.tcpv4v6 ->
+  Mirage_impl_mimic.mimic ->
+  alpn_client)
+  impl

--- a/lib/mirage/impl/mirage_impl_mimic.ml
+++ b/lib/mirage/impl/mirage_impl_mimic.ml
@@ -1,0 +1,27 @@
+open Functoria
+open Mirage_impl_dns
+open Mirage_impl_stack
+open Mirage_impl_happy_eyeballs
+
+type mimic = Mimic
+
+let mimic = Type.v Mimic
+
+let mimic_merge =
+  let packages = [ package "mimic" ] in
+  let connect _ _modname = function
+    | [ a; b ] -> Fmt.str "Lwt.return (Mimic.merge %s %s)" a b
+    | [ x ] -> Fmt.str "%s.ctx" x
+    | _ -> Fmt.str "Lwt.return Mimic.empty"
+  in
+  impl ~packages ~connect "Mimic.Merge" (mimic @-> mimic @-> mimic)
+
+let mimic_happy_eyeballs =
+  let packages = [ package "mimic-happy-eyeballs" ~min:"0.0.5" ] in
+  let connect _ modname = function
+    | [ _stackv4v6; _dns_client; happy_eyeballs ] ->
+        Fmt.str {ocaml|%s.connect %s|ocaml} modname happy_eyeballs
+    | _ -> assert false
+  in
+  impl ~packages ~connect "Mimic_happy_eyeballs.Make"
+    (stackv4v6 @-> dns_client @-> happy_eyeballs @-> mimic)

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -248,6 +248,13 @@ type http_server = Mirage_impl_http.http_server
 let http_server = Mirage_impl_http.http_server
 let paf_server ~port tcpv4v6 = Mirage_impl_http.paf_server port $ tcpv4v6
 
+type alpn_client = Mirage_impl_http.alpn_client
+
+let alpn_client = Mirage_impl_http.alpn_client
+
+let paf_client ?(pclock = default_posix_clock) tcpv4v6 mimic =
+  Mirage_impl_http.paf_client $ pclock $ tcpv4v6 $ mimic
+
 type argv = Functoria.argv
 
 let argv = Functoria.argv
@@ -265,15 +272,22 @@ type tracing = Mirage_impl_tracing.tracing
 let tracing = Mirage_impl_tracing.tracing
 let mprof_trace = Mirage_impl_tracing.mprof_trace
 
+type mimic = Mirage_impl_mimic.mimic
+
+let mimic = Mirage_impl_mimic.mimic
+
+let mimic_happy_eyeballs stackv4v6 dns_client happy_eyeballs =
+  Mirage_impl_mimic.mimic_happy_eyeballs
+  $ stackv4v6
+  $ dns_client
+  $ happy_eyeballs
+
 type git_client = Mirage_impl_git.git_client
 
 let git_client = Mirage_impl_git.git_client
 
 let merge_git_clients ctx0 ctx1 =
   Mirage_impl_git.git_merge_clients $ ctx0 $ ctx1
-
-let git_happy_eyeballs stackv4v6 dns_client happy_eyeballs =
-  Mirage_impl_git.git_happy_eyeballs $ stackv4v6 $ dns_client $ happy_eyeballs
 
 let git_tcp tcpv4v6 ctx = Mirage_impl_git.git_tcp $ tcpv4v6 $ ctx
 

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -289,6 +289,9 @@ let git_client = Mirage_impl_git.git_client
 let merge_git_clients ctx0 ctx1 =
   Mirage_impl_git.git_merge_clients $ ctx0 $ ctx1
 
+let git_happy_eyeballs stackv4v6 dns_client happy_eyeballs =
+  Mirage_impl_git.git_happy_eyeballs $ stackv4v6 $ dns_client $ happy_eyeballs
+
 let git_tcp tcpv4v6 ctx = Mirage_impl_git.git_tcp $ tcpv4v6 $ ctx
 
 let git_ssh ?authenticator ~key ?(mclock = default_monotonic_clock)

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -995,6 +995,10 @@ val merge_git_clients : git_client impl -> git_client impl -> git_client impl
 (** [merge_git_clients a b] is a device that can connect to remote Git
     repositories using either the device [a] or the device [b]. *)
 
+val git_happy_eyeballs :
+  stackv4v6 impl -> dns_client impl -> happy_eyeballs impl -> mimic impl
+(** @deprecated You should use {!val:mimic_happy_eyeballs}. *)
+
 val git_tcp : tcpv4v6 impl -> mimic impl -> git_client impl
 (** [git_tcp tcpv4v6 dns] is a device able to connect to a remote Git repository
     using TCP/IP. *)

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -778,6 +778,42 @@ val conduit : conduit typ
 val conduit_direct :
   ?tls:bool -> ?random:random impl -> stackv4v6 impl -> conduit impl
 
+(** {2 Mimic devices}
+
+    For some implementations which requires to communicate with an external
+    resources (such as a webserver or a git server), we must hide the underlying
+    implementations that depend on the {i target} (such as the network stack)
+    and are necessary for these implementations.
+
+    The aim of [mimic] is to offer first of all the ability to initiate a TCP/IP
+    connection independently of the chosen {i target} (see
+    {!val:mimic_happy_eyeballs}).
+
+    The resulting {i device} can then be composed with other protocols like TLS,
+    Git or HTTP and it is through this resulting {i device} that other devices
+    can initiate an internet connection to a peer (like a webserver or a Git
+    server). *)
+
+type mimic
+
+val mimic : mimic typ
+
+val mimic_happy_eyeballs :
+  stackv4v6 impl -> dns_client impl -> happy_eyeballs impl -> mimic impl
+(** [mimic_happy_eyeballs stackv4v6 dns happy_eyeballs] creates a device which
+    initiate a global {i happy-eyeballs} loop. By this way, an underlying
+    instance works to initiate a TCP/IP connection from an IP address or a
+    domain-name.
+
+    For the domain-name resolution, we ask the {i happy-eyeballs} instance to
+    resolve the given domain-name {i via} the DNS instance created by [dns]
+    (which includes several arguments like nameservers used - see
+    {!val:generic_dns_client} for more informations).
+
+    The resulting {i device} can be used {b and} re-used to for any {i clients}
+    which need to initiate a connection (like {!val:alpn_client} or
+    {!val:git_tcp}). *)
+
 (** {2 HTTP configuration} *)
 
 type http
@@ -859,6 +895,51 @@ val paf_server : port:int key -> tcpv4v6 impl -> http_server impl
       let () = register "main" [ main $ http_server ]
     ]} *)
 
+type alpn_client
+
+val alpn_client : alpn_client typ
+
+val paf_client :
+  ?pclock:pclock impl -> tcpv4v6 impl -> mimic impl -> alpn_client impl
+(** [alpn_client tcpv4v6 ctx] creates an ALPN device which can do HTTP
+    ([http/1.1] & [h2]) requests as a HTTP client. The device allocated
+    represents values required to initiate a connection to HTTP webservers. The
+    user can, then, use the module [Http_mirage_client.request] to communicate
+    with HTTP webservers. This is an example of how to use the ALPN devices:
+
+    {b unikernel.ml}
+
+    {[
+      module Make (HTTP_client : Http_mirage_client.S) = struct
+        let start http =
+          Http_mirage_client.request http "https://google.com"
+            (fun _response buf str -> Buffer.add_string buf str ; Lwt.return buf)
+            (Buffer.create 0x100) >>= function
+          | Ok (response, buf) ->
+            let body = Buffer.contents buf in
+            ...
+          | Error _ -> ...
+      end
+    ]}
+
+    {b config.ml}
+
+    {[
+      open Mirage
+
+      let main = foreign "Unikernel.Make" (alpn_client @-> job)
+      let stackv4v6 = generic_stackv4v6 default_network
+      let dns = generic_dns_client stack
+
+      let alpn_client =
+        let dns =
+          mimic_happy_eyeballs stackv4v6 dns (generic_happy_eyeballs stack dns)
+        in
+        alpn_client (tcpv4v6_of_stackv4v6 stackv4v6) dns
+
+      let () = register "main" [ main $ alpn_client ]
+    ]} *)
+
 (** {2 Argv configuration} *)
 
 type argv = Functoria.argv
@@ -894,8 +975,12 @@ val no_argv : argv impl
     can be implemented like:
 
     {[
+      let dns = generic_dns_client stack
+
       let git_client =
-        let dns = happy_eyeballs stackv4v6 in
+        let dns =
+          mimic_happy_eyeballs stackv4v6 dns (generic_happy_eyeballs stack dns)
+        in
         let ssh = git_ssh ~key (tcpv4v6_of_stackv4v6 stackv4v6) dns in
         let tcp = git_tcp (tcpv4v6_of_stackv4v6 stackv4v6) dns in
         merge_git_clients ssh tcp
@@ -910,10 +995,7 @@ val merge_git_clients : git_client impl -> git_client impl -> git_client impl
 (** [merge_git_clients a b] is a device that can connect to remote Git
     repositories using either the device [a] or the device [b]. *)
 
-val git_happy_eyeballs :
-  stackv4v6 impl -> dns_client impl -> happy_eyeballs impl -> git_client impl
-
-val git_tcp : tcpv4v6 impl -> git_client impl -> git_client impl
+val git_tcp : tcpv4v6 impl -> mimic impl -> git_client impl
 (** [git_tcp tcpv4v6 dns] is a device able to connect to a remote Git repository
     using TCP/IP. *)
 
@@ -923,7 +1005,7 @@ val git_ssh :
   ?mclock:mclock impl ->
   ?time:time impl ->
   tcpv4v6 impl ->
-  git_client impl ->
+  mimic impl ->
   git_client impl
 (** [git_ssh ?authenticator ~key tcpv4v6 dns] is a device able to connect to a
     remote Git repository using an SSH connection with the given private [key].
@@ -947,7 +1029,7 @@ val git_http :
   ?headers:(string * string) list key ->
   ?pclock:pclock impl ->
   tcpv4v6 impl ->
-  git_client impl ->
+  mimic impl ->
   git_client impl
 (** [git_http ?authenticator ?headers tcpv4v6 dns] is a device able to connect
     to a remote Git repository via an HTTP(S) connection, using the provided

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -896,12 +896,13 @@ val paf_server : port:int key -> tcpv4v6 impl -> http_server impl
     ]} *)
 
 type alpn_client
+(** Abstract type for ALPN HTTP clients *)
 
 val alpn_client : alpn_client typ
 
 val paf_client :
   ?pclock:pclock impl -> tcpv4v6 impl -> mimic impl -> alpn_client impl
-(** [alpn_client tcpv4v6 ctx] creates an ALPN device which can do HTTP
+(** [paf_client tcpv4v6 ctx] creates an ALPN device which can do HTTP
     ([http/1.1] & [h2]) requests as a HTTP client. The device allocated
     represents values required to initiate a connection to HTTP webservers. The
     user can, then, use the module [Http_mirage_client.request] to communicate
@@ -935,7 +936,7 @@ val paf_client :
         let dns =
           mimic_happy_eyeballs stackv4v6 dns (generic_happy_eyeballs stack dns)
         in
-        alpn_client (tcpv4v6_of_stackv4v6 stackv4v6) dns
+        paf_client (tcpv4v6_of_stackv4v6 stackv4v6) dns
 
       let () = register "main" [ main $ alpn_client ]
     ]} *)


### PR DESCRIPTION
This PR rename the initial `git_client` used to create a witness which is able to initiate a Git connection to `mimic` and be able to re-use the same instance for an new introduced ALPN client (http/1.1 and h2).

The ALPN client is currently used by the Robur's opam-mirror unikernel and can be used in several contexts when the user wants to do an HTTP (http/1.1 or h2) requests with TLS.

The mimic device (specially the `mimic_happy_eyeballs` device) initiate an happy_eyeballs instance which can be used and re-used by several devices such as `git_client` devices or the new introduced `alpn_devices`.

This commit breaks some names and specially some unikernels like our Git example into our mirage-skeleton repository. The main change is the renaming of `git_happy_eyeballs` to `mimic_happy_eyeballs` when the second is not really related to Git stuff (and used by something else such as our new introduced `alpn_client`).