### PR TITLE
Add tar_kv_ro and tar_kv_rw

### DIFF
--- a/lib/mirage/impl/mirage_impl_block.ml
+++ b/lib/mirage/impl/mirage_impl_block.ml
@@ -101,17 +101,24 @@ let generic_block ?group ?(key = Key.value @@ Key.block ?group ()) name =
     ]
     ~default:(ramdisk name)
 
-let tar_kv_ro_conf, tar_kv_rw_conf =
+let tar_kv_ro_conf =
   let packages = [ package ~min:"1.0.0" ~max:"3.0.0" "tar-mirage" ] in
   let connect _ modname = function
     | [ block ] -> Fmt.str "%s.connect %s" modname block
-    | _ -> failwith (connect_err "tar_kv" 1)
+    | _ -> failwith (connect_err "tar_kv_ro" 1)
   in
-  impl ~packages ~connect "Tar_mirage.Make_KV_RO" (block @-> Mirage_impl_kv.ro),
-  impl ~packages ~connect "Tar_mirage.Make_KV_RW" (block @-> Mirage_impl_kv.rw)
+  impl ~packages ~connect "Tar_mirage.Make_KV_RO" (block @-> Mirage_impl_kv.ro)
+
+let tar_kv_rw_conf =
+  let packages = [ package ~min:"1.0.0" ~max:"3.0.0" "tar-mirage" ] in
+  let connect _ modname = function
+    | [ _pclock; block ] -> Fmt.str "%s.connect %s" modname block
+    | _ -> failwith (connect_err "tar_kv_rw" 2)
+  in
+  impl ~packages ~connect "Tar_mirage.Make_KV_RW" (pclock @-> block @-> Mirage_impl_kv.rw)
 
 let tar_kv_ro block = tar_kv_ro_conf $ block
-let tar_kv_rw block = tar_kv_rw_conf $ block
+let tar_kv_rw pclock block = tar_kv_rw_conf $ pclock $ block
 let archive = tar_kv_ro
 
 let fat_conf =

--- a/lib/mirage/impl/mirage_impl_block.ml
+++ b/lib/mirage/impl/mirage_impl_block.ml
@@ -115,7 +115,8 @@ let tar_kv_rw_conf =
     | [ _pclock; block ] -> Fmt.str "%s.connect %s" modname block
     | _ -> failwith (connect_err "tar_kv_rw" 2)
   in
-  impl ~packages ~connect "Tar_mirage.Make_KV_RW" (pclock @-> block @-> Mirage_impl_kv.rw)
+  impl ~packages ~connect "Tar_mirage.Make_KV_RW"
+    (pclock @-> block @-> Mirage_impl_kv.rw)
 
 let tar_kv_ro block = tar_kv_ro_conf $ block
 let tar_kv_rw pclock block = tar_kv_rw_conf $ pclock $ block

--- a/lib/mirage/impl/mirage_impl_block.ml
+++ b/lib/mirage/impl/mirage_impl_block.ml
@@ -101,15 +101,18 @@ let generic_block ?group ?(key = Key.value @@ Key.block ?group ()) name =
     ]
     ~default:(ramdisk name)
 
-let archive_conf =
+let tar_kv_ro_conf, tar_kv_rw_conf =
   let packages = [ package ~min:"1.0.0" ~max:"3.0.0" "tar-mirage" ] in
   let connect _ modname = function
     | [ block ] -> Fmt.str "%s.connect %s" modname block
-    | _ -> failwith (connect_err "archive" 1)
+    | _ -> failwith (connect_err "tar_kv" 1)
   in
-  impl ~packages ~connect "Tar_mirage.Make_KV_RO" (block @-> Mirage_impl_kv.ro)
+  impl ~packages ~connect "Tar_mirage.Make_KV_RO" (block @-> Mirage_impl_kv.ro),
+  impl ~packages ~connect "Tar_mirage.Make_KV_RW" (block @-> Mirage_impl_kv.rw)
 
