### PR TITLE
Remove Key.Alias

### DIFF
--- a/lib/functoria/functoria.ml
+++ b/lib/functoria/functoria.ml
@@ -44,7 +44,6 @@ module type KEY =
      and type 'a key = 'a Key.key
      and type t = Key.t
      and type Set.t = Key.Set.t
-     and type 'a Alias.t = 'a Key.Alias.t
      and type context = Key.context
 
 (** Devices *)

--- a/lib/functoria/functoria.mli
+++ b/lib/functoria/functoria.mli
@@ -133,7 +133,6 @@ module type KEY =
      and type 'a key = 'a Key.key
      and type t = Key.t
      and type Set.t = Key.Set.t
-     and type 'a Alias.t = 'a Key.Alias.t
      and type context = Key.context
 
 module Package = Package

--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -468,7 +468,9 @@ let add_extra_info setters arg =
   | None -> arg
   | Some doc ->
       let doc =
-        String.concat " " [ doc; info_alias setters; info_arg arg.kind ]
+        [ doc; info_alias setters; info_arg arg.kind ]
+        |> List.filter (( <> ) "")
+        |> String.concat " "
       in
       { arg with info = { arg.info with doc = Some doc } }
 

--- a/lib/functoria/key.mli
+++ b/lib/functoria/key.mli
@@ -225,36 +225,6 @@ val is_configure : t -> bool
 val filter_stage : Arg.stage -> Set.t -> Set.t
 (** [filter_stage s ks] is [ks] but with only keys available at stage [s]. *)
 
