### PR TITLE
Enforce the usage of solo5.0.7.5 when we make unikernels

### DIFF
--- a/lib/mirage/target/solo5.ml
+++ b/lib/mirage/target/solo5.ml
@@ -16,6 +16,8 @@ let build_packages =
   [
     Functoria.package ~min:"0.8.1" ~max:"0.9.0" ~scope:`Switch ~build:true
       "ocaml-solo5";
+    Functoria.package ~min:"0.7.5" ~max:"0.8.8" ~scope:`Switch ~build:true
+      "solo5";
   ]
 
 let runtime_packages target =

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -31,6 +31,7 @@ Query opam file
     "ocaml" { build & >= "4.08.0" }
     "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
     "opam-monorepo" { build & >= "0.3.2" }
+    "solo5" { build & >= "0.7.5" & < "0.8.8" }
   ]
   
   x-mirage-opam-lock-location: "mirage/noop-hvt.opam.locked"
@@ -45,8 +46,8 @@ Query opam file
   ["mirage-overlays" "https://github.com/dune-universe/mirage-opam-overlays.git"]]
   
   x-opam-monorepo-opam-provided: ["mirage"
-  "ocaml""ocaml-solo5"
-  "opam-monorepo"]
+  "ocaml""ocaml-solo5""opam-monorepo"
+  "solo5"]
   
 
 
@@ -62,6 +63,7 @@ Query packages
   "ocaml" { build & >= "4.08.0" }
   "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
   "opam-monorepo" { build & >= "0.3.2" }
+  "solo5" { build & >= "0.7.5" & < "0.8.8" }
 
 Query files
   $ ./config.exe query --target hvt files


### PR DESCRIPTION
It includes the fix about the MSA03: https://mirage.io/blog/MSA03