### PR TITLE
mirage: mark console as deprecated

### DIFF
--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -226,12 +226,15 @@ type console
 (** Abstract type for consoles. *)
 
 val console : console typ
+[@@ocaml.deprecated "use Logs and Printf instead"]
 (** Implementations of the [Mirage_console.S] signature. *)
 
 val default_console : console impl
+[@@ocaml.deprecated "use Logs and Printf instead"]
 (** Default console implementation. *)
 
 val custom_console : string -> console impl
+[@@ocaml.deprecated "use Logs and Printf instead"]
 (** Custom console implementation. *)
 
 (** {2 Block devices} *)


### PR DESCRIPTION
To test with: https://github.com/mirage/mirage-skeleton/pull/360

so it can safely be removed in an upcoming release. see https://github.com/mirage/mirage-skeleton/pull/360

the reasoning behind this is that "console" devices have been carried over since a long time, but the need for it, esp. with Logs and log reporters in place is not well funded: there is no `read` from a console, there's no information such as width and height (for 2d graphics this would be needed), plus there are nowadays mature ssh and telnet implementations for doing 2d ascii art.

The original xen console device, with frontend and backend, and supporting multiple consoles, was a nice thing -- but I cannot find a unikernel that uses that code. So, to wrap up, in a world/ecosystem where complexity is usually increased (by people pushing more code on the table), my path forward is to remove stuff that isn't needed anymore (or doesn't have a good use case story).

Please let me know if there are users of this console code, and we'll unmark it as deprecated. In the meantime, I'd like to slim the size and complexity of this repository. While cutting network and block devices sounds like a bad idea, the console and logging can be shortened drastically.