### PR TITLE
Add `build` stanzas to packages that are supposed to be vendored

### DIFF
--- a/test/opam-monorepo/mini-opam-overlays/packages/fmt/fmt.0.9.0+dune/opam
+++ b/test/opam-monorepo/mini-opam-overlays/packages/fmt/fmt.0.9.0+dune/opam
@@ -4,3 +4,6 @@ dev-repo: "fmt"
 url {
   src: "https://fmt.src"
 }
+build: [
+  ["dune" "build"]
+]

--- a/test/opam-monorepo/mini-opam-overlays/packages/zarith/zarith.1.12+dune+mirage/opam
+++ b/test/opam-monorepo/mini-opam-overlays/packages/zarith/zarith.1.12+dune+mirage/opam
@@ -5,3 +5,6 @@ url {
   src: "https://github.com/ocaml/zarith.git"
 }
 tags: [ "cross-compile" ]
+build: [
+  ["dune" "build"]
+]

--- a/test/opam-monorepo/mini-opam-repository/packages/dune/dune.3.0.0/opam
+++ b/test/opam-monorepo/mini-opam-repository/packages/dune/dune.3.0.0/opam
@@ -4,3 +4,6 @@ dev-repo: ""
 url {
   src: "https://mirage.src"
 }
+build: [
+  [make]
+]

--- a/test/opam-monorepo/mini-opam-repository/packages/gmp/gmp.6.2.9+dune/opam
+++ b/test/opam-monorepo/mini-opam-repository/packages/gmp/gmp.6.2.9+dune/opam
@@ -4,3 +4,6 @@ dev-repo: "gmp"
 url {
   src: "https://gmp.src"
 }
+build: [
+  ["dune" "build"]
+]

--- a/test/opam-monorepo/mini-opam-repository/packages/mirage-runtime/mirage-runtime.4.0.0/opam
+++ b/test/opam-monorepo/mini-opam-repository/packages/mirage-runtime/mirage-runtime.4.0.0/opam
@@ -4,3 +4,6 @@ dev-repo: "mirage"
 url {
   src: "https://mirage.src"
 }
+build: [
+  ["dune" "build"]
+]

--- a/test/opam-monorepo/mini-opam-repository/packages/ocaml-solo5/ocaml-solo5.0.8.0/opam
+++ b/test/opam-monorepo/mini-opam-repository/packages/ocaml-solo5/ocaml-solo5.0.8.0/opam
@@ -4,3 +4,6 @@ dev-repo: "ocaml-solo5"
 url {
   src: "https://ocaml-solo5.src"
 }
+build: [
+  ["dune" "build"]
+]

--- a/test/opam-monorepo/mini-opam-repository/packages/solo5/solo5.0.7.1/opam
+++ b/test/opam-monorepo/mini-opam-repository/packages/solo5/solo5.0.7.1/opam
@@ -4,3 +4,6 @@ dev-repo: "solo5"
 url {
   src: "https://solo5.src"
 }
+build: [
+  ["dune" "build"]
+]


### PR DESCRIPTION
In https://github.com/tarides/opam-monorepo/pull/355 opam-monorepo marked packages without build instructions as virtual (e.g. packages that are conf-packages, dependency-only packages, etc).

This requires that the dummy OPAM files used here also have `build` stanzas, otherwise they are considered virtual and skipped.

(The `dune` change is only for good measure for future-proofing, similar to the compiler `dune` is treated specially anyway)