### PR TITLE
Simplify the management of configure and runtime keys

### DIFF
--- a/lib/functoria/DSL.ml
+++ b/lib/functoria/DSL.ml
@@ -46,9 +46,9 @@ let impl ?packages ?packages_v ?install ?install_v ?keys ?extra_deps ?connect
   @@ Device.v ?packages ?packages_v ?install ?install_v ?keys ?extra_deps
        ?connect ?dune ?configure ?files module_name module_type
 
-let main ?packages ?packages_v ?keys ?extra_deps module_name ty =
+let main ?packages ?packages_v ?extra_deps module_name ty =
   let connect _ = Device.start in
-  impl ?packages ?packages_v ?keys ?extra_deps ~connect module_name ty
+  impl ?packages ?packages_v ?extra_deps ~connect module_name ty
 
-let foreign ?packages ?packages_v ?keys ?deps module_name ty =
-  main ?packages ?packages_v ?keys ?extra_deps:deps module_name ty
+let foreign ?packages ?packages_v ?deps module_name ty =
+  main ?packages ?packages_v ?extra_deps:deps module_name ty

--- a/lib/functoria/DSL.mli
+++ b/lib/functoria/DSL.mli
@@ -130,7 +130,6 @@ type info = Info.t
 val foreign :
   ?packages:package list ->
   ?packages_v:package list value ->
-  ?keys:abstract_key list ->
   ?deps:abstract_impl list ->
   string ->
   'a typ ->
@@ -140,7 +139,6 @@ val foreign :
 val main :
   ?packages:package list ->
   ?packages_v:package list value ->
-  ?keys:abstract_key list ->
   ?extra_deps:abstract_impl list ->
   string ->
   'a typ ->
@@ -150,8 +148,6 @@ val main :
 
     - If [packages] or [packages_v] is set, then the given packages are
       installed before compiling the current application.
-    - If [keys] is set, use the given {{!Key.key} keys} to parse at configure
-      and runtime the command-line arguments before calling [<name>.connect].
     - If [extra_deps] is set, the given list of {{!abstract_impl} abstract}
       implementations is added as data-dependencies: they will be initialized
       before calling [<name>.connect]. *)

--- a/lib/functoria/job.ml
+++ b/lib/functoria/job.ml
@@ -34,16 +34,7 @@ module Keys = struct
     Action.with_output ~path:file ~purpose:"key_gen file" (fun ppf ->
         let keys = Key.Set.of_list @@ Info.keys i in
         let pp_var = Key.serialize (Info.context i) in
-        Fmt.pf ppf "@[<v>%a@]@." Fmt.(iter Key.Set.iter pp_var) keys;
-        let runvars = Key.Set.elements (Key.filter_stage `Run keys) in
-        let pp_runvar ppf v = Fmt.pf ppf "%s_t" (Key.ocaml_name v) in
-        let pp_names ppf v = Fmt.pf ppf "%S" (Key.name v) in
-        Fmt.pf ppf
-          "@[<v2>let runtime_keys = List.combine@ @[<2>%a@]@ @[<2>%a@]@.@]"
-          Fmt.Dump.(list pp_runvar)
-          runvars
-          Fmt.Dump.(list pp_names)
-          runvars)
+        Fmt.pf ppf "@[<v>%a@]@." Fmt.(iter Key.Set.iter pp_var) keys)
 end
 
 let keys ?(runtime_package = "functoria-runtime")
@@ -54,10 +45,10 @@ let keys ?(runtime_package = "functoria-runtime")
   let file = Fpath.(v (String.Ascii.lowercase key_gen) + "ml") in
   let configure = Keys.configure ~file in
   let files _ = [ file ] in
-  let connect info impl_name = function
+  let connect info _ = function
     | [ argv ] ->
-        Fmt.str "return (%s.with_argv (List.map fst %s.runtime_keys) %S %s)"
-          runtime_modname impl_name (Info.name info) argv
+        Fmt.str "return %s.(with_argv (runtime_keys ()) %S %s)" runtime_modname
+          (Info.name info) argv
     | _ -> failwith "The keys connect should receive exactly one argument."
   in
   Impl.v ~files ~configure ~packages ~extra_deps ~connect key_gen t

--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -140,7 +140,7 @@ module Arg = struct
     | Required : 'a converter -> 'a option kind
     | Flag : bool kind
 
-  type stage = [ `Configure | `Run | `Both ]
+  type stage = [ `Configure | `Run ]
 
   let pp_conv c = snd (converter c)
 
@@ -191,15 +191,16 @@ module Arg = struct
 
   let stage t = t.stage
 
-  let opt ?(stage = `Both) conv default info =
+  let opt ?(stage = `Configure) conv default info =
     { stage; info; kind = Opt (default, conv) }
 
-  let flag ?(stage = `Both) info = { stage; info; kind = Flag }
+  let flag ?(stage = `Configure) info = { stage; info; kind = Flag }
 
-  let required ?(stage = `Both) conv info =
+  let required ?(stage = `Configure) conv info =
     { stage; info; kind = Required conv }
 
-  let opt_all ?(stage = `Both) conv info = { stage; info; kind = Opt_all conv }
+  let opt_all ?(stage = `Configure) conv info =
+    { stage; info; kind = Opt_all conv }
 
   let default (type a) (t : a t) =
     match t.kind with
@@ -315,18 +316,13 @@ let abstract = v
 let arg k = k.arg
 let name (Any k) = k.name
 let stage (Any k) = Arg.stage k.arg
-
-let is_runtime k =
-  match stage k with `Run | `Both -> true | `Configure -> false
-
-let is_configure k =
-  match stage k with `Configure | `Both -> true | `Run -> false
+let is_runtime k = match stage k with `Run -> true | `Configure -> false
+let is_configure k = match stage k with `Configure -> true | `Run -> false
 
 let filter_stage stage s =
   match stage with
   | `Run -> Set.filter is_runtime s
   | `Configure | `NoEmit -> Set.filter is_configure s
-  | `Both -> s
 
 (* Key Map *)
 

--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -241,14 +241,6 @@ module Arg = struct
         in
         make_opt_all_cmdliner wrap i desc
 
-  let serialize_value (type a) (v : a) ppf (t : a t) =
-    match t.kind with
-    | Flag -> (serialize bool) ppf v
-    | Opt (_, c) -> (serialize c) ppf v
-    | Required c -> (
-        match v with Some v -> (serialize c) ppf v | None -> assert false)
-    | Opt_all c -> (serialize (list c)) ppf v
-
   (* This is only called by serialize_ro, hence a configure time
            key, so the value is known. *)
 
@@ -457,12 +449,4 @@ let serialize_runtime ctx fmt t =
      @[<2>let %s =@ @[Functoria_runtime.key@ %s_t@]@]@,"
     (ocaml_name t) (serialize ctx) t (ocaml_name t) (ocaml_name t)
 
-let serialize_configure ctx fmt t =
-  let (Any k) = t in
-  Format.fprintf fmt "@[<2>let %s () =@ %a@]@," (ocaml_name t)
-    (Arg.serialize_value (get ctx k))
-    (arg k)
-
-let serialize ctx fmt k =
-  if is_runtime k then serialize_runtime ctx fmt k
-  else serialize_configure ctx fmt k
+let serialize ctx fmt k = if is_runtime k then serialize_runtime ctx fmt k

--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -440,22 +440,23 @@ let ocaml_name k = Name.ocamlify (name k)
 let serialize_call fmt k = Fmt.pf fmt "(%s.%s ())" module_name (ocaml_name k)
 let serialize ctx ppf (Any k) = Arg.serialize (get ctx k) ppf (arg k)
 
-let serialize_rw ctx fmt t =
+let serialize_runtime ctx fmt t =
   Format.fprintf fmt
     "@[<2>let %s =@ @[Functoria_runtime.Key.create@ %a@]@]@,\
      @,\
-     @[<2>let %s_t =@ @[Functoria_runtime.Key.term@ %s@]@]@,\
+     @[<2>let () =@ @[Functoria_runtime.(key@ (Key.term@ %s))@]@]@,\
      @,\
      @[<2>let %s () =@ @[Functoria_runtime.Key.get@ %s@]@]@,"
     (ocaml_name t)
     Fmt.(parens (serialize ctx))
-    t (ocaml_name t) (ocaml_name t) (ocaml_name t) (ocaml_name t)
+    t (ocaml_name t) (ocaml_name t) (ocaml_name t)
 
-let serialize_ro ctx fmt t =
+let serialize_configure ctx fmt t =
   let (Any k) = t in
   Format.fprintf fmt "@[<2>let %s () =@ %a@]@," (ocaml_name t)
     (Arg.serialize_value (get ctx k))
     (arg k)
 
 let serialize ctx fmt k =
-  if is_runtime k then serialize_rw ctx fmt k else serialize_ro ctx fmt k
+  if is_runtime k then serialize_runtime ctx fmt k
+  else serialize_configure ctx fmt k

--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -20,7 +20,12 @@ open Misc
 
 module Serialize = struct
   let string fmt s = Format.fprintf fmt "%S" s
-  let option x = Fmt.(parens @@ Dump.option x)
+
+  let option x ppf v =
+    match v with
+    | None -> Fmt.(Dump.option x) ppf v
+    | Some _ -> Fmt.(parens (Dump.option x)) ppf v
+
   let list x = Fmt.Dump.list x
   let pair a b = Fmt.Dump.pair a b
 end
@@ -43,20 +48,20 @@ module Arg = struct
   let runtime_conv x = x.runtime_conv
 
   let string =
-    conv ~conv:Cmdliner.Arg.string ~runtime_conv:"Cmdliner.Arg.string"
-      ~serialize:(fun fmt -> Format.fprintf fmt "%S")
+    conv ~conv:Cmdliner.Arg.string ~runtime_conv:"string" ~serialize:(fun fmt ->
+        Format.fprintf fmt "%S")
 
   let bool =
-    conv ~conv:Cmdliner.Arg.bool ~runtime_conv:"Cmdliner.Arg.bool"
-      ~serialize:(fun fmt -> Format.fprintf fmt "%b")
+    conv ~conv:Cmdliner.Arg.bool ~runtime_conv:"bool" ~serialize:(fun fmt ->
+        Format.fprintf fmt "%b")
 
   let int =
-    conv ~conv:Cmdliner.Arg.int ~runtime_conv:"Cmdliner.Arg.int"
-      ~serialize:(fun fmt i -> Format.fprintf fmt "(%i)" i)
+    conv ~conv:Cmdliner.Arg.int ~runtime_conv:"int" ~serialize:(fun fmt i ->
+        Format.fprintf fmt "(%i)" i)
 
   let int64 =
-    conv ~conv:Cmdliner.Arg.int64 ~runtime_conv:"Cmdliner.Arg.int64"
-      ~serialize:(fun fmt i -> Format.fprintf fmt "(%LiL)" i)
+    conv ~conv:Cmdliner.Arg.int64 ~runtime_conv:"int64" ~serialize:(fun fmt i ->
+        Format.fprintf fmt "(%LiL)" i)
 
   let list ?sep d =
     let runtime_conv =
@@ -122,8 +127,8 @@ module Arg = struct
     let pp_env = pp_opt "env" serialize_env in
     let pp_doc = pp_opt "doc" Serialize.string in
     let pp_docv = pp_opt "docv" Serialize.string in
-    Format.fprintf fmt "(Cmdliner.Arg.info@ ~docs:%a%a%a%a@ %a)"
-      Serialize.string docs pp_docv docv pp_doc doc pp_env env
+    Format.fprintf fmt "@[(info@ ~docs:%a%a%a%a@ %a)@]" Serialize.string docs
+      pp_docv docv pp_doc doc pp_env env
       Serialize.(list string)
       names
 

--- a/lib/functoria/key.mli
+++ b/lib/functoria/key.mli
@@ -97,32 +97,30 @@ module Arg : sig
 
   (** {1 Optional Arguments} *)
 
-  type stage = [ `Configure | `Run | `Both ]
+  type stage = [ `Configure | `Run ]
   (** The type for specifying at which stage an argument is available.
 
       - [`Configure] means that the argument is read on the command-line at
         configuration-time.
-      - [`Run] means that the argument is read on the command-line at runtime.
-      - [`Both] means that the argument is read on the command-line both at
-        configuration-time and run-time. *)
+      - [`Run] means that the argument is read on the command-line at runtime. *)
 
   val opt : ?stage:stage -> 'a converter -> 'a -> info -> 'a t
   (** [opt conv v i] is similar to
       {{:http://erratique.ch/software/cmdliner/doc/Cmdliner/Arg/index.html#val-opt}
         Cmdliner.Arg.opt} but for cross-stage optional command-line arguments.
-      If not set, [stage] is [`Both]. *)
+      If not set, [stage] is [`Configure]. *)
 
   val required : ?stage:stage -> 'a converter -> info -> 'a option t
   (** [required conv i] is similar to
       {{:http://erratique.ch/software/cmdliner/doc/Cmdliner/Arg/index.html#val-required}
         Cmdliner.Arg.required} but for cross-stage required command-line
-      arguments. If not set, [stage] is [`Both]. *)
+      arguments. If not set, [stage] is [`Configure]. *)
 
   val flag : ?stage:stage -> info -> bool t
   (** [flag i] is similar to
       {{:http://erratique.ch/software/cmdliner/doc/Cmdliner/Arg/index.html#val-flag}
         Cmdliner.Arg.flag} but for cross-stage command-line flags. If not set,
-      [stage] is [`Both]. *)
+      [stage] is [`Configure]. *)
 
   val opt_all : ?stage:stage -> 'a converter -> info -> 'a list t
 end
@@ -217,10 +215,10 @@ val pp_deps : 'a value Fmt.t
 (** {1 Stages} *)
 
 val is_runtime : t -> bool
-(** [is_runtime k] is true if [k]'s stage is [`Run] or [`Both]. *)
+(** [is_runtime k] is true if [k]'s stage is [`Run]. *)
 
 val is_configure : t -> bool
-(** [is_configure k] is true if [k]'s stage is [`Configure] or [`Both]. *)
+(** [is_configure k] is true if [k]'s stage is [`Configure]. *)
 
 val filter_stage : Arg.stage -> Set.t -> Set.t
 (** [filter_stage s ks] is [ks] but with only keys available at stage [s]. *)

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -23,16 +23,18 @@ open Astring
 module Arg = struct
   include Key.Arg
 
-  let from_run s = "Mirage_runtime.Arg." ^ s
+  let from_run s =
+    Fmt.str "@[<2>(Functoria_runtime.Arg.conv@ %s.of_string@ %s.to_string)@]" s
+      s
 
-  let make d m of_string to_string =
+  let make m of_string to_string =
     let parser s =
       match of_string s with
       | Error (`Msg m) -> `Error ("Can't parse ip address: " ^ s ^ ": " ^ m)
       | Ok ip -> `Ok ip
     and serialize ppf t = Fmt.pf ppf "(%s.of_string_exn %S)" m (to_string t)
     and pp ppf t = Fmt.string ppf (to_string t) in
-    Key.Arg.conv ~conv:(parser, pp) ~serialize ~runtime_conv:(from_run d)
+    Key.Arg.conv ~conv:(parser, pp) ~serialize ~runtime_conv:(from_run m)
 
   module type S = sig
     type t
@@ -41,14 +43,14 @@ module Arg = struct
     val to_string : t -> string
   end
 
-  let of_module (type t) d m (module M : S with type t = t) =
-    make d m M.of_string M.to_string
+  let of_module (type t) m (module M : S with type t = t) =
+    make m M.of_string M.to_string
 
-  let ipv4_address = of_module "ipv4_address" "Ipaddr.V4" (module Ipaddr.V4)
-  let ipv4 = of_module "ipv4" "Ipaddr.V4.Prefix" (module Ipaddr.V4.Prefix)
-  let ipv6_address = of_module "ipv6_address" "Ipaddr.V6" (module Ipaddr.V6)
-  let ipv6 = of_module "ipv6" "Ipaddr.V6.Prefix" (module Ipaddr.V6.Prefix)
-  let ip_address = of_module "ip_address" "Ipaddr" (module Ipaddr)
+  let ipv4_address = of_module "Ipaddr.V4" (module Ipaddr.V4)
+  let ipv4 = of_module "Ipaddr.V4.Prefix" (module Ipaddr.V4.Prefix)
+  let ipv6_address = of_module "Ipaddr.V6" (module Ipaddr.V6)
+  let ipv6 = of_module "Ipaddr.V6.Prefix" (module Ipaddr.V6.Prefix)
+  let ip_address = of_module "Ipaddr" (module Ipaddr)
 end
 
 (** {2 Documentation helper} *)

--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -24,7 +24,7 @@ module Arg = struct
   include Key.Arg
 
   let from_run s =
-    Fmt.str "@[<2>(Functoria_runtime.Arg.conv@ %s.of_string@ %s.to_string)@]" s
+    Fmt.str "@[<2>(Functoria_runtime.Key.conv@ %s.of_string@ %s.to_string)@]" s
       s
 
   let make m of_string to_string =

--- a/lib_runtime/functoria/functoria_runtime.ml
+++ b/lib_runtime/functoria/functoria_runtime.ml
@@ -31,13 +31,6 @@ module Arg = struct
   let key ?default c i =
     match default with None -> required c i | Some d -> opt c d i
 
-  let default (type a) (t : a t) =
-    match t.kind with
-    | Opt (d, _) -> Some d
-    | Opt_all (d, _) -> Some d
-    | Flag -> Some false
-    | Required _ -> None
-
   let kind t = t.kind
   let info t = t.info
 
@@ -61,8 +54,6 @@ module Key = struct
           "Key.get: Called too early. Please delay this call after cmdliner's \
            evaluation."
     | Some v -> v
-
-  let default t = Arg.default t.arg
 
   let term (type a) (t : a t) =
     let set w = t.value <- Some w in

--- a/lib_runtime/functoria/functoria_runtime.ml
+++ b/lib_runtime/functoria/functoria_runtime.ml
@@ -40,6 +40,10 @@ module Arg = struct
 
   let kind t = t.kind
   let info t = t.info
+
+  let conv of_string to_string : _ Cmdliner.Arg.conv =
+    let pp ppf v = Format.pp_print_string ppf (to_string v) in
+    Cmdliner.Arg.conv (of_string, pp)
 end
 
 module Key = struct

--- a/lib_runtime/functoria/functoria_runtime.ml
+++ b/lib_runtime/functoria/functoria_runtime.ml
@@ -14,36 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Arg = struct
-  type 'a kind =
-    | Opt : 'a * 'a Cmdliner.Arg.conv -> 'a kind
-    | Opt_all : 'a list * 'a Cmdliner.Arg.conv -> 'a list kind
-    | Flag : bool kind
-    | Required : 'a Cmdliner.Arg.conv -> 'a kind
-
-  type 'a t = { info : Cmdliner.Arg.info; kind : 'a kind }
-
-  let flag info = { info; kind = Flag }
-  let opt conv default info = { info; kind = Opt (default, conv) }
-  let opt_all conv default info = { info; kind = Opt_all (default, conv) }
-  let required conv info = { info; kind = Required conv }
-
-  let key ?default c i =
-    match default with None -> required c i | Some d -> opt c d i
-
-  let kind t = t.kind
-  let info t = t.info
-
-  let conv of_string to_string : _ Cmdliner.Arg.conv =
-    let pp ppf v = Format.pp_print_string ppf (to_string v) in
-    Cmdliner.Arg.conv (of_string, pp)
-end
-
 let runtime_keys_r = ref []
 let runtime_keys () = !runtime_keys_r
 
 module Key = struct
-  type 'a t = { arg : 'a Arg.t; mutable value : 'a option }
+  type 'a t = { arg : 'a Cmdliner.Term.t; mutable value : 'a option }
 
   let create arg = { arg; value = None }
 
@@ -57,19 +32,18 @@ module Key = struct
 
   let term (type a) (t : a t) =
     let set w = t.value <- Some w in
-    let doc = Arg.info t.arg in
-    let term arg = Cmdliner.Term.(const set $ arg) in
-    match Arg.kind t.arg with
-    | Arg.Flag -> term @@ Cmdliner.Arg.(value & flag doc)
-    | Arg.Opt (default, desc) ->
-        term @@ Cmdliner.Arg.(value & opt desc default doc)
-    | Arg.Opt_all (default, desc) ->
-        term @@ Cmdliner.Arg.(value & opt_all desc default doc)
-    | Arg.Required desc ->
-        term @@ Cmdliner.Arg.(required & opt (some desc) None doc)
+    Cmdliner.Term.(const set $ t.arg)
+
+  let conv of_string to_string : _ Cmdliner.Arg.conv =
+    let pp ppf v = Format.pp_print_string ppf (to_string v) in
+    Cmdliner.Arg.conv (of_string, pp)
 end
 
-let key t = runtime_keys_r := t :: !runtime_keys_r
+let key t =
+  let u = Key.create t in
+  runtime_keys_r := Key.term u :: !runtime_keys_r;
+  fun () -> Key.get u
+
 let initialized = ref false
 let help_version = 63
 let argument_error = 64

--- a/lib_runtime/functoria/functoria_runtime.ml
+++ b/lib_runtime/functoria/functoria_runtime.ml
@@ -46,6 +46,9 @@ module Arg = struct
     Cmdliner.Arg.conv (of_string, pp)
 end
 
+let runtime_keys_r = ref []
+let runtime_keys () = !runtime_keys_r
+
 module Key = struct
   type 'a t = { arg : 'a Arg.t; mutable value : 'a option }
 
@@ -75,6 +78,7 @@ module Key = struct
         term @@ Cmdliner.Arg.(required & opt (some desc) None doc)
 end
 
+let key t = runtime_keys_r := t :: !runtime_keys_r
 let initialized = ref false
 let help_version = 63
 let argument_error = 64

--- a/lib_runtime/functoria/functoria_runtime.mli
+++ b/lib_runtime/functoria/functoria_runtime.mli
@@ -69,10 +69,6 @@ module Key : sig
 
       @raise Invalid_argument if called before cmdliner's evaluation. *)
 
-  val default : 'a t -> 'a option
-  (** [default k] is the default value of [k], if one is available. This
-      function can be called before cmdliner's evaluation. *)
-
   val term : 'a t -> unit Cmdliner.Term.t
   (** [term k] is the [Cmdliner] term whose evaluation sets [k]s' value to the
       parsed command-line argument. *)

--- a/lib_runtime/functoria/functoria_runtime.mli
+++ b/lib_runtime/functoria/functoria_runtime.mli
@@ -18,40 +18,6 @@
 
 (** Functoria runtime. *)
 
-(** [Arg] defines command-line arguments which can be set at runtime. This
-    module is the runtime companion of [Functoria.Key]. It exposes a subset of
-    {{:http://erratique.ch/software/cmdliner/doc/Cmdliner/Arg/index.html}
-      Cmdliner.Arg}. *)
-module Arg : sig
-  (** {1 Runtime command-line arguments} *)
-
-  type 'a t
-  (** The type for runtime command-line arguments. Similar to
-      [Functoria.Key.Arg.t] but only available at runtime. *)
-
-  val opt : 'a Cmdliner.Arg.conv -> 'a -> Cmdliner.Arg.info -> 'a t
-  (** [opt] is the runtime companion of [Functoria.Ky.Arg.opt]. *)
-
-  val opt_all :
-    'a Cmdliner.Arg.conv -> 'a list -> Cmdliner.Arg.info -> 'a list t
-  (** [opt_all] is the runtime companion of [Functoria.Key.Arg.opt_all]. *)
-
-  val required : 'a Cmdliner.Arg.conv -> Cmdliner.Arg.info -> 'a t
-  (** [required] is the runtime companion of [Functoria.Key.Arg.required]. *)
-
-  val key : ?default:'a -> 'a Cmdliner.Arg.conv -> Cmdliner.Arg.info -> 'a t
-  (** [key] is either {!opt} or {!required}, depending if [~default] is
-      provided. *)
-
-  val flag : Cmdliner.Arg.info -> bool t
-  (** [flag] is the runtime companion of [Functoria.Key.Arg.flag]. *)
-
-  val conv :
-    (string -> ('a, [ `Msg of string ]) result) ->
-    ('a -> string) ->
-    'a Cmdliner.Arg.conv
-end
-
 (** [Key] defines values that can be set by runtime command-line arguments. This
     module is the runtime companion of {!Key}. *)
 module Key : sig
@@ -60,22 +26,20 @@ module Key : sig
   type 'a t
   (** The type for runtime keys containing a value of type ['a]. *)
 
-  val create : 'a Arg.t -> 'a t
+  val create : 'a Cmdliner.Term.t -> 'a t
   (** [create conv] create a new runtime key. *)
 
-  val get : 'a t -> 'a
-  (** [get k] is the value of the key [k]. Use the default value if no
-      command-line argument is provided.
-
-      @raise Invalid_argument if called before cmdliner's evaluation. *)
-
-  val term : 'a t -> unit Cmdliner.Term.t
-  (** [term k] is the [Cmdliner] term whose evaluation sets [k]s' value to the
-      parsed command-line argument. *)
+  val conv :
+    (string -> ('a, [ `Msg of string ]) result) ->
+    ('a -> string) ->
+    'a Cmdliner.Arg.conv
 end
 
-val key : unit Cmdliner.Term.t -> unit
-(** [key t] registers the Cmdliner term [k] as a runtime key. *)
+val key : 'a Cmdliner.Term.t -> unit -> 'a
+(** [key t] registers the Cmdliner term [k] as a runtime key and return a
+    callback [f] that evaluates to [t]s' value passed on the command-line.
+
+    [f] will raise [Invalid_argument] if called before cmdliner's evaluation. *)
 
 val argument_error : int
 (** [argument_error] is the exit code used for argument parsing errors: 64. *)

--- a/lib_runtime/functoria/functoria_runtime.mli
+++ b/lib_runtime/functoria/functoria_runtime.mli
@@ -45,6 +45,11 @@ module Arg : sig
 
   val flag : Cmdliner.Arg.info -> bool t
   (** [flag] is the runtime companion of [Functoria.Key.Arg.flag]. *)
+
+  val conv :
+    (string -> ('a, [ `Msg of string ]) result) ->
+    ('a -> string) ->
+    'a Cmdliner.Arg.conv
 end
 
 (** [Key] defines values that can be set by runtime command-line arguments. This

--- a/lib_runtime/functoria/functoria_runtime.mli
+++ b/lib_runtime/functoria/functoria_runtime.mli
@@ -78,6 +78,9 @@ module Key : sig
       parsed command-line argument. *)
 end
 
+val key : unit Cmdliner.Term.t -> unit
+(** [key t] registers the Cmdliner term [k] as a runtime key. *)
+
 val argument_error : int
 (** [argument_error] is the exit code used for argument parsing errors: 64. *)
 
@@ -92,3 +95,5 @@ type info = {
   libraries : (string * string) list;  (** the result of [dune-build-info] *)
 }
 (** The type for build information available at runtime. *)
+
+val runtime_keys : unit -> unit Cmdliner.Term.t list

--- a/lib_runtime/mirage/dune
+++ b/lib_runtime/mirage/dune
@@ -1,4 +1,4 @@
 (library
  (name mirage_runtime)
  (public_name mirage-runtime)
- (libraries functoria-runtime lwt ipaddr logs))
+ (libraries functoria-runtime lwt logs))

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -37,26 +37,6 @@ let set_level ~default l =
 module Arg = struct
   include Functoria_runtime.Arg
 
-  let make of_string to_string : _ Cmdliner.Arg.conv =
-    let pp ppf v = Format.pp_print_string ppf (to_string v) in
-    Cmdliner.Arg.conv (of_string, pp)
-
-  module type S = sig
-    type t
-
-    val of_string : string -> (t, [ `Msg of string ]) result
-    val to_string : t -> string
-  end
-
-  let of_module (type t) (module M : S with type t = t) =
-    make M.of_string M.to_string
-
-  let ip_address = of_module (module Ipaddr)
-  let ipv4_address = of_module (module Ipaddr.V4)
-  let ipv4 = of_module (module Ipaddr.V4.Prefix)
-  let ipv6_address = of_module (module Ipaddr.V6)
-  let ipv6 = of_module (module Ipaddr.V6.Prefix)
-
   let log_threshold =
     let parser str =
       let level src s =

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -35,8 +35,6 @@ let set_level ~default l =
     l
 
 module Arg = struct
-  include Functoria_runtime.Arg
-
   let log_threshold =
     let parser str =
       let level src s =
@@ -63,8 +61,7 @@ module Arg = struct
       ]
 end
 
-include (
-  Functoria_runtime : module type of Functoria_runtime with module Arg := Arg)
+include Functoria_runtime
 
 let exit_hooks = ref []
 let enter_iter_hooks = ref []

--- a/lib_runtime/mirage/mirage_runtime.mli
+++ b/lib_runtime/mirage/mirage_runtime.mli
@@ -32,42 +32,7 @@ module Arg : sig
 
   include module type of Functoria_runtime.Arg
 
-  val make :
-    (string -> ('a, [ `Msg of string ]) result) ->
-    ('a -> string) ->
-    'a Cmdliner.Arg.conv
-  (** [make of_string pp] is the command-line argument converter using on
-      [of_string] and [pp]. *)
-
-  (** [S] is the signature used by {!of_module} to create a command-line
-      argument converter. *)
-  module type S = sig
-    type t
-
-    val of_string : string -> (t, [ `Msg of string ]) result
-    val to_string : t -> string
-  end
-
-  val of_module : (module S with type t = 'a) -> 'a Cmdliner.Arg.conv
-  (** [of module (module M)] creates a command-line argyument converter from a
-      module satisfying the signature {!S}. *)
-
   (** {2 Mirage command-line argument converters} *)
-
-  val ip_address : Ipaddr.t Cmdliner.Arg.conv
-  (** [ip] converts IP address. *)
-
-  val ipv4_address : Ipaddr.V4.t Cmdliner.Arg.conv
-  (** [ipv4_address] converts an IPv4 address. *)
-
-  val ipv4 : Ipaddr.V4.Prefix.t Cmdliner.Arg.conv
-  (** [ipv4] converts ipv4/netmask to Ipaddr.V4.t * Ipaddr.V4.Prefix.t . *)
-
-  val ipv6_address : Ipaddr.V6.t Cmdliner.Arg.conv
-  (** [ipv6_address]converts IPv6 address. *)
-
-  val ipv6 : Ipaddr.V6.Prefix.t Cmdliner.Arg.conv
-  (**[ipv6] converts IPv6 prefixes. *)
 
   val log_threshold : log_threshold Cmdliner.Arg.conv
   (** [log_threshold] converts log reporter threshold. *)

--- a/lib_runtime/mirage/mirage_runtime.mli
+++ b/lib_runtime/mirage/mirage_runtime.mli
@@ -30,8 +30,6 @@ val set_level : default:Logs.level option -> log_threshold list -> unit
 module Arg : sig
   (** {2 Mirage command-line arguments} *)
 
-  include module type of Functoria_runtime.Arg
-
   (** {2 Mirage command-line argument converters} *)
 
   val log_threshold : log_threshold Cmdliner.Arg.conv
@@ -42,7 +40,7 @@ module Arg : sig
   (** [allocation_policy] converts allocation policy. *)
 end
 
-include module type of Functoria_runtime with module Arg := Arg
+include module type of Functoria_runtime
 
 (** {2 Registering scheduler hooks} *)
 

--- a/test/functoria-runtime/app.ml
+++ b/test/functoria-runtime/app.ml
@@ -1,6 +1,4 @@
-module type K = sig
-  val runtime_keys : (unit Cmdliner.Term.t * string) list
-end
+module type K = sig end
 
 module type I = sig
   val info : Functoria_runtime.info

--- a/test/functoria/e2e/app/app.ml
+++ b/test/functoria/e2e/app/app.ml
@@ -1,5 +1,10 @@
 open Cmdliner
 
+let hello =
+  let doc = Arg.info ~doc:"How to say hello." [ "hello" ] in
+  let key = Arg.(value @@ opt string "Hello World!" doc) in
+  Functoria_runtime.key key
+
 let arg =
   let doc =
     Arg.info ~docs:"APPLICATION OPTIONS" ~doc:"A runtime argument." [ "arg" ]
@@ -8,6 +13,5 @@ let arg =
   Functoria_runtime.key key
 
 module Make (_ : sig end) = struct
-  let start () =
-    Fmt.pr "Success: hello=%s arg=%s\n%!" Key_gen.(hello ()) (arg ())
+  let start () = Fmt.pr "Success: hello=%s arg=%s\n%!" (hello ()) (arg ())
 end

--- a/test/functoria/e2e/app/app.ml
+++ b/test/functoria/e2e/app/app.ml
@@ -9,8 +9,5 @@ let arg =
 
 module Make (_ : sig end) = struct
   let start () =
-    Fmt.pr "Success: vote=%s hello=%s arg=%s\n%!"
-      Key_gen.(vote ())
-      Key_gen.(hello ())
-      (arg ())
+    Fmt.pr "Success: hello=%s arg=%s\n%!" Key_gen.(hello ()) (arg ())
 end

--- a/test/functoria/e2e/app/app.ml
+++ b/test/functoria/e2e/app/app.ml
@@ -1,4 +1,16 @@
+open Cmdliner
+
+let arg =
+  let doc =
+    Arg.info ~docs:"APPLICATION OPTIONS" ~doc:"A runtime argument." [ "arg" ]
+  in
+  let key = Arg.(value & opt string "-" doc) in
+  Functoria_runtime.key key
+
 module Make (_ : sig end) = struct
   let start () =
-    Fmt.pr "Success: vote=%s hello=%s\n%!" Key_gen.(vote ()) Key_gen.(hello ())
+    Fmt.pr "Success: vote=%s hello=%s arg=%s\n%!"
+      Key_gen.(vote ())
+      Key_gen.(hello ())
+      (arg ())
 end

--- a/test/functoria/e2e/app/config.ml
+++ b/test/functoria/e2e/app/config.ml
@@ -1,9 +1,5 @@
 open Functoria
 open E2e
 
-let key =
-  let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt ~stage:`Run string "Hello World!" doc))
-
-let main = main ~keys:[ Key.v key ] "App.Make" (job @-> job)
+let main = main "App.Make" (job @-> job)
 let () = register "noop" [ main $ noop ]

--- a/test/functoria/e2e/app/config.ml
+++ b/test/functoria/e2e/app/config.ml
@@ -3,7 +3,7 @@ open E2e
 
 let key =
   let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt string "Hello World!" doc))
+  Key.(create "hello" Arg.(opt ~stage:`Run string "Hello World!" doc))
 
 let main = main ~keys:[ Key.v key ] "App.Make" (job @-> job)
 let () = register "noop" [ main $ noop ]

--- a/test/functoria/e2e/build.t
+++ b/test/functoria/e2e/build.t
@@ -39,7 +39,7 @@ Build an application.
   vote
   warn_error
   $ ./app/main.exe
-  Success: vote=cat hello=Hello World!
+  Success: vote=cat hello=Hello World! arg=-
   $ ./test.exe clean --file app/config.ml
   $ ls -a app/
   .
@@ -89,7 +89,7 @@ Test `--output`:
   vote
   warn_error
   $ ./app/toto.exe
-  Success: vote=cat hello=Hello World!
+  Success: vote=cat hello=Hello World! arg=-
   $ ./test.exe clean --file app/config.ml
   $ ls -a app/
   .

--- a/test/functoria/e2e/build.t
+++ b/test/functoria/e2e/build.t
@@ -12,10 +12,8 @@ Build an application.
   test.exe: [INFO] Generating: app/dune.config (base)
   config.exe: [INFO] reading cache app/test/context
   config.exe: [INFO] Name       noop
-                     Keys      
-                       hello=Hello World! (default),
-                       vote=cat (default),
-                       warn_error=false (default)
+                     Keys       vote=cat (default),
+                                warn_error=false (default)
   config.exe: [INFO] dune build --root .
   $ ls -a app/
   .
@@ -61,10 +59,8 @@ Test `--output`:
   test.exe: [INFO] Generating: app/dune.config (base)
   config.exe: [INFO] reading cache app/test/context
   config.exe: [INFO] Name       noop
-                     Keys      
-                       hello=Hello World! (default),
-                       vote=cat (default),
-                       warn_error=false (default)
+                     Keys       vote=cat (default),
+                                warn_error=false (default)
                      Output     toto
   config.exe: [INFO] dune build --root .
   $ ls -a app/

--- a/test/functoria/e2e/build.t
+++ b/test/functoria/e2e/build.t
@@ -39,7 +39,7 @@ Build an application.
   vote
   warn_error
   $ ./app/main.exe
-  Success: vote=cat hello=Hello World! arg=-
+  Success: hello=Hello World! arg=-
   $ ./test.exe clean --file app/config.ml
   $ ls -a app/
   .
@@ -89,7 +89,7 @@ Test `--output`:
   vote
   warn_error
   $ ./app/toto.exe
-  Success: vote=cat hello=Hello World! arg=-
+  Success: hello=Hello World! arg=-
   $ ./test.exe clean --file app/config.ml
   $ ls -a app/
   .

--- a/test/functoria/e2e/clean.t
+++ b/test/functoria/e2e/clean.t
@@ -32,10 +32,8 @@ Make sure that clean remove everything:
   test.exe: [INFO] Generating: app/dune.config (base)
   config.exe: [INFO] reading cache app/test/context
   config.exe: [INFO] Name       noop
-                     Keys      
-                       hello=Hello World! (default),
-                       vote=cat (default),
-                       warn_error=false (default)
+                     Keys       vote=cat (default),
+                                warn_error=false (default)
   test.exe: [INFO] Skipped ./app
   test.exe: [INFO] Skipped ./help.exe
   test.exe: [INFO] Skipped ./lib
@@ -80,10 +78,8 @@ Check that clean works with `--output`:
   test.exe: [INFO] Generating: app/dune.config (base)
   config.exe: [INFO] reading cache app/test/context
   config.exe: [INFO] Name       noop
-                     Keys      
-                       hello=Hello World! (default),
-                       vote=cat (default),
-                       warn_error=false (default)
+                     Keys       vote=cat (default),
+                                warn_error=false (default)
                      Output     toto
   test.exe: [INFO] Skipped ./app
   test.exe: [INFO] Skipped ./help.exe

--- a/test/functoria/e2e/configure.t
+++ b/test/functoria/e2e/configure.t
@@ -18,10 +18,8 @@ is passed:
   test.exe: [INFO] Set-up config skeleton.
   config.exe: [INFO] reading cache app/test/context
   config.exe: [INFO] Name       noop
-                     Keys      
-                       hello=Hello World! (default),
-                       vote=cat (default),
-                       warn_error=false (default)
+                     Keys       vote=cat (default),
+                                warn_error=false (default)
   config.exe: [INFO] Generating: noop.opam (opam)
   config.exe: [INFO] in dir { "context" = ;
                               "config_file" = app/config.ml;

--- a/test/functoria/e2e/describe.t
+++ b/test/functoria/e2e/describe.t
@@ -2,10 +2,8 @@ Test that `describe` works as expected:
 
   $ ./test.exe describe --file app/config.ml
   Name       noop
-  Keys      
-    hello=Hello World! (default),
-    vote=cat (default),
-    warn_error=false (default)
+  Keys       vote=cat (default),
+             warn_error=false (default)
   $ ./test.exe describe -v --file app/config.ml
   test.exe: [INFO] run: describe:
                         { "args" =
@@ -20,9 +18,7 @@ Test that `describe` works as expected:
   test.exe: [INFO] Generating: dune-project (base)
   test.exe: [INFO] Generating: app/dune.config (base)
   Name       noop
-  Keys      
-    hello=Hello World! (default),
-    vote=cat (default),
-    warn_error=false (default)
+  Keys       vote=cat (default),
+             warn_error=false (default)
   Libraries  fmt, functoria-runtime
   Packages   fmt { ?monorepo }, functoria-runtime { ?monorepo }

--- a/test/functoria/e2e/run.t
+++ b/test/functoria/e2e/run.t
@@ -2,7 +2,7 @@ Run an application
 
   $ ./test.exe configure --file app/config.ml
   $ dune exec -- ./app/main.exe --arg=yo
-  Success: vote=cat hello=Hello World! arg=yo
+  Success: hello=Hello World! arg=yo
   $ dune exec -- ./app/main.exe --help=plain
   NAME
          noop

--- a/test/functoria/e2e/run.t
+++ b/test/functoria/e2e/run.t
@@ -8,12 +8,13 @@ Run an application
          noop
   
   SYNOPSIS
-         noop [OPTION]…
+         noop [--hello=VAL] [OPTION]…
   
   APPLICATION OPTIONS
          --arg=VAL (absent=-)
              A runtime argument.
   
+  OPTIONS
          --hello=VAL (absent=Hello World!)
              How to say hello.
   

--- a/test/functoria/e2e/run.t
+++ b/test/functoria/e2e/run.t
@@ -1,0 +1,37 @@
+Run an application
+
+  $ ./test.exe configure --file app/config.ml
+  $ dune exec -- ./app/main.exe --arg=yo
+  Success: vote=cat hello=Hello World! arg=yo
+  $ dune exec -- ./app/main.exe --help=plain
+  NAME
+         noop
+  
+  SYNOPSIS
+         noop [OPTION]…
+  
+  APPLICATION OPTIONS
+         --arg=VAL (absent=-)
+             A runtime argument.
+  
+         --hello=VAL (absent=Hello World!)
+             How to say hello.
+  
+  COMMON OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of auto,
+             pager, groff or plain. With auto, the format is pager or plain
+             whenever the TERM env var is dumb or undefined.
+  
+  EXIT STATUS
+         noop exits with:
+  
+         0   on success.
+  
+         123 on indiscriminate errors reported on standard error.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  [63]

--- a/test/functoria/gen-1/key_gen.ml.expected
+++ b/test/functoria/gen-1/key_gen.ml.expected
@@ -1,4 +1,1 @@
 
-let runtime_keys = List.combine
-  []
-  []

--- a/test/functoria/gen-1/main.ml.expected
+++ b/test/functoria/gen-1/main.ml.expected
@@ -13,7 +13,7 @@ let sys__1 = lazy (
 let key_gen__2 = lazy (
   let __sys__1 = Lazy.force sys__1 in
   __sys__1 >>= fun _sys__1 ->
-  return (Functoria_runtime.with_argv (List.map fst Key_gen.runtime_keys) "foo" _sys__1)
+  return Functoria_runtime.(with_argv (runtime_keys ()) "foo" _sys__1)
   )
 
 let info_gen__3 = lazy (

--- a/test/functoria/gen-2/key_gen.ml.expected
+++ b/test/functoria/gen-2/key_gen.ml.expected
@@ -1,7 +1,6 @@
 let hello_t =
-  Cmdliner.Arg.(value (opt Cmdliner.Arg.string "Hello World!"
-    (Cmdliner.Arg.info ~docs:"APPLICATION OPTIONS" ~doc:"How to say hello."
-    ["hello"])))
+  Cmdliner.Arg.(value (opt string "Hello World!"
+    (info ~docs:"APPLICATION OPTIONS" ~doc:"How to say hello." ["hello"])))
 
 let hello = Functoria_runtime.key hello_t
 

--- a/test/functoria/gen-2/key_gen.ml.expected
+++ b/test/functoria/gen-2/key_gen.ml.expected
@@ -1,6 +1,1 @@
-let hello_t =
-  Cmdliner.Arg.(value (opt string "Hello World!"
-    (info ~docs:"APPLICATION OPTIONS" ~doc:"How to say hello." ["hello"])))
-
-let hello = Functoria_runtime.key hello_t
 

--- a/test/functoria/gen-2/key_gen.ml.expected
+++ b/test/functoria/gen-2/key_gen.ml.expected
@@ -4,10 +4,7 @@ let hello =
    (Cmdliner.Arg.info ~docs:"APPLICATION OPTIONS" ~doc:"How to say hello."
    ["hello"]))
 
-let hello_t = Functoria_runtime.Key.term hello
+let () = Functoria_runtime.(key (Key.term hello))
 
 let hello () = Functoria_runtime.Key.get hello
 
-let runtime_keys = List.combine
-  [hello_t]
-  ["hello"]

--- a/test/functoria/gen-2/key_gen.ml.expected
+++ b/test/functoria/gen-2/key_gen.ml.expected
@@ -1,10 +1,7 @@
-let hello =
-  Functoria_runtime.Key.create
-  (Functoria_runtime.Arg.opt Cmdliner.Arg.string "Hello World!"
-   (Cmdliner.Arg.info ~docs:"APPLICATION OPTIONS" ~doc:"How to say hello."
-   ["hello"]))
+let hello_t =
+  Cmdliner.Arg.(value (opt Cmdliner.Arg.string "Hello World!"
+    (Cmdliner.Arg.info ~docs:"APPLICATION OPTIONS" ~doc:"How to say hello."
+    ["hello"])))
 
-let () = Functoria_runtime.(key (Key.term hello))
-
-let hello () = Functoria_runtime.Key.get hello
+let hello = Functoria_runtime.key hello_t
 

--- a/test/functoria/gen-2/main.ml.expected
+++ b/test/functoria/gen-2/main.ml.expected
@@ -13,7 +13,7 @@ let sys__1 = lazy (
 let key_gen__2 = lazy (
   let __sys__1 = Lazy.force sys__1 in
   __sys__1 >>= fun _sys__1 ->
-  return (Functoria_runtime.with_argv (List.map fst Key_gen.runtime_keys) "foo" _sys__1)
+  return Functoria_runtime.(with_argv (runtime_keys ()) "foo" _sys__1)
   )
 
 let unit__3 = lazy (

--- a/test/functoria/gen-2/test.ml
+++ b/test/functoria/gen-2/test.ml
@@ -21,7 +21,7 @@ let build_info =
 
 let key =
   let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt string "Hello World!" doc))
+  Key.(create "hello" Arg.(opt ~stage:`Run string "Hello World!" doc))
 
 let test () =
   let i1 = keys sys_argv in

--- a/test/functoria/gen-2/test.ml
+++ b/test/functoria/gen-2/test.ml
@@ -19,18 +19,12 @@ let build_info =
     ("topkg", "1.0.1");
   ]
 
-let key =
-  let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt ~stage:`Run string "Hello World!" doc))
-
 let test () =
   let i1 = keys sys_argv in
   let i2 = noop in
   let context = Context.empty in
   let sigs = job @-> job @-> info @-> job in
-  let job =
-    main ~keys:[ Key.v key ] "App.Make" sigs $ i1 $ i2 $ app_info ~build_info ()
-  in
+  let job = main "App.Make" sigs $ i1 $ i2 $ app_info ~build_info () in
   Functoria_test.run ~init:[ i1; i2 ] context job
 
 let () =

--- a/test/functoria/help/build.t
+++ b/test/functoria/help/build.t
@@ -23,9 +23,6 @@ Help build --man-format=plain
              Name of the output file.
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   
@@ -95,9 +92,6 @@ Help build --help=plain
              Name of the output file.
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   

--- a/test/functoria/help/clean.t
+++ b/test/functoria/help/clean.t
@@ -23,9 +23,6 @@ Help clean --man-format=plain
              Name of the output file.
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   
@@ -95,9 +92,6 @@ Help clean --help=plain
              Name of the output file.
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   

--- a/test/functoria/help/config.ml
+++ b/test/functoria/help/config.ml
@@ -1,9 +1,5 @@
 open F0
 open Functoria
 
-let key =
-  let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt string "Hello World!" doc))
-
-let main = Functoria.main ~keys:[ Key.v key ] "App" job
+let main = Functoria.main "App" job
 let () = register ~src:`None "noop" [ main ]

--- a/test/functoria/help/configure-o.t
+++ b/test/functoria/help/configure-o.t
@@ -40,9 +40,6 @@ Help configure -o --man-format=plain
              Name of the output file.
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   
@@ -135,9 +132,6 @@ Help configure -o --help=plain
              Name of the output file.
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   

--- a/test/functoria/help/configure.t
+++ b/test/functoria/help/configure.t
@@ -40,9 +40,6 @@ Help configure --man-format=plain
              Name of the output file.
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   
@@ -135,9 +132,6 @@ Configure help --help=plain
              Name of the output file.
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   

--- a/test/functoria/help/describe.t
+++ b/test/functoria/help/describe.t
@@ -53,9 +53,6 @@ Help describe --man-format=plain
              Name of the output file.
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   
@@ -155,9 +152,6 @@ Help describe --help=plain
              Name of the output file.
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   

--- a/test/functoria/help/query.t
+++ b/test/functoria/help/query.t
@@ -46,9 +46,6 @@ Help query --man-format=plain
              'dune-project', 'dune-workspace' or 'dune.dist'
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   
@@ -147,9 +144,6 @@ Help query --help=plain
              'dune-project', 'dune-workspace' or 'dune.dist'
   
   APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
          --vote=VOTE (absent=cat)
              Vote.
   

--- a/test/functoria/query/config.ml
+++ b/test/functoria/query/config.ml
@@ -3,7 +3,7 @@ open Functoria
 
 let key =
   let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt string "Hello World!" doc))
+  Key.(create "hello" Arg.(opt ~stage:`Run string "Hello World!" doc))
 
 let main =
   Functoria.main ~keys:[ Key.v key ] ~extra_deps:[ dep (app_info ()) ] "App" job

--- a/test/functoria/query/config.ml
+++ b/test/functoria/query/config.ml
@@ -1,11 +1,5 @@
 open F0
 open Functoria
 
-let key =
-  let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt ~stage:`Run string "Hello World!" doc))
-
-let main =
-  Functoria.main ~keys:[ Key.v key ] ~extra_deps:[ dep (app_info ()) ] "App" job
-
+let main = Functoria.main ~extra_deps:[ dep (app_info ()) ] "App" job
 let () = register ~src:`None "noop" [ main ]

--- a/test/mirage/help/build.t
+++ b/test/mirage/help/build.t
@@ -29,10 +29,6 @@ Help build --man-format=plain
          -o FILE, --output=FILE
              Name of the output file.
   
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
              Colorize the output. WHEN must be one of auto, always or never.
@@ -105,10 +101,6 @@ Help build --help=plain
   
          -o FILE, --output=FILE
              Name of the output file.
-  
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/help/clean.t
+++ b/test/mirage/help/clean.t
@@ -30,10 +30,6 @@ Help clean --man-format=plain
          -o FILE, --output=FILE
              Name of the output file.
   
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
              Colorize the output. WHEN must be one of auto, always or never.
@@ -107,10 +103,6 @@ Help clean --help=plain
   
          -o FILE, --output=FILE
              Name of the output file.
-  
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/help/config.ml
+++ b/test/mirage/help/config.ml
@@ -1,8 +1,4 @@
 open Mirage
 
-let key =
-  let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt string "Hello World!" doc))
-
-let main = main ~keys:[ Key.v key ] "App" (job @-> job)
+let main = main "App" (job @-> job)
 let () = register "noop" [ main $ noop ]

--- a/test/mirage/help/configure-o.t
+++ b/test/mirage/help/configure-o.t
@@ -46,10 +46,6 @@ Help configure -o --man-format=plain
          -o FILE, --output=FILE
              Name of the output file.
   
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
              Colorize the output. WHEN must be one of auto, always or never.
@@ -142,10 +138,6 @@ Help configure -o --help=plain
   
          -o FILE, --output=FILE
              Name of the output file.
-  
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/help/configure.t
+++ b/test/mirage/help/configure.t
@@ -46,10 +46,6 @@ Help configure --man-format=plain
          -o FILE, --output=FILE
              Name of the output file.
   
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
              Colorize the output. WHEN must be one of auto, always or never.
@@ -142,10 +138,6 @@ Configure help --help=plain
   
          -o FILE, --output=FILE
              Name of the output file.
-  
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/help/describe.t
+++ b/test/mirage/help/describe.t
@@ -59,10 +59,6 @@ Help describe --man-format=plain
          -o FILE, --output=FILE
              Name of the output file.
   
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
              Colorize the output. WHEN must be one of auto, always or never.
@@ -165,10 +161,6 @@ Help describe --help=plain
   
          -o FILE, --output=FILE
              Name of the output file.
-  
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/help/query.t
+++ b/test/mirage/help/query.t
@@ -52,10 +52,6 @@ Help query --man-format=plain
              'opam', 'files', 'Makefile', 'dune.config', 'dune.build',
              'dune-project', 'dune-workspace' or 'dune.dist'
   
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
-  
   COMMON OPTIONS
          --color=WHEN (absent=auto)
              Colorize the output. WHEN must be one of auto, always or never.
@@ -154,10 +150,6 @@ Help query --help=plain
              The information to query. INFO must be one of 'name', 'packages',
              'opam', 'files', 'Makefile', 'dune.config', 'dune.build',
              'dune-project', 'dune-workspace' or 'dune.dist'
-  
-  APPLICATION OPTIONS
-         --hello=VAL (absent=Hello World!)
-             How to say hello.
   
   COMMON OPTIONS
          --color=WHEN (absent=auto)

--- a/test/mirage/info_gen/key_gen.ml.expected
+++ b/test/mirage/info_gen/key_gen.ml.expected
@@ -1,2 +1,1 @@
-let target () = `Unix
 

--- a/test/mirage/info_gen/key_gen.ml.expected
+++ b/test/mirage/info_gen/key_gen.ml.expected
@@ -1,5 +1,2 @@
 let target () = `Unix
 
-let runtime_keys = List.combine
-  []
-  []

--- a/test/mirage/info_gen/main.ml.expected
+++ b/test/mirage/info_gen/main.ml.expected
@@ -13,7 +13,7 @@ let bootvar__1 = lazy (
 let key_gen__2 = lazy (
   let __bootvar__1 = Lazy.force bootvar__1 in
   __bootvar__1 >>= fun _bootvar__1 ->
-  return (Mirage_runtime.with_argv (List.map fst Key_gen.runtime_keys) "foo" _bootvar__1)
+  return Mirage_runtime.(with_argv (runtime_keys ()) "foo" _bootvar__1)
   )
 
 let info_gen__3 = lazy (

--- a/test/mirage/job-no-device-behind-if/config.ml
+++ b/test/mirage/job-no-device-behind-if/config.ml
@@ -1,8 +1,4 @@
 open Mirage
 
-let key =
-  let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt string "Hello World!" doc))
-
-let main = main ~keys:[ Key.v key ] "App" job
+let main = main "App" job
 let () = register ~src:`None "noop" [ if_impl Key.is_solo5 main main ]

--- a/test/mirage/job-no-device/config.ml
+++ b/test/mirage/job-no-device/config.ml
@@ -1,8 +1,4 @@
 open Mirage
 
-let key =
-  let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt string "Hello World!" doc))
-
-let main = main ~keys:[ Key.v key ] "App" job
+let main = main "App" job
 let () = register ~src:`None "noop" [ main ]

--- a/test/mirage/query/config.ml
+++ b/test/mirage/query/config.ml
@@ -1,8 +1,4 @@
 open Mirage
 
-let key =
-  let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt string "Hello World!" doc))
-
-let main = main ~keys:[ Key.v key ] "App" (job @-> job)
+let main = main "App" (job @-> job)
 let () = register ~src:`None "noop" [ main $ noop ]

--- a/test/mirage/query/config_dash_in_name.ml
+++ b/test/mirage/query/config_dash_in_name.ml
@@ -1,8 +1,4 @@
 open Mirage
 
-let key =
-  let doc = Key.Arg.info ~doc:"How to say hello." [ "hello" ] in
-  Key.(create "hello" Arg.(opt string "Hello World!" doc))
-
-let main = main ~keys:[ Key.v key ] "App" (job @-> job)
+let main = main "App" (job @-> job)
 let () = register ~src:`None "noop-functor.v0" [ main $ noop ]

--- a/test/mirage/random-unix/dune
+++ b/test/mirage/random-unix/dune
@@ -25,7 +25,7 @@
 (executable
  (name key_gen)
  (modules key_gen)
- (libraries mirage-runtime))
+ (libraries mirage-runtime ipaddr))
 
 (rule
  (alias runtest)

--- a/test/mirage/random-unix/key_gen.ml.expected
+++ b/test/mirage/random-unix/key_gen.ml.expected
@@ -7,6 +7,12 @@ let accept_router_advertisements_t =
 let accept_router_advertisements =
   Functoria_runtime.key accept_router_advertisements_t
 
+let flag_t =
+  Cmdliner.Arg.(value (flag
+    (info ~docs:"APPLICATION OPTIONS" ~doc:"A flag." ["flag"])))
+
+let flag = Functoria_runtime.key flag_t
+
 let interface_t =
   Cmdliner.Arg.(value (opt string "tap0"
     (info ~docs:"UNIKERNEL PARAMETERS" ~docv:"INTERFACE"
@@ -67,4 +73,24 @@ let ipv6_only_t =
     ~doc:"Only use IPv6 for the unikernel." ["ipv6-only"])))
 
 let ipv6_only = Functoria_runtime.key ipv6_only_t
+
+let opt_t =
+  Cmdliner.Arg.(value (opt string "default"
+    (info ~docs:"APPLICATION OPTIONS" ~doc:"An optional key." ["opt"])))
+
+let opt = Functoria_runtime.key opt_t
+
+let opt_all_t =
+  Cmdliner.Arg.(value (opt_all string []
+    (info ~docs:"APPLICATION OPTIONS" ~doc:"All the optional keys."
+    ["opt-all"])))
+
+let opt_all = Functoria_runtime.key opt_all_t
+
+let required_t =
+  Cmdliner.Arg.(required (opt (some string)
+    None (info ~docs:"APPLICATION OPTIONS"
+         ~doc:"A required key.  This key is required." ["required"])))
+
+let required = Functoria_runtime.key required_t
 

--- a/test/mirage/random-unix/key_gen.ml.expected
+++ b/test/mirage/random-unix/key_gen.ml.expected
@@ -5,8 +5,7 @@ let accept_router_advertisements =
    ~doc:"Accept router advertisements for the unikernel."
    ["accept-router-advertisements"]))
 
-let accept_router_advertisements_t =
-  Functoria_runtime.Key.term accept_router_advertisements
+let () = Functoria_runtime.(key (Key.term accept_router_advertisements))
 
 let accept_router_advertisements () =
   Functoria_runtime.Key.get accept_router_advertisements
@@ -17,7 +16,7 @@ let interface =
    ~docs:"UNIKERNEL PARAMETERS" ~docv:"INTERFACE"
    ~doc:"The network interface listened by the unikernel." ["interface"]))
 
-let interface_t = Functoria_runtime.Key.term interface
+let () = Functoria_runtime.(key (Key.term interface))
 
 let interface () = Functoria_runtime.Key.get interface
 
@@ -31,7 +30,7 @@ let ipv4 =
    ~doc:"The network of the unikernel specified as an IP address and netmask, e.g. 192.168.0.1/16 ."
    ["ipv4"]))
 
-let ipv4_t = Functoria_runtime.Key.term ipv4
+let () = Functoria_runtime.(key (Key.term ipv4))
 
 let ipv4 () = Functoria_runtime.Key.get ipv4
 
@@ -43,7 +42,7 @@ let ipv4_gateway =
    ~docv:"IPV4-GATEWAY" ~doc:"The gateway of the unikernel."
    ["ipv4-gateway"]))
 
-let ipv4_gateway_t = Functoria_runtime.Key.term ipv4_gateway
+let () = Functoria_runtime.(key (Key.term ipv4_gateway))
 
 let ipv4_gateway () = Functoria_runtime.Key.get ipv4_gateway
 
@@ -53,7 +52,7 @@ let ipv4_only =
    ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4-ONLY"
    ~doc:"Only use IPv4 for the unikernel." ["ipv4-only"]))
 
-let ipv4_only_t = Functoria_runtime.Key.term ipv4_only
+let () = Functoria_runtime.(key (Key.term ipv4_only))
 
 let ipv4_only () = Functoria_runtime.Key.get ipv4_only
 
@@ -66,7 +65,7 @@ let ipv6 =
    ~doc:"The network of the unikernel specified as IPv6 address and prefix length."
    ["ipv6"]))
 
-let ipv6_t = Functoria_runtime.Key.term ipv6
+let () = Functoria_runtime.(key (Key.term ipv6))
 
 let ipv6 () = Functoria_runtime.Key.get ipv6
 
@@ -78,7 +77,7 @@ let ipv6_gateway =
    ~docv:"IPV6-GATEWAY" ~doc:"The gateway of the unikernel."
    ["ipv6-gateway"]))
 
-let ipv6_gateway_t = Functoria_runtime.Key.term ipv6_gateway
+let () = Functoria_runtime.(key (Key.term ipv6_gateway))
 
 let ipv6_gateway () = Functoria_runtime.Key.get ipv6_gateway
 
@@ -88,12 +87,7 @@ let ipv6_only =
    ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6-ONLY"
    ~doc:"Only use IPv6 for the unikernel." ["ipv6-only"]))
 
-let ipv6_only_t = Functoria_runtime.Key.term ipv6_only
+let () = Functoria_runtime.(key (Key.term ipv6_only))
 
 let ipv6_only () = Functoria_runtime.Key.get ipv6_only
 
-let runtime_keys = List.combine
-  [accept_router_advertisements_t; interface_t; ipv4_t; ipv4_gateway_t;
-   ipv4_only_t; ipv6_t; ipv6_gateway_t; ipv6_only_t]
-  ["accept-router-advertisements"; "interface"; "ipv4"; "ipv4-gateway";
-   "ipv4-only"; "ipv6"; "ipv6-gateway"; "ipv6-only"]

--- a/test/mirage/random-unix/key_gen.ml.expected
+++ b/test/mirage/random-unix/key_gen.ml.expected
@@ -23,7 +23,9 @@ let interface () = Functoria_runtime.Key.get interface
 
 let ipv4 =
   Functoria_runtime.Key.create
-  (Functoria_runtime.Arg.opt Mirage_runtime.Arg.ipv4
+  (Functoria_runtime.Arg.opt
+   (Functoria_runtime.Arg.conv Ipaddr.V4.Prefix.of_string
+  Ipaddr.V4.Prefix.to_string)
    (Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24") (Cmdliner.Arg.info
    ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4"
    ~doc:"The network of the unikernel specified as an IP address and netmask, e.g. 192.168.0.1/16 ."
@@ -36,9 +38,10 @@ let ipv4 () = Functoria_runtime.Key.get ipv4
 let ipv4_gateway =
   Functoria_runtime.Key.create
   (Functoria_runtime.Arg.opt
-   (Cmdliner.Arg.some Mirage_runtime.Arg.ipv4_address) (None)
-   (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4-GATEWAY"
-   ~doc:"The gateway of the unikernel." ["ipv4-gateway"]))
+   (Cmdliner.Arg.some (Functoria_runtime.Arg.conv Ipaddr.V4.of_string Ipaddr.V4.to_string))
+   (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS"
+   ~docv:"IPV4-GATEWAY" ~doc:"The gateway of the unikernel."
+   ["ipv4-gateway"]))
 
 let ipv4_gateway_t = Functoria_runtime.Key.term ipv4_gateway
 
@@ -56,7 +59,9 @@ let ipv4_only () = Functoria_runtime.Key.get ipv4_only
 
 let ipv6 =
   Functoria_runtime.Key.create
-  (Functoria_runtime.Arg.opt (Cmdliner.Arg.some Mirage_runtime.Arg.ipv6)
+  (Functoria_runtime.Arg.opt
+   (Cmdliner.Arg.some (Functoria_runtime.Arg.conv Ipaddr.V6.Prefix.of_string
+  Ipaddr.V6.Prefix.to_string))
    (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6"
    ~doc:"The network of the unikernel specified as IPv6 address and prefix length."
    ["ipv6"]))
@@ -68,9 +73,10 @@ let ipv6 () = Functoria_runtime.Key.get ipv6
 let ipv6_gateway =
   Functoria_runtime.Key.create
   (Functoria_runtime.Arg.opt
-   (Cmdliner.Arg.some Mirage_runtime.Arg.ipv6_address) (None)
-   (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6-GATEWAY"
-   ~doc:"The gateway of the unikernel." ["ipv6-gateway"]))
+   (Cmdliner.Arg.some (Functoria_runtime.Arg.conv Ipaddr.V6.of_string Ipaddr.V6.to_string))
+   (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS"
+   ~docv:"IPV6-GATEWAY" ~doc:"The gateway of the unikernel."
+   ["ipv6-gateway"]))
 
 let ipv6_gateway_t = Functoria_runtime.Key.term ipv6_gateway
 

--- a/test/mirage/random-unix/key_gen.ml.expected
+++ b/test/mirage/random-unix/key_gen.ml.expected
@@ -1,6 +1,6 @@
 let accept_router_advertisements_t =
-  Cmdliner.Arg.(value (opt Cmdliner.Arg.bool true (Cmdliner.Arg.info
-    ~docs:"UNIKERNEL PARAMETERS" ~docv:"ACCEPT-ROUTER-ADVERTISEMENTS"
+  Cmdliner.Arg.(value (opt bool true
+    (info ~docs:"UNIKERNEL PARAMETERS" ~docv:"ACCEPT-ROUTER-ADVERTISEMENTS"
     ~doc:"Accept router advertisements for the unikernel."
     ["accept-router-advertisements"])))
 
@@ -8,8 +8,8 @@ let accept_router_advertisements =
   Functoria_runtime.key accept_router_advertisements_t
 
 let interface_t =
-  Cmdliner.Arg.(value (opt Cmdliner.Arg.string "tap0" (Cmdliner.Arg.info
-    ~docs:"UNIKERNEL PARAMETERS" ~docv:"INTERFACE"
+  Cmdliner.Arg.(value (opt string "tap0"
+    (info ~docs:"UNIKERNEL PARAMETERS" ~docv:"INTERFACE"
     ~doc:"The network interface listened by the unikernel." ["interface"])))
 
 let interface = Functoria_runtime.key interface_t
@@ -18,8 +18,8 @@ let ipv4_t =
   Cmdliner.Arg.(value (opt
     (Functoria_runtime.Key.conv Ipaddr.V4.Prefix.of_string
   Ipaddr.V4.Prefix.to_string)
-    (Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24") (Cmdliner.Arg.info
-    ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4"
+    (Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24")
+    (info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4"
     ~doc:"The network of the unikernel specified as an IP address and netmask, e.g. 192.168.0.1/16 ."
     ["ipv4"])))
 
@@ -28,15 +28,15 @@ let ipv4 = Functoria_runtime.key ipv4_t
 let ipv4_gateway_t =
   Cmdliner.Arg.(value (opt
     (Cmdliner.Arg.some (Functoria_runtime.Key.conv Ipaddr.V4.of_string Ipaddr.V4.to_string))
-    (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS"
-    ~docv:"IPV4-GATEWAY" ~doc:"The gateway of the unikernel."
-    ["ipv4-gateway"])))
+    None
+    (info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4-GATEWAY"
+    ~doc:"The gateway of the unikernel." ["ipv4-gateway"])))
 
 let ipv4_gateway = Functoria_runtime.key ipv4_gateway_t
 
 let ipv4_only_t =
-  Cmdliner.Arg.(value (opt Cmdliner.Arg.bool false (Cmdliner.Arg.info
-    ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4-ONLY"
+  Cmdliner.Arg.(value (opt bool false
+    (info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4-ONLY"
     ~doc:"Only use IPv4 for the unikernel." ["ipv4-only"])))
 
 let ipv4_only = Functoria_runtime.key ipv4_only_t
@@ -45,7 +45,8 @@ let ipv6_t =
   Cmdliner.Arg.(value (opt
     (Cmdliner.Arg.some (Functoria_runtime.Key.conv Ipaddr.V6.Prefix.of_string
   Ipaddr.V6.Prefix.to_string))
-    (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6"
+    None
+    (info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6"
     ~doc:"The network of the unikernel specified as IPv6 address and prefix length."
     ["ipv6"])))
 
@@ -54,15 +55,15 @@ let ipv6 = Functoria_runtime.key ipv6_t
 let ipv6_gateway_t =
   Cmdliner.Arg.(value (opt
     (Cmdliner.Arg.some (Functoria_runtime.Key.conv Ipaddr.V6.of_string Ipaddr.V6.to_string))
-    (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS"
-    ~docv:"IPV6-GATEWAY" ~doc:"The gateway of the unikernel."
-    ["ipv6-gateway"])))
+    None
+    (info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6-GATEWAY"
+    ~doc:"The gateway of the unikernel." ["ipv6-gateway"])))
 
 let ipv6_gateway = Functoria_runtime.key ipv6_gateway_t
 
 let ipv6_only_t =
-  Cmdliner.Arg.(value (opt Cmdliner.Arg.bool false (Cmdliner.Arg.info
-    ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6-ONLY"
+  Cmdliner.Arg.(value (opt bool false
+    (info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6-ONLY"
     ~doc:"Only use IPv6 for the unikernel." ["ipv6-only"])))
 
 let ipv6_only = Functoria_runtime.key ipv6_only_t

--- a/test/mirage/random-unix/key_gen.ml.expected
+++ b/test/mirage/random-unix/key_gen.ml.expected
@@ -1,93 +1,69 @@
+let accept_router_advertisements_t =
+  Cmdliner.Arg.(value (opt Cmdliner.Arg.bool true (Cmdliner.Arg.info
+    ~docs:"UNIKERNEL PARAMETERS" ~docv:"ACCEPT-ROUTER-ADVERTISEMENTS"
+    ~doc:"Accept router advertisements for the unikernel."
+    ["accept-router-advertisements"])))
+
 let accept_router_advertisements =
-  Functoria_runtime.Key.create
-  (Functoria_runtime.Arg.opt Cmdliner.Arg.bool true (Cmdliner.Arg.info
-   ~docs:"UNIKERNEL PARAMETERS" ~docv:"ACCEPT-ROUTER-ADVERTISEMENTS"
-   ~doc:"Accept router advertisements for the unikernel."
-   ["accept-router-advertisements"]))
+  Functoria_runtime.key accept_router_advertisements_t
 
-let () = Functoria_runtime.(key (Key.term accept_router_advertisements))
+let interface_t =
+  Cmdliner.Arg.(value (opt Cmdliner.Arg.string "tap0" (Cmdliner.Arg.info
+    ~docs:"UNIKERNEL PARAMETERS" ~docv:"INTERFACE"
+    ~doc:"The network interface listened by the unikernel." ["interface"])))
 
-let accept_router_advertisements () =
-  Functoria_runtime.Key.get accept_router_advertisements
+let interface = Functoria_runtime.key interface_t
 
-let interface =
-  Functoria_runtime.Key.create
-  (Functoria_runtime.Arg.opt Cmdliner.Arg.string "tap0" (Cmdliner.Arg.info
-   ~docs:"UNIKERNEL PARAMETERS" ~docv:"INTERFACE"
-   ~doc:"The network interface listened by the unikernel." ["interface"]))
-
-let () = Functoria_runtime.(key (Key.term interface))
-
-let interface () = Functoria_runtime.Key.get interface
-
-let ipv4 =
-  Functoria_runtime.Key.create
-  (Functoria_runtime.Arg.opt
-   (Functoria_runtime.Arg.conv Ipaddr.V4.Prefix.of_string
+let ipv4_t =
+  Cmdliner.Arg.(value (opt
+    (Functoria_runtime.Key.conv Ipaddr.V4.Prefix.of_string
   Ipaddr.V4.Prefix.to_string)
-   (Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24") (Cmdliner.Arg.info
-   ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4"
-   ~doc:"The network of the unikernel specified as an IP address and netmask, e.g. 192.168.0.1/16 ."
-   ["ipv4"]))
+    (Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24") (Cmdliner.Arg.info
+    ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4"
+    ~doc:"The network of the unikernel specified as an IP address and netmask, e.g. 192.168.0.1/16 ."
+    ["ipv4"])))
 
-let () = Functoria_runtime.(key (Key.term ipv4))
+let ipv4 = Functoria_runtime.key ipv4_t
 
-let ipv4 () = Functoria_runtime.Key.get ipv4
+let ipv4_gateway_t =
+  Cmdliner.Arg.(value (opt
+    (Cmdliner.Arg.some (Functoria_runtime.Key.conv Ipaddr.V4.of_string Ipaddr.V4.to_string))
+    (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS"
+    ~docv:"IPV4-GATEWAY" ~doc:"The gateway of the unikernel."
+    ["ipv4-gateway"])))
 
-let ipv4_gateway =
-  Functoria_runtime.Key.create
-  (Functoria_runtime.Arg.opt
-   (Cmdliner.Arg.some (Functoria_runtime.Arg.conv Ipaddr.V4.of_string Ipaddr.V4.to_string))
-   (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS"
-   ~docv:"IPV4-GATEWAY" ~doc:"The gateway of the unikernel."
-   ["ipv4-gateway"]))
+let ipv4_gateway = Functoria_runtime.key ipv4_gateway_t
 
-let () = Functoria_runtime.(key (Key.term ipv4_gateway))
+let ipv4_only_t =
+  Cmdliner.Arg.(value (opt Cmdliner.Arg.bool false (Cmdliner.Arg.info
+    ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4-ONLY"
+    ~doc:"Only use IPv4 for the unikernel." ["ipv4-only"])))
 
-let ipv4_gateway () = Functoria_runtime.Key.get ipv4_gateway
+let ipv4_only = Functoria_runtime.key ipv4_only_t
 
-let ipv4_only =
-  Functoria_runtime.Key.create
-  (Functoria_runtime.Arg.opt Cmdliner.Arg.bool false (Cmdliner.Arg.info
-   ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV4-ONLY"
-   ~doc:"Only use IPv4 for the unikernel." ["ipv4-only"]))
-
-let () = Functoria_runtime.(key (Key.term ipv4_only))
-
-let ipv4_only () = Functoria_runtime.Key.get ipv4_only
-
-let ipv6 =
-  Functoria_runtime.Key.create
-  (Functoria_runtime.Arg.opt
-   (Cmdliner.Arg.some (Functoria_runtime.Arg.conv Ipaddr.V6.Prefix.of_string
+let ipv6_t =
+  Cmdliner.Arg.(value (opt
+    (Cmdliner.Arg.some (Functoria_runtime.Key.conv Ipaddr.V6.Prefix.of_string
   Ipaddr.V6.Prefix.to_string))
-   (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6"
-   ~doc:"The network of the unikernel specified as IPv6 address and prefix length."
-   ["ipv6"]))
+    (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6"
+    ~doc:"The network of the unikernel specified as IPv6 address and prefix length."
+    ["ipv6"])))
 
-let () = Functoria_runtime.(key (Key.term ipv6))
+let ipv6 = Functoria_runtime.key ipv6_t
 
-let ipv6 () = Functoria_runtime.Key.get ipv6
+let ipv6_gateway_t =
+  Cmdliner.Arg.(value (opt
+    (Cmdliner.Arg.some (Functoria_runtime.Key.conv Ipaddr.V6.of_string Ipaddr.V6.to_string))
+    (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS"
+    ~docv:"IPV6-GATEWAY" ~doc:"The gateway of the unikernel."
+    ["ipv6-gateway"])))
 
-let ipv6_gateway =
-  Functoria_runtime.Key.create
-  (Functoria_runtime.Arg.opt
-   (Cmdliner.Arg.some (Functoria_runtime.Arg.conv Ipaddr.V6.of_string Ipaddr.V6.to_string))
-   (None) (Cmdliner.Arg.info ~docs:"UNIKERNEL PARAMETERS"
-   ~docv:"IPV6-GATEWAY" ~doc:"The gateway of the unikernel."
-   ["ipv6-gateway"]))
+let ipv6_gateway = Functoria_runtime.key ipv6_gateway_t
 
-let () = Functoria_runtime.(key (Key.term ipv6_gateway))
+let ipv6_only_t =
+  Cmdliner.Arg.(value (opt Cmdliner.Arg.bool false (Cmdliner.Arg.info
+    ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6-ONLY"
+    ~doc:"Only use IPv6 for the unikernel." ["ipv6-only"])))
 
-let ipv6_gateway () = Functoria_runtime.Key.get ipv6_gateway
-
-let ipv6_only =
-  Functoria_runtime.Key.create
-  (Functoria_runtime.Arg.opt Cmdliner.Arg.bool false (Cmdliner.Arg.info
-   ~docs:"UNIKERNEL PARAMETERS" ~docv:"IPV6-ONLY"
-   ~doc:"Only use IPv6 for the unikernel." ["ipv6-only"]))
-
-let () = Functoria_runtime.(key (Key.term ipv6_only))
-
-let ipv6_only () = Functoria_runtime.Key.get ipv6_only
+let ipv6_only = Functoria_runtime.key ipv6_only_t
 

--- a/test/mirage/random-unix/main.ml.expected
+++ b/test/mirage/random-unix/main.ml.expected
@@ -207,7 +207,7 @@ let sys__17 = lazy (
 let key_gen__18 = lazy (
   let __sys__17 = Lazy.force sys__17 in
   __sys__17 >>= fun _sys__17 ->
-  return (Functoria_runtime.with_argv (List.map fst Key_gen.runtime_keys) "foo" _sys__17)
+  return Functoria_runtime.(with_argv (runtime_keys ()) "foo" _sys__17)
   )
 
 let functoria_runtime__19 = lazy (

--- a/test/mirage/random-unix/test.ml
+++ b/test/mirage/random-unix/test.ml
@@ -1,5 +1,21 @@
 open Mirage
 
+let opt =
+  let doc = Key.Arg.info ~doc:"An optional key." [ "opt" ] in
+  Key.(create "opt" Arg.(opt string "default" doc))
+
+let opt_all =
+  let doc = Key.Arg.info ~doc:"All the optional keys." [ "opt-all" ] in
+  Key.(create "opt-all" Arg.(opt_all string doc))
+
+let flag =
+  let doc = Key.Arg.info ~doc:"A flag." [ "flag" ] in
+  Key.(create "flag" Arg.(flag doc))
+
+let required =
+  let doc = Key.Arg.info ~doc:"A required key." [ "required" ] in
+  Key.(create "required" Arg.(required string doc))
+
 let test () =
   let context = Key.add_to_context Key.target `Unix Context.empty in
   let sigs = conduit @-> random @-> job in
@@ -20,6 +36,7 @@ let test () =
   let job =
     let connect _ _ _ = "return ()" in
     Functoria.impl
+      ~keys:Key.[ v opt; v opt_all; v flag; v required ]
       ~extra_deps:[ dep job; dep init ]
       "Functoria_runtime" ~connect Functoria.job
   in

--- a/test/mirage/random-unix/test.ml
+++ b/test/mirage/random-unix/test.ml
@@ -2,19 +2,19 @@ open Mirage
 
 let opt =
   let doc = Key.Arg.info ~doc:"An optional key." [ "opt" ] in
-  Key.(create "opt" Arg.(opt string "default" doc))
+  Key.(create "opt" Arg.(opt ~stage:`Run string "default" doc))
 
 let opt_all =
   let doc = Key.Arg.info ~doc:"All the optional keys." [ "opt-all" ] in
-  Key.(create "opt-all" Arg.(opt_all string doc))
+  Key.(create "opt-all" Arg.(opt_all ~stage:`Run string doc))
 
 let flag =
   let doc = Key.Arg.info ~doc:"A flag." [ "flag" ] in
-  Key.(create "flag" Arg.(flag doc))
+  Key.(create "flag" Arg.(flag ~stage:`Run doc))
 
 let required =
   let doc = Key.Arg.info ~doc:"A required key." [ "required" ] in
-  Key.(create "required" Arg.(required string doc))
+  Key.(create "required" Arg.(required ~stage:`Run string doc))
 
 let test () =
   let context = Key.add_to_context Key.target `Unix Context.empty in


### PR DESCRIPTION
To test with https://github.com/mirage/mirage-skeleton/pull/364

This PR simplifies the management of "keys" - what mirage used to describe parameters that can be passed a configure-time (to configure the deployment target) and runtime (to configure configuration options).

This PRs does a few things to simplify the current state:
- first it remove mandatory dependency to `ipaddr` for unikernels that do not need to link with that library
- then it removes the cmdliner half-reimplementation used to describe runtime keys and allow users to use Cmdliner terms directly
- then it allows users to define runtime keys in the unikernel itself (by calling `Mirage_runtime.Key.register <cmdliner term>`)