-(** Alias allows to define virtual keys in terms of other keys at configuration
-    time only. *)
-module Alias : sig
-  (** {1 Alias} *)
-
-  type 'a t
-  (** The type for key alias. *)
-
-  val add : 'b key -> ('a -> 'b option) -> 'a t -> 'a t
-  (** [add k f a] set [a] as an alias for the key [k]: setting [a] on the
-      command-line will set [k] to [f] applied to [a]'s value. If [f] returns
-      [None], no value is set. *)
-
-  val flag : Arg.info -> bool t
-  (** [flag] is similar to {!Arg.flag} but defines configure-only command-line
-      flag alias. Set [stage] to [`Configure]. *)
-
-  (*
-  val opt: 'a Arg.converter -> 'a -> Arg.info -> 'a t
-  (** [opt] is similar to {!Arg.opt} but defines configure-only
-      optional command-line arguments. Set [stage] to [`Configure]. *)
-*)
-end
-
-val alias : string -> 'a Alias.t -> 'a key
-(** Similar to {!create} but for command-line alias. *)
-
-val aliases : t -> Set.t
-(** [aliases t] is the list of [t]'s aliases. *)
-
 (** {1 Parsing context} *)
 
 type context

--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -52,10 +52,7 @@ module Config = struct
   let get_if_context jobs =
     let all_keys = Engine.all_keys jobs in
     let skeys = Engine.if_keys jobs in
-    let f k s =
-      if Key.Set.is_empty @@ Key.Set.inter (Key.aliases k) skeys then s
-      else Key.Set.add k s
-    in
+    let f k s = if true then s else Key.Set.add k s in
     Key.Set.fold f all_keys skeys
 
   let v ?(config_file = Fpath.v "config.ml") ?(keys = []) ?(packages = [])

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -16,7 +16,6 @@
 
 open Functoria
 module Key = Key
-module Alias = Key.Alias
 open Astring
 
 (** {2 Custom Descriptions} *)
@@ -451,4 +450,4 @@ let logs =
   let arg = Key.Arg.(opt logs []) info in
   Key.create "logs" arg
 
-include (Key : Functoria.KEY with module Arg := Arg and module Alias := Alias)
+include (Key : Functoria.KEY with module Arg := Arg)

--- a/test/functoria/e2e/help.t
+++ b/test/functoria/e2e/help.t
@@ -58,10 +58,10 @@ Test that the help command works without config file:
   
   APPLICATION OPTIONS
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   ARGUMENTS
          TOPIC

--- a/test/functoria/gen-2/key_gen.ml.expected
+++ b/test/functoria/gen-2/key_gen.ml.expected
@@ -1,6 +1,6 @@
 let hello = Functoria_runtime.Key.create
   (Functoria_runtime.Arg.opt Cmdliner.Arg.string "Hello World!" (Cmdliner.Arg.info
-   ~docs:"APPLICATION OPTIONS" ?docv:(None) ?doc:(Some "How to say hello.  ")
+   ~docs:"APPLICATION OPTIONS" ?docv:(None) ?doc:(Some "How to say hello.")
    ?env:(None) ["hello"]))
 
 let hello_t = Functoria_runtime.Key.term hello

--- a/test/functoria/help/build.t
+++ b/test/functoria/help/build.t
@@ -24,13 +24,13 @@ Help build --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -96,13 +96,13 @@ Help build --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/functoria/help/clean.t
+++ b/test/functoria/help/clean.t
@@ -24,13 +24,13 @@ Help clean --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -96,13 +96,13 @@ Help clean --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/functoria/help/configure-o.t
+++ b/test/functoria/help/configure-o.t
@@ -41,13 +41,13 @@ Help configure -o --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -136,13 +136,13 @@ Help configure -o --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/functoria/help/configure.t
+++ b/test/functoria/help/configure.t
@@ -41,13 +41,13 @@ Help configure --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -136,13 +136,13 @@ Configure help --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/functoria/help/describe.t
+++ b/test/functoria/help/describe.t
@@ -54,13 +54,13 @@ Help describe --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -156,13 +156,13 @@ Help describe --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/functoria/help/query.t
+++ b/test/functoria/help/query.t
@@ -47,13 +47,13 @@ Help query --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -148,13 +148,13 @@ Help query --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/functoria/lib/run.t
+++ b/test/functoria/lib/run.t
@@ -166,10 +166,10 @@ Help configure
   
   APPLICATION OPTIONS
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -331,10 +331,10 @@ Build help no config with bad arguments
   
   APPLICATION OPTIONS
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/functoria/tool/run.t
+++ b/test/functoria/tool/run.t
@@ -307,10 +307,10 @@ Build help no config with bad arguments
   
   APPLICATION OPTIONS
          --vote=VOTE (absent=cat)
-             Vote. 
+             Vote.
   
          --warn-error=BOOL (absent=false)
-             Enable -warn-error when compiling OCaml sources. 
+             Enable -warn-error when compiling OCaml sources.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/help/build.t
+++ b/test/mirage/help/build.t
@@ -15,64 +15,64 @@ Help build --man-format=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   OCAML RUNTIME PARAMETERS
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -89,7 +89,7 @@ Help build --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -153,64 +153,64 @@ Help build --help=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   OCAML RUNTIME PARAMETERS
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -227,7 +227,7 @@ Help build --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/help/clean.t
+++ b/test/mirage/help/clean.t
@@ -16,64 +16,64 @@ Help clean --man-format=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   OCAML RUNTIME PARAMETERS
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -90,7 +90,7 @@ Help clean --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -155,64 +155,64 @@ Help clean --help=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   OCAML RUNTIME PARAMETERS
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -229,7 +229,7 @@ Help clean --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/help/configure-o.t
+++ b/test/mirage/help/configure-o.t
@@ -15,64 +15,64 @@ Help configure -o --man-format=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   OCAML RUNTIME PARAMETERS
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -106,7 +106,7 @@ Help configure -o --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -173,64 +173,64 @@ Help configure -o --help=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   OCAML RUNTIME PARAMETERS
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -264,7 +264,7 @@ Help configure -o --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/help/configure.t
+++ b/test/mirage/help/configure.t
@@ -15,64 +15,64 @@ Help configure --man-format=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   OCAML RUNTIME PARAMETERS
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -106,7 +106,7 @@ Help configure --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -173,64 +173,64 @@ Configure help --help=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   OCAML RUNTIME PARAMETERS
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -264,7 +264,7 @@ Configure help --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/help/describe.t
+++ b/test/mirage/help/describe.t
@@ -28,64 +28,64 @@ Help describe --man-format=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   OCAML RUNTIME PARAMETERS
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   DESCRIBE OPTIONS
          --dot
@@ -119,7 +119,7 @@ Help describe --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -196,64 +196,64 @@ Help describe --help=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   OCAML RUNTIME PARAMETERS
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   DESCRIBE OPTIONS
          --dot
@@ -287,7 +287,7 @@ Help describe --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/help/query.t
+++ b/test/mirage/help/query.t
@@ -15,7 +15,7 @@ Help query --man-format=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   QUERY OPTIONS
          --depext
@@ -39,58 +39,58 @@ Help query --man-format=plain
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -112,7 +112,7 @@ Help query --man-format=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)
@@ -179,7 +179,7 @@ Help query --help=plain
          -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
              Be more or less verbose. LEVEL must be of the form
              *:info,foo:debug means that that the log threshold is set to info
