### PR TITLE
Fix the describe help layout.

### DIFF
--- a/lib/functoria/cli.ml
+++ b/lib/functoria/cli.ml
@@ -380,12 +380,15 @@ module Subcommands = struct
                 "Represented as circles. Branches are dotted, and the default \
                  branch is in bold." );
             `Noblank;
+            `Noblank;
             `I
               ( "Configurables",
                 "Represented as rectangles. The order of the output arrows is \
                  the order of the functor arguments." );
             `Noblank;
+            `Noblank;
             `I ("Data dependencies", "Represented as dashed arrows.");
+            `Noblank;
             `Noblank;
             `I
               ( "App vertices",

--- a/test/functoria/help/describe.t
+++ b/test/functoria/help/describe.t
@@ -13,15 +13,12 @@ Help describe --man-format=plain
          The dot output contains the following elements:
          If vertices
              Represented as circles. Branches are dotted, and the default
-             branch is in bold.       Configurables
-                                          Represented as rectangles. The order
-                                          of the output arrows is the order of
-                                          the functor arguments.       
-                                                                Data
-                                                                dependencies
-                                                                           
-                                                                Represented as
-                                                                dashed arrows.
+             branch is in bold.
+         Configurables
+             Represented as rectangles. The order of the output arrows is the
+             order of the functor arguments.
+         Data dependencies
+             Represented as dashed arrows.
          App vertices
              Represented as diamonds. The bold arrow is the functor part.
   DESCRIBE OPTIONS
@@ -117,15 +114,12 @@ Help describe --help=plain
          The dot output contains the following elements:
          If vertices
              Represented as circles. Branches are dotted, and the default
-             branch is in bold.       Configurables
-                                          Represented as rectangles. The order
-                                          of the output arrows is the order of
-                                          the functor arguments.       
-                                                                Data
-                                                                dependencies
-                                                                           
-                                                                Represented as
-                                                                dashed arrows.
+             branch is in bold.
+         Configurables
+             Represented as rectangles. The order of the output arrows is the
+             order of the functor arguments.
+         Data dependencies
+             Represented as dashed arrows.
          App vertices
              Represented as diamonds. The bold arrow is the functor part.
   DESCRIBE OPTIONS

--- a/test/mirage/help/describe.t
+++ b/test/mirage/help/describe.t
@@ -15,15 +15,12 @@ Help describe --man-format=plain
          The dot output contains the following elements:
          If vertices
              Represented as circles. Branches are dotted, and the default
-             branch is in bold.       Configurables
-                                          Represented as rectangles. The order
-                                          of the output arrows is the order of
-                                          the functor arguments.       
-                                                                Data
-                                                                dependencies
-                                                                           
-                                                                Represented as
-                                                                dashed arrows.
+             branch is in bold.
+         Configurables
+             Represented as rectangles. The order of the output arrows is the
+             order of the functor arguments.
+         Data dependencies
+             Represented as dashed arrows.
          App vertices
              Represented as diamonds. The bold arrow is the functor part.
   UNIKERNEL PARAMETERS
@@ -185,15 +182,12 @@ Help describe --help=plain
          The dot output contains the following elements:
          If vertices
              Represented as circles. Branches are dotted, and the default
-             branch is in bold.       Configurables
-                                          Represented as rectangles. The order
-                                          of the output arrows is the order of
-                                          the functor arguments.       
-                                                                Data
-                                                                dependencies
-                                                                           
-                                                                Represented as
-                                                                dashed arrows.
+             branch is in bold.
+         Configurables
+             Represented as rectangles. The order of the output arrows is the
+             order of the functor arguments.
+         Data dependencies
+             Represented as dashed arrows.
          App vertices
              Represented as diamonds. The bold arrow is the functor part.
   UNIKERNEL PARAMETERS


### PR DESCRIPTION
Addresses #1222 . There seems to be an issue within the `Cmdliner` library that was causing this malformed output.