### PR TITLE
Disallow empty key names

### DIFF
--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -486,6 +486,8 @@ let alias name a =
   make ~setters ~arg ~name
 
 let create name arg =
+  if name = "" then
+    invalid_arg "Key.create: key name cannot be the empty string";
   let setters = [] in
   make ~setters ~arg ~name
 


### PR DESCRIPTION
If you try to define a key with the name `""` in config.ml an error is raised if the key becomes relevant. However, the key may not always be relevant if it depends on e.g. `is_solo5`. This change pushes the check earlier so the error doesn't depend on conditionals.

```
couldn't open output channel for key_gen file: Invalid_argument("")
```