-let archive block = archive_conf $ block
+let tar_kv_ro block = tar_kv_ro_conf $ block
+let tar_kv_rw block = tar_kv_rw_conf $ block
+let archive = tar_kv_ro
 
 let fat_conf =
   let packages = [ package ~min:"0.15.0" ~max:"0.16.0" "fat-filesystem" ] in

--- a/lib/mirage/impl/mirage_impl_block.ml
+++ b/lib/mirage/impl/mirage_impl_block.ml
@@ -110,7 +110,7 @@ let tar_kv_ro_conf =
   impl ~packages ~connect "Tar_mirage.Make_KV_RO" (block @-> Mirage_impl_kv.ro)
 
 let tar_kv_rw_conf =
-  let packages = [ package ~min:"1.0.0" ~max:"3.0.0" "tar-mirage" ] in
+  let packages = [ package ~min:"2.2.0" ~max:"3.0.0" "tar-mirage" ] in
   let connect _ modname = function
     | [ _pclock; block ] -> Fmt.str "%s.connect %s" modname block
     | _ -> failwith (connect_err "tar_kv_rw" 2)

--- a/lib/mirage/impl/mirage_impl_block.mli
+++ b/lib/mirage/impl/mirage_impl_block.mli
@@ -8,6 +8,7 @@ val generic_block :
   string ->
   block Functoria.impl
 
+val tar_kv_ro : block Functoria.impl -> Mirage_impl_kv.ro Functoria.impl
 val archive : block Functoria.impl -> Mirage_impl_kv.ro Functoria.impl
 val fat_ro : block Functoria.impl -> Mirage_impl_kv.ro Functoria.impl
 val ramdisk : string -> block Functoria.impl
@@ -31,6 +32,8 @@ val all_blocks : (string, block_t) Hashtbl.t
 val chamelon :
   program_block_size:int Functoria.key ->
   (block -> Mirage_impl_pclock.pclock -> Mirage_impl_kv.rw) Functoria.impl
+
+val tar_kv_rw : block Functoria.impl -> Mirage_impl_kv.rw Functoria.impl
 
 val ccm_block :
   ?maclen:int ->

--- a/lib/mirage/impl/mirage_impl_block.mli
+++ b/lib/mirage/impl/mirage_impl_block.mli
@@ -33,7 +33,10 @@ val chamelon :
   program_block_size:int Functoria.key ->
   (block -> Mirage_impl_pclock.pclock -> Mirage_impl_kv.rw) Functoria.impl
 
-val tar_kv_rw : Mirage_impl_pclock.pclock Functoria.impl -> block Functoria.impl -> Mirage_impl_kv.rw Functoria.impl
+val tar_kv_rw :
+  Mirage_impl_pclock.pclock Functoria.impl ->
+  block Functoria.impl ->
+  Mirage_impl_kv.rw Functoria.impl
 
 val ccm_block :
   ?maclen:int ->

--- a/lib/mirage/impl/mirage_impl_block.mli
+++ b/lib/mirage/impl/mirage_impl_block.mli
@@ -33,7 +33,7 @@ val chamelon :
   program_block_size:int Functoria.key ->
   (block -> Mirage_impl_pclock.pclock -> Mirage_impl_kv.rw) Functoria.impl
 
-val tar_kv_rw : block Functoria.impl -> Mirage_impl_kv.rw Functoria.impl
+val tar_kv_rw : Mirage_impl_pclock.pclock Functoria.impl -> block Functoria.impl -> Mirage_impl_kv.rw Functoria.impl
 
 val ccm_block :
   ?maclen:int ->

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -80,9 +80,12 @@ let docteur ?mode ?disk ?analyze ?branch ?extra_deps remote =
 let chamelon ~program_block_size ?(pclock = default_posix_clock) block =
   Mirage_impl_block.chamelon ~program_block_size $ block $ pclock
 
+let tar_kv_rw = Mirage_impl_block.tar_kv_rw
+
 type block = Mirage_impl_block.block
 
 let block = Mirage_impl_block.block
+let tar_kv_ro = Mirage_impl_block.tar_kv_ro
 let archive = Mirage_impl_block.archive
 let fat_ro = Mirage_impl_block.fat_ro
 let generic_block = Mirage_impl_block.generic_block

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -80,7 +80,8 @@ let docteur ?mode ?disk ?analyze ?branch ?extra_deps remote =
 let chamelon ~program_block_size ?(pclock = default_posix_clock) block =
   Mirage_impl_block.chamelon ~program_block_size $ block $ pclock
 
-let tar_kv_rw = Mirage_impl_block.tar_kv_rw
+let tar_kv_rw ?(pclock = default_posix_clock) block =
+  Mirage_impl_block.tar_kv_rw pclock block
 
 type block = Mirage_impl_block.block
 

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -272,7 +272,8 @@ val crunch : string -> kv_ro impl
 val tar_kv_ro : block impl -> kv_ro impl
 (** [tar_kv_ro block] is a read-only tar archive. *)
 
-val archive : block impl -> kv_ro impl [@@ocaml.deprecated "use Mirage.tar_kv_ro"]
+val archive : block impl -> kv_ro impl
+  [@@ocaml.deprecated "use Mirage.tar_kv_ro"]
 (** @deprecated You should use {!val:tar_kv_ro} (or {!val:tar_kv_rw}). *)
 
 val direct_kv_ro : string -> kv_ro impl
@@ -390,7 +391,7 @@ val chamelon :
 val tar_kv_rw : ?pclock:pclock impl -> block impl -> kv_rw impl
 (** [tar_kv_rw block] is a read/write tar archive. Note that the filesystem is
     append-only. That is, files can generally not be removed, [set_partial] only
-    works on what is allocated, and there are restrictions on [rename].  *)
+    works on what is allocated, and there are restrictions on [rename]. *)
 
 val ccm_block :
   ?maclen:int -> ?nonce_len:int -> string option key -> block impl -> block impl

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -269,8 +269,11 @@ val kv_ro : kv_ro typ
 val crunch : string -> kv_ro impl
 (** Crunch a directory. *)
 
+val tar_kv_ro : block impl -> kv_ro impl
+(** [tar_kv_ro block] is a read-only tar archive. *)
+
 val archive : block impl -> kv_ro impl
-(** Use a TAR archive. *)
+(** @deprecated You should use {!val:tar_kv_ro} (or {!val:tar_kv_rw}). *)
 
 val direct_kv_ro : string -> kv_ro impl
 (** Direct access to the underlying filesystem as a key/value store. For Xen
@@ -383,6 +386,11 @@ val chamelon :
       $ dd if=/dev/zero of=db.img bs=1M count=1
       $ chamelon format db.img 512
     ]} *)
+
+val tar_kv_rw : block impl -> kv_rw impl
+(** [tar_kv_rw block] is a read/write tar archive. Note that the filesystem is
+    append-only. That is, files can generally not be removed, [set_partial] only
+    works on what is allocated, and there are restrictions on [rename].  *)
 
 val ccm_block :
   ?maclen:int -> ?nonce_len:int -> string option key -> block impl -> block impl

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -272,7 +272,7 @@ val crunch : string -> kv_ro impl
 val tar_kv_ro : block impl -> kv_ro impl
 (** [tar_kv_ro block] is a read-only tar archive. *)
 
-val archive : block impl -> kv_ro impl
+val archive : block impl -> kv_ro impl [@@ocaml.deprecated "use Mirage.tar_kv_ro"]
 (** @deprecated You should use {!val:tar_kv_ro} (or {!val:tar_kv_rw}). *)
 
 val direct_kv_ro : string -> kv_ro impl
@@ -387,7 +387,7 @@ val chamelon :
       $ chamelon format db.img 512
     ]} *)
 
-val tar_kv_rw : block impl -> kv_rw impl
+val tar_kv_rw : ?pclock:pclock impl -> block impl -> kv_rw impl
 (** [tar_kv_rw block] is a read/write tar archive. Note that the filesystem is
     append-only. That is, files can generally not be removed, [set_partial] only
     works on what is allocated, and there are restrictions on [rename].  *)


### PR DESCRIPTION
In addition, `archive` is deprecated in favor of `tar_kv_ro` and `tar_kv_rw`.