### PR TITLE
Removed deprecated device git_happy_eyeballs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "ocaml.sandbox": {
+        "kind": "global"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "ocaml.sandbox": {
-        "kind": "global"
-    }
-}

--- a/lib/mirage/impl/mirage_impl_git.ml
+++ b/lib/mirage/impl/mirage_impl_git.ml
@@ -22,16 +22,6 @@ let git_merge_clients =
   impl ~packages ~connect "Mimic.Merge"
     (git_client @-> git_client @-> git_client)
 
-let git_happy_eyeballs =
-  let packages = [ package "mimic-happy-eyeballs" ~min:"0.0.5" ] in
-  let connect _ modname = function
-    | [ _stackv4v6; _dns_client; happy_eyeballs ] ->
-        Fmt.str {ocaml|%s.connect %s|ocaml} modname happy_eyeballs
-    | _ -> assert false
-  in
-  impl ~packages ~connect "Mimic_happy_eyeballs.Make"
-    (stackv4v6 @-> dns_client @-> happy_eyeballs @-> mimic)
-
 let git_tcp =
   let packages =
     [ package "git-mirage" ~sublibs:[ "tcp" ] ~min:"3.10.0" ~max:"3.12.0" ]

--- a/lib/mirage/impl/mirage_impl_git.ml
+++ b/lib/mirage/impl/mirage_impl_git.ml
@@ -2,10 +2,7 @@ open Functoria
 open Mirage_impl_time
 open Mirage_impl_mclock
 open Mirage_impl_pclock
-open Mirage_impl_stack
 open Mirage_impl_tcp
-open Mirage_impl_dns
-open Mirage_impl_happy_eyeballs
 open Mirage_impl_mimic
 
 type git_client = Git_client

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -289,9 +289,6 @@ let git_client = Mirage_impl_git.git_client
 let merge_git_clients ctx0 ctx1 =
   Mirage_impl_git.git_merge_clients $ ctx0 $ ctx1
 
-let git_happy_eyeballs stackv4v6 dns_client happy_eyeballs =
-  Mirage_impl_git.git_happy_eyeballs $ stackv4v6 $ dns_client $ happy_eyeballs
-
 let git_tcp tcpv4v6 ctx = Mirage_impl_git.git_tcp $ tcpv4v6 $ ctx
 
 let git_ssh ?authenticator ~key ?(mclock = default_monotonic_clock)

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -996,10 +996,6 @@ val merge_git_clients : git_client impl -> git_client impl -> git_client impl
 (** [merge_git_clients a b] is a device that can connect to remote Git
     repositories using either the device [a] or the device [b]. *)
 
-val git_happy_eyeballs :
-  stackv4v6 impl -> dns_client impl -> happy_eyeballs impl -> mimic impl
-(** @deprecated You should use {!val:mimic_happy_eyeballs}. *)
-
 val git_tcp : tcpv4v6 impl -> mimic impl -> git_client impl
 (** [git_tcp tcpv4v6 dns] is a device able to connect to a remote Git repository
     using TCP/IP. *)


### PR DESCRIPTION
Issue : #1378 

Removed git_happy_eyeballs from
1. lib/mirage/impl/mirage_impl_git.ml
2. lib/mirage/mirage.ml
3. lib/mirage/mirage/mli 

git_happy_eyeballs has been deprecated, and should be deleted for the next release.