-             for every log sources but the foo which is set to debug. 
+             for every log sources but the foo which is set to debug.
   
   QUERY OPTIONS
          --depext
@@ -203,58 +203,58 @@ Help query --help=plain
          --allocation-policy=ALLOCATION (absent=next-fit)
              The policy used for allocating in the OCaml heap. Possible values
              are: next-fit, first-fit, best-fit. Best-fit is only supported
-             since OCaml 4.10. 
+             since OCaml 4.10.
   
          --backtrace=BOOL (absent=true)
              Trigger the printing of a stack backtrace when an uncaught
-             exception aborts the unikernel. 
+             exception aborts the unikernel.
   
          --custom-major-ratio=CUSTOM MAJOR RATIO
              Target ratio of floating garbage to major heap size for
-             out-of-heap memory held by custom values. Default: 44. 
+             out-of-heap memory held by custom values. Default: 44.
   
          --custom-minor-max-size=CUSTOM MINOR MAX SIZE
              Maximum amount of out-of-heap memory for each custom value
-             allocated in the minor heap. Default: 8192 bytes. 
+             allocated in the minor heap. Default: 8192 bytes.
   
          --custom-minor-ratio=CUSTOM MINOR RATIO
              Bound on floating garbage for out-of-heap memory held by custom
-             values in the minor heap. Default: 100. 
+             values in the minor heap. Default: 100.
   
          --gc-verbosity=VERBOSITY
              GC messages on standard error output. Sum of flags. Check GC
-             module documentation for details. 
+             module documentation for details.
   
          --gc-window-size=WINDOW SIZE
              The size of the window used by the major GC for smoothing out
-             variations in its workload. Between 1 adn 50, default: 1. 
+             variations in its workload. Between 1 adn 50, default: 1.
   
          --major-heap-increment=MAJOR INCREMENT
              The size increment for the major heap (in words). If less than or
              equal 1000, it is a percentage of the current heap size. If more
-             than 1000, it is a fixed number of words. Default: 15. 
+             than 1000, it is a fixed number of words. Default: 15.
   
          --max-space-overhead=MAX SPACE OVERHEAD
              Heap compaction is triggered when the estimated amount of wasted
              memory exceeds this (percentage of live data). If above 1000000,
-             compaction is never triggered. Default: 500. 
+             compaction is never triggered. Default: 500.
   
          --minor-heap-size=MINOR SIZE
-             The size of the minor heap (in words). Default: 256k. 
+             The size of the minor heap (in words). Default: 256k.
   
          --randomize-hashtables=BOOL (absent=true)
-             Turn on randomization of all hash tables by default. 
+             Turn on randomization of all hash tables by default.
   
          --space-overhead=SPACE OVERHEAD
              The percentage of live data of wasted memory, due to GC does not
              immediately collect unreachable blocks. The major GC speed is
              computed from this parameter, it will work more if smaller.
-             Default: 80. 
+             Default: 80.
   
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode. 
+             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -276,7 +276,7 @@ Help query --help=plain
   
   APPLICATION OPTIONS
          --hello=VAL (absent=Hello World!)
-             How to say hello. 
+             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)


### PR DESCRIPTION
This doesn't seem to be used anymore - it was a great initial feature to have initially to migrate from previous version of mirage, but it doesn't seem to be useful anymore. So let's remove it :-)

On top of #1435 