### PR TITLE
refactor: remove unused arguments from Key.context 

### DIFF
--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -419,8 +419,8 @@ let create name arg =
 
 (* {2 Cmdliner interface} *)
 
-let context ?(stage = `Both) l =
-  let stage = filter_stage stage l in
+let context l =
+  let stage = filter_stage `Configure l in
   let names = Names.of_list (Set.elements stage) in
   let gather (Any k) rest =
     let f v p = match v with None -> p | Some v -> Context.add k.key v p in

--- a/lib/functoria/key.mli
+++ b/lib/functoria/key.mli
@@ -233,7 +233,7 @@ type context := Context.t
 val add_to_context : 'a key -> 'a -> context -> context
 (** Add a binding to a context. *)
 
-val context : ?stage:Arg.stage -> Set.t -> context Cmdliner.Term.t
+val context : Set.t -> context Cmdliner.Term.t
 (** [context ks] is a [Cmdliner]
     {{:http://erratique.ch/software/cmdliner/doc/Cmdliner/Term/index.html#type-t}
       term} that evaluates into a parsing context for command-line arguments. *)

--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -171,7 +171,7 @@ module Make (P : S) = struct
       | Some _, _ -> output
       | _, cache -> cache
     in
-    let context = Key.context ~stage:`Configure keys in
+    let context = Key.context keys in
     let context = Context_cache.merge cache context in
     let f context =
       let config = Key.eval context info context in
@@ -458,7 +458,7 @@ module Make (P : S) = struct
       (* Consider only the non-required keys. *)
       let non_required_term =
         let if_keys = Config.keys config in
-        Key.context ~stage:`Configure if_keys
+        Key.context if_keys
       in
       let context =
         match Cmdliner.Cmd.eval_peek_opts ~argv non_required_term with

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -130,8 +130,7 @@ module Make (P : S) = struct
       (* Extract all the keys directly. Useful to pre-resolve the keys
          provided by the specialized DSL. *)
       let base_keys = Engine.all_keys @@ Impl.abstract @@ P.create [] in
-      Cmdliner.Term.(
-        const (fun _ -> Action.ok ()) $ Key.context base_keys ~stage:`Configure)
+      Cmdliner.Term.(const (fun _ -> Action.ok ()) $ Key.context base_keys)
     in
     let result =
       Cli.eval ?help_ppf ?err_ppf ~name:P.name ~version:P.version


### PR DESCRIPTION
On top of #1449 