### PR TITLE
allow solo5 0.8 line (works fine with the current set of things)

### DIFF
--- a/lib/mirage/target/solo5.ml
+++ b/lib/mirage/target/solo5.ml
@@ -16,7 +16,7 @@ let build_packages =
   [
     Functoria.package ~min:"0.8.1" ~max:"0.9.0" ~scope:`Switch ~build:true
       "ocaml-solo5";
-    Functoria.package ~min:"0.7.5" ~max:"0.8.0" ~scope:`Switch ~build:true
+    Functoria.package ~min:"0.7.5" ~max:"0.9.0" ~scope:`Switch ~build:true
       "solo5";
   ]
 

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -30,7 +30,7 @@ Query opam file
     "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
     "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
     "opam-monorepo" { build & >= "0.3.2" }
-    "solo5" { build & >= "0.7.5" & < "0.8.0" }
+    "solo5" { build & >= "0.7.5" & < "0.9.0" }
   ]
   
   x-mirage-opam-lock-location: "mirage/noop-hvt.opam.locked"
@@ -61,7 +61,7 @@ Query packages
   "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
   "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
   "opam-monorepo" { build & >= "0.3.2" }
-  "solo5" { build & >= "0.7.5" & < "0.8.0" }
+  "solo5" { build & >= "0.7.5" & < "0.9.0" }
 
 Query files
   $ ./config.exe query --target hvt files


### PR DESCRIPTION
what changed in solo5 0.8.0 is the ABI version (since some new stuff was integrated to support ocaml 5 // ocaml-solo5 in the PR https://github.com/mirage/ocaml-solo5/pull/124).

The reason why this was not part of mirage 4.4.0 is just a packaging issue -- we provide at https://builds.robur.coop/job/solo5 binary packages, and they should integrate both solo5 0.7.5 and solo5 0.8.0 binaries -- in this way, albatross (since https://github.com/roburio/albatross/pull/163) could take the right tender and support both old and new solo5 unikernels.

Since the packaging atm only installs 0.7.5 solo5, we decided to wait a bit more. We hope to soon have solo5 packages with both abi version 1 and 2.