### PR TITLE
fix opam-monorepo issue with Ocaml5+

### DIFF
--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -376,7 +376,7 @@ let run t = %s.Main.run t ; exit 0|ocaml}
       let min = "4.3.1" and max = "4.4.0" in
       let common =
         [
-          package ~scope:`Switch ~build:true ~min:"4.08.0" "ocaml";
+          package ~scope:`Monorepo ~build:true ~min:"4.08.0" "ocaml";
           package ~scope:`Monorepo "lwt";
           package ~scope:`Monorepo ~min ~max "mirage-runtime";
           package ~scope:`Switch ~build:true ~min ~max "mirage";

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -376,7 +376,6 @@ let run t = %s.Main.run t ; exit 0|ocaml}
       let min = "4.3.1" and max = "4.4.0" in
       let common =
         [
-          package ~scope:`Monorepo ~build:true ~min:"4.08.0" "ocaml";
           package ~scope:`Monorepo "lwt";
           package ~scope:`Monorepo ~min ~max "mirage-runtime";
           package ~scope:`Switch ~build:true ~min ~max "mirage";

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -28,7 +28,6 @@ Query opam file
     "mirage-logs" { ?monorepo & >= "1.2.0" & < "2.0.0" }
     "mirage-runtime" { ?monorepo & >= "4.3.1" & < "4.4.0" }
     "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
-    "ocaml" { ?monorepo & build & >= "4.08.0" }
     "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
     "opam-monorepo" { build & >= "0.3.2" }
     "solo5" { build & >= "0.7.5" & < "0.8.0" }
@@ -60,7 +59,6 @@ Query packages
   "mirage-logs" { ?monorepo & >= "1.2.0" & < "2.0.0" }
   "mirage-runtime" { ?monorepo & >= "4.3.1" & < "4.4.0" }
   "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
-  "ocaml" { ?monorepo & build & >= "4.08.0" }
   "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
   "opam-monorepo" { build & >= "0.3.2" }
   "solo5" { build & >= "0.7.5" & < "0.8.0" }

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -28,7 +28,7 @@ Query opam file
     "mirage-logs" { ?monorepo & >= "1.2.0" & < "2.0.0" }
     "mirage-runtime" { ?monorepo & >= "4.3.1" & < "4.4.0" }
     "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
-    "ocaml" { build & >= "4.08.0" }
+    "ocaml" { ?monorepo & build & >= "4.08.0" }
     "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
     "opam-monorepo" { build & >= "0.3.2" }
     "solo5" { build & >= "0.7.5" & < "0.8.0" }
@@ -46,7 +46,7 @@ Query opam file
   ["mirage-overlays" "https://github.com/dune-universe/mirage-opam-overlays.git"]]
   
   x-opam-monorepo-opam-provided: ["mirage"
-  "ocaml""ocaml-solo5""opam-monorepo"
+  "ocaml-solo5""opam-monorepo"
   "solo5"]
   
 
@@ -60,7 +60,7 @@ Query packages
   "mirage-logs" { ?monorepo & >= "1.2.0" & < "2.0.0" }
   "mirage-runtime" { ?monorepo & >= "4.3.1" & < "4.4.0" }
   "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
-  "ocaml" { build & >= "4.08.0" }
+  "ocaml" { ?monorepo & build & >= "4.08.0" }
   "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
   "opam-monorepo" { build & >= "0.3.2" }
   "solo5" { build & >= "0.7.5" & < "0.8.0" }

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -32,7 +32,6 @@ Query opam file
     "mirage-logs" { ?monorepo & >= "1.2.0" & < "2.0.0" }
     "mirage-runtime" { ?monorepo & >= "4.3.1" & < "4.4.0" }
     "mirage-unix" { ?monorepo & >= "5.0.0" & < "6.0.0" }
-    "ocaml" { ?monorepo & build & >= "4.08.0" }
     "opam-monorepo" { build & >= "0.3.2" }
   ]
   
@@ -61,7 +60,6 @@ Query packages
   "mirage-logs" { ?monorepo & >= "1.2.0" & < "2.0.0" }
   "mirage-runtime" { ?monorepo & >= "4.3.1" & < "4.4.0" }
   "mirage-unix" { ?monorepo & >= "5.0.0" & < "6.0.0" }
-  "ocaml" { ?monorepo & build & >= "4.08.0" }
   "opam-monorepo" { build & >= "0.3.2" }
 
 Query files

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -32,7 +32,7 @@ Query opam file
     "mirage-logs" { ?monorepo & >= "1.2.0" & < "2.0.0" }
     "mirage-runtime" { ?monorepo & >= "4.3.1" & < "4.4.0" }
     "mirage-unix" { ?monorepo & >= "5.0.0" & < "6.0.0" }
-    "ocaml" { build & >= "4.08.0" }
+    "ocaml" { ?monorepo & build & >= "4.08.0" }
     "opam-monorepo" { build & >= "0.3.2" }
   ]
   
@@ -48,7 +48,6 @@ Query opam file
   ["mirage-overlays" "https://github.com/dune-universe/mirage-opam-overlays.git"]]
   
   x-opam-monorepo-opam-provided: ["mirage"
-  "ocaml"
   "opam-monorepo"]
   
 
@@ -62,7 +61,7 @@ Query packages
   "mirage-logs" { ?monorepo & >= "1.2.0" & < "2.0.0" }
   "mirage-runtime" { ?monorepo & >= "4.3.1" & < "4.4.0" }
   "mirage-unix" { ?monorepo & >= "5.0.0" & < "6.0.0" }
-  "ocaml" { build & >= "4.08.0" }
+  "ocaml" { ?monorepo & build & >= "4.08.0" }
   "opam-monorepo" { build & >= "0.3.2" }
 
 Query files


### PR DESCRIPTION
Dear developers,

This PR should solve https://github.com/tarides/opam-monorepo/issues/340 and permits to compile mirage unikernels with Ocaml5+.

The underlying issue was the `ocaml` package marked as opam-provided and thus removed from dependencies at https://github.com/tarides/opam-monorepo/blob/9cc963ce7bc91592a301feca1e2238bc17448bd8/lib/opam_solve.ml#L114 (This can be seen inside the solver: https://github.com/ocaml-opam/opam-0install-solver/issues/47). Therefore, as https://github.com/ocaml/opam-repository/blob/master/packages/base-domains/base-domains.base/opam have a dependency list which contains `ocaml` OR `ocaml-variants`, leave the solver only with `ocaml-variants` if we remove `ocaml`.

For the time being I moved ocaml to the `Monorepo` scope, this is why it now appears as monorepo in the test files, but unsure if that the best move, comments are more than welcome!