### PR TITLE
keys: make ~stage a required argument

### DIFF
--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -191,15 +191,15 @@ module Arg = struct
 
   let stage t = t.stage
 
-  let opt ?(stage = `Configure) conv default info =
+  let opt ~stage conv default info =
     { stage; info; kind = Opt (default, conv) }
 
-  let flag ?(stage = `Configure) info = { stage; info; kind = Flag }
+  let flag ~stage info = { stage; info; kind = Flag }
 
-  let required ?(stage = `Configure) conv info =
+  let required ~stage conv info =
     { stage; info; kind = Required conv }
 
-  let opt_all ?(stage = `Configure) conv info =
+  let opt_all ~stage conv info =
     { stage; info; kind = Opt_all conv }
 
   let default (type a) (t : a t) =

--- a/lib/functoria/key.mli
+++ b/lib/functoria/key.mli
@@ -104,25 +104,25 @@ module Arg : sig
         configuration-time.
       - [`Run] means that the argument is read on the command-line at runtime. *)
 
-  val opt : ?stage:stage -> 'a converter -> 'a -> info -> 'a t
+  val opt : stage:stage -> 'a converter -> 'a -> info -> 'a t
   (** [opt conv v i] is similar to
       {{:http://erratique.ch/software/cmdliner/doc/Cmdliner/Arg/index.html#val-opt}
         Cmdliner.Arg.opt} but for cross-stage optional command-line arguments.
       If not set, [stage] is [`Configure]. *)
 
-  val required : ?stage:stage -> 'a converter -> info -> 'a option t
+  val required : stage:stage -> 'a converter -> info -> 'a option t
   (** [required conv i] is similar to
       {{:http://erratique.ch/software/cmdliner/doc/Cmdliner/Arg/index.html#val-required}
         Cmdliner.Arg.required} but for cross-stage required command-line
       arguments. If not set, [stage] is [`Configure]. *)
 
-  val flag : ?stage:stage -> info -> bool t
+  val flag : stage:stage -> info -> bool t
   (** [flag i] is similar to
       {{:http://erratique.ch/software/cmdliner/doc/Cmdliner/Arg/index.html#val-flag}
         Cmdliner.Arg.flag} but for cross-stage command-line flags. If not set,
       [stage] is [`Configure]. *)
 
-  val opt_all : ?stage:stage -> 'a converter -> info -> 'a list t
+  val opt_all : stage:stage -> 'a converter -> info -> 'a list t
 end
 
 (** {1 Configuration Keys} *)

--- a/test/functoria/context/config.ml
+++ b/test/functoria/context/config.ml
@@ -18,7 +18,7 @@ let target =
       ~serialize:target_serialize
   in
   let doc = Key.Arg.info ~doc:"Target." [ "t" ] in
-  Key.(create "target" Arg.(opt conv' `X doc))
+  Key.(create "target" Arg.(opt ~stage:`Configure conv' `X doc))
 
 let main = match_impl (Key.value target) ~default:y [ (`X, x) ]
 let () = register ~src:`None "noop" [ main ]

--- a/test/functoria/test_key.ml
+++ b/test/functoria/test_key.ml
@@ -1,12 +1,12 @@
 open Functoria
 
-let key_a = Key.create "a" Key.Arg.(flag @@ info [ "a" ])
-let key_b = Key.create "b" Key.Arg.(opt int 0 @@ info [ "b" ])
+let key_a = Key.create "a" Key.Arg.(flag ~stage:`Configure @@ info [ "a" ])
+let key_b = Key.create "b" Key.Arg.(opt ~stage:`Configure int 0 @@ info [ "b" ])
 
 let key_c =
   Key.create "c" Key.Arg.(required ~stage:`Configure string @@ info [ "c" ])
 
-let key_d = Key.create "d" Key.Arg.(opt_all int @@ info [ "d" ])
+let key_d = Key.create "d" Key.Arg.(opt_all ~stage:`Configure int @@ info [ "d" ])
 let empty = Context.empty
 let ( & ) (k, v) c = Key.add_to_context k v c
 let ( && ) x y = x & y & empty
@@ -80,15 +80,15 @@ let test_merge () =
 let key = Alcotest.testable Key.pp Key.equal
 
 let test_equal () =
-  let k1 = Key.(v @@ create "foo" Arg.(opt int 1 (info [ "foo" ]))) in
-  let k2 = Key.(v @@ create "foo" Arg.(opt int 2 (info [ "foo" ]))) in
-  let k3 = Key.(v @@ create "foo" Arg.(opt int 1 (info [ "foo" ]))) in
+  let k1 = Key.(v @@ create "foo" Arg.(opt ~stage:`Configure int 1 (info [ "foo" ]))) in
+  let k2 = Key.(v @@ create "foo" Arg.(opt ~stage:`Configure int 2 (info [ "foo" ]))) in
+  let k3 = Key.(v @@ create "foo" Arg.(opt ~stage:`Configure int 1 (info [ "foo" ]))) in
   Alcotest.(check @@ neg key) "different defaults" k1 k2;
   Alcotest.(check @@ key) "same defaults" k1 k3
 
 let test_cmdliner () =
-  let k1 = Key.(v @@ create "foo" Arg.(opt int 1 (info [ "foo" ]))) in
-  let k2 = Key.(v @@ create "foo" Arg.(opt int 2 (info [ "foo" ]))) in
+  let k1 = Key.(v @@ create "foo" Arg.(opt ~stage:`Configure int 1 (info [ "foo" ]))) in
+  let k2 = Key.(v @@ create "foo" Arg.(opt ~stage:`Configure int 2 (info [ "foo" ]))) in
   let keys = Key.Set.of_list [ k1; k2 ] in
   let context = Key.context keys in
   let _ = eval (fun x -> x) context [] in


### PR DESCRIPTION
There doesn't seem to be a clear preference for `` `Configure``, and since it is a breaking change it may be desirable to force users to consider the stage of the keys.

See the discussion in https://github.com/mirage/mirage/pull/1437#issuecomment-1614378015