### PR TITLE
mirage-runtime/functoria-runtime: remove dependency on Fmt

### DIFF
--- a/functoria-runtime.opam
+++ b/functoria-runtime.opam
@@ -23,7 +23,6 @@ depends: [
   "dune" {>= "2.9.0"}
   "cmdliner" {>= "1.1.1"}
   "cmdliner" {with-test & >= "1.2.0"}
-  "fmt" {>= "0.8.7"}
 ]
 
 synopsis: "Runtime support library for functoria-generated code"

--- a/lib_runtime/functoria/dune
+++ b/lib_runtime/functoria/dune
@@ -1,4 +1,4 @@
 (library
  (name functoria_runtime)
  (public_name functoria-runtime)
- (libraries cmdliner fmt))
+ (libraries cmdliner))

--- a/lib_runtime/mirage/dune
+++ b/lib_runtime/mirage/dune
@@ -1,4 +1,4 @@
 (library
  (name mirage_runtime)
  (public_name mirage-runtime)
- (libraries functoria-runtime lwt ipaddr logs fmt))
+ (libraries functoria-runtime lwt ipaddr logs))

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -31,17 +31,16 @@ let set_level ~default l =
             let s = List.find (fun s -> Logs.Src.name s = src) srcs in
             Logs.Src.set_level s level
           with Not_found ->
-            Fmt.(pf stdout)
-              "%a %s is not a valid log source.\n%!"
-              Fmt.(styled `Yellow string)
-              "Warning:" src))
+            Format.printf
+              "WARNING: %s is not a valid log source.\n%!" src))
     l
 
 module Arg = struct
   include Functoria_runtime.Arg
 
   let make of_string to_string : _ Cmdliner.Arg.conv =
-    Cmdliner.Arg.conv (of_string, Fmt.of_to_string to_string)
+    let pp ppf v = Format.pp_print_string ppf (to_string v) in
+    Cmdliner.Arg.conv (of_string, pp)
 
   module type S = sig
     type t
@@ -71,8 +70,8 @@ module Arg = struct
       | _ -> Error (`Msg ("Can't parse log threshold: " ^ str))
     in
     let serialize ppf = function
-      | `All, l -> Fmt.string ppf (Logs.level_to_string l)
-      | `Src s, l -> Fmt.pf ppf "%s:%s" s (Logs.level_to_string l)
+      | `All, l -> Format.pp_print_string ppf (Logs.level_to_string l)
+      | `Src s, l -> Format.fprintf ppf "%s:%s" s (Logs.level_to_string l)
     in
     Cmdliner.Arg.conv (parser, serialize)
 

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -31,8 +31,7 @@ let set_level ~default l =
             let s = List.find (fun s -> Logs.Src.name s = src) srcs in
             Logs.Src.set_level s level
           with Not_found ->
-            Format.printf
-              "WARNING: %s is not a valid log source.\n%!" src))
+            Format.printf "WARNING: %s is not a valid log source.\n%!" src))
     l
 
 module Arg = struct

--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -21,7 +21,6 @@ depends: [
   "dune" {>= "2.9.0"}
   "ipaddr"             {>= "5.0.0"}
   "functoria-runtime"  {= version}
-  "fmt" {>= "0.8.4"}
   "logs"
   "lwt" {>= "4.0.0"}
   "alcotest" {with-test}


### PR DESCRIPTION
To test with: https://github.com/mirage/mirage-skeleton/pull/354

functoria-runtime did not use Fmt at all, and mirage-runtime only at two occasions. Given that these opam packages are core to every MirageOS unikernels, let's minimize their dependency to the bare minimum.