### PR TITLE
adjust solo5 bound: use 0.8.0 as upper bound

### DIFF
--- a/lib/mirage/target/solo5.ml
+++ b/lib/mirage/target/solo5.ml
@@ -16,7 +16,7 @@ let build_packages =
   [
     Functoria.package ~min:"0.8.1" ~max:"0.9.0" ~scope:`Switch ~build:true
       "ocaml-solo5";
-    Functoria.package ~min:"0.7.5" ~max:"0.8.8" ~scope:`Switch ~build:true
+    Functoria.package ~min:"0.7.5" ~max:"0.8.0" ~scope:`Switch ~build:true
       "solo5";
   ]
 

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -31,7 +31,7 @@ Query opam file
     "ocaml" { build & >= "4.08.0" }
     "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
     "opam-monorepo" { build & >= "0.3.2" }
-    "solo5" { build & >= "0.7.5" & < "0.8.8" }
+    "solo5" { build & >= "0.7.5" & < "0.8.0" }
   ]
   
   x-mirage-opam-lock-location: "mirage/noop-hvt.opam.locked"
@@ -63,7 +63,7 @@ Query packages
   "ocaml" { build & >= "4.08.0" }
   "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
   "opam-monorepo" { build & >= "0.3.2" }
-  "solo5" { build & >= "0.7.5" & < "0.8.8" }
+  "solo5" { build & >= "0.7.5" & < "0.8.0" }
 
 Query files
   $ ./config.exe query --target hvt files


### PR DESCRIPTION
//cc @dinosaure I'm a bit confused why 0.8.8 should be there. From my perspective, any 0.Y may change API in 0.(Y + 1), so best to restrict to < 0.8.0 [this is done for other opam packages as well in this package].