### PR TITLE
WIP: Simplify context file

### DIFF
--- a/lib/functoria/context.ml
+++ b/lib/functoria/context.ml
@@ -37,6 +37,14 @@ let empty = Map.empty
 let add k v (t : t) : t = Map.add k.name (k.put v) t
 let mem k (t : t) = Map.mem k.name t
 
+let diff ~base x =
+  Map.fold
+    (fun k v acc ->
+      match Map.find_opt k x with
+      | None -> acc
+      | Some v' -> if v = v' then acc else k :: acc)
+    base []
+
 let find k (t : t) =
   if Map.mem k.name t then Some (k.get @@ Map.find k.name t) else None
 
@@ -44,7 +52,3 @@ let dump : t Fmt.t =
   let pp_elt ppf (k, v) = Fmt.pf ppf "[%s: %a]" k Fmt.exn v in
   let map_iter f = Map.iter (fun k v -> f (k, v)) in
   Fmt.box ~indent:2 @@ Fmt.(iter ~sep:(any "@ ")) map_iter pp_elt
-
-let merge ~default m =
-  let aux _ _ v = Some v in
-  Map.union aux default m

--- a/lib/functoria/context.mli
+++ b/lib/functoria/context.mli
@@ -41,9 +41,9 @@ val find : 'a key -> t -> 'a option
 (** [find k t] is [v] is the binding [(k, v)] has been added to [t], otherwise
     it is [None]. *)
 
-val merge : default:t -> t -> t
-(** [merge ~default t] merges [t] on top of [default]. If a key appears in both
-    [default] and [t], the value present in [t] is kept. *)
-
 val dump : t Fmt.t
 (** [dump] dumps the state of [t]. *)
+
+val diff : base:t -> t -> string list
+(** [diff ~base x] is the set of keys from [base] that are present in [x] with a
+    different value. *)

--- a/lib/functoria/context_cache.ml
+++ b/lib/functoria/context_cache.ml
@@ -42,7 +42,7 @@ let write file argv =
 let read file =
   Log.info (fun l -> l "reading cache %a" Fpath.pp file);
   let* is_file = Action.is_file file in
-  if not is_file then Action.ok empty
+  if not is_file then Action.errorf "%a is not a file" Fpath.pp file
   else
     let* args = Action.read_file file in
     let args = String.cuts ~sep:"\n" args in
@@ -68,11 +68,6 @@ let peek t term =
   | Some c, _ | _, Ok (`Ok c) -> Some c
   | _ -> None
 
-let merge t term =
-  let cache = match peek t term with None -> Context.empty | Some c -> c in
-  let f term = Context.merge ~default:cache term in
-  Cmdliner.Term.(const f $ term)
-
 let peek_output t = Cli.peek_output t
 
 let file ~name args =
@@ -80,3 +75,5 @@ let file ~name args =
   match args.Cli.context_file with
   | Some f -> f
   | None -> Fpath.(build_dir / name / "context")
+
+let dump = Fmt.Dump.(array string)

--- a/lib/functoria/context_cache.mli
+++ b/lib/functoria/context_cache.mli
@@ -43,10 +43,8 @@ val peek : t -> Context.t Cmdliner.Term.t -> Context.t option
 (** [peek t term] is the context obtained by evaluating [term] over the cached
     context [t]. *)
 
-val merge : t -> Context.t Cmdliner.Term.t -> Context.t Cmdliner.Term.t
-(** [eval_context t term] is the context obtained by evaluating [term] over the
-    cached context [t]. *)
-
 val peek_output : t -> string option
 (** [peek_output t] is the evaluation of {!Cli.output} over the cached context
     [t]. *)
+
+val dump : t Fmt.t

--- a/test/functoria/context/run.t
+++ b/test/functoria/context/run.t
@@ -12,15 +12,13 @@ Query package - no target - y.context
 
 Query package - x target  - y.context
   $ ./config.exe query package -t x --context-file=y.context
-  "fmt" { ?monorepo }
-  "functoria-runtime" { ?monorepo }
-  "x" { ?monorepo }
+  test: `--target' has different values in the context file (passed with `--context-file') and on the CLI.
+  [1]
 
 Query package - y target  - x.context
   $ ./config.exe query package -t y --context-file=x.context
-  "fmt" { ?monorepo }
-  "functoria-runtime" { ?monorepo }
-  "y" { ?monorepo }
+  test: `--target' has different values in the context file (passed with `--context-file') and on the CLI.
+  [1]
 
 Describe - no target - x.context
   $ ./config.exe describe --context-file=x.context
@@ -38,17 +36,13 @@ Describe - no target - y.context
 
 Describe - x target  - y.context
   $ ./config.exe describe -t x --context-file=y.context
-  Name       noop
-  Keys       target=x,
-             vote=cat (default),
-             warn_error=false (default)
+  test: `--target' has different values in the context file (passed with `--context-file') and on the CLI.
+  [1]
 
 Describe - y target  - x.context
   $ ./config.exe describe -t y --context-file=x.context
-  Name       noop
-  Keys       target=y,
-             vote=cat (default),
-             warn_error=false (default)
+  test: `--target' has different values in the context file (passed with `--context-file') and on the CLI.
+  [1]
 
 Bad context cache
   $ ./config.exe configure -t nonexistent --context-file=z.context

--- a/test/functoria/context/run.t
+++ b/test/functoria/context/run.t
@@ -12,12 +12,16 @@ Query package - no target - y.context
 
 Query package - x target  - y.context
   $ ./config.exe query package -t x --context-file=y.context
-  test: `--target' has different values in the context file (passed with `--context-file') and on the CLI.
+  test: unknown option '-t'.
+  Usage: test query [OPTION]… [INFO]
+  Try 'test query --help' or 'test --help' for more information.
   [1]
 
 Query package - y target  - x.context
   $ ./config.exe query package -t y --context-file=x.context
-  test: `--target' has different values in the context file (passed with `--context-file') and on the CLI.
+  test: unknown option '-t'.
+  Usage: test query [OPTION]… [INFO]
+  Try 'test query --help' or 'test --help' for more information.
   [1]
 
 Describe - no target - x.context
@@ -36,12 +40,16 @@ Describe - no target - y.context
 
 Describe - x target  - y.context
   $ ./config.exe describe -t x --context-file=y.context
-  test: `--target' has different values in the context file (passed with `--context-file') and on the CLI.
+  test: unknown option '-t'.
+  Usage: test describe [OPTION]…
+  Try 'test describe --help' or 'test --help' for more information.
   [1]
 
 Describe - y target  - x.context
   $ ./config.exe describe -t y --context-file=x.context
-  test: `--target' has different values in the context file (passed with `--context-file') and on the CLI.
+  test: unknown option '-t'.
+  Usage: test describe [OPTION]…
+  Try 'test describe --help' or 'test --help' for more information.
   [1]
 
 Bad context cache

--- a/test/functoria/test_key.ml
+++ b/test/functoria/test_key.ml
@@ -68,14 +68,11 @@ let test_find () =
   Alcotest.(check (option (option string)))
     "find c" None (Key.find context key_c)
 
-let test_merge () =
+let test_diff () =
   let cache = (key_a, true) && (key_c, Some "foo") in
   let cli = (key_a, false) && (key_b, 2) in
-  let context = Context.merge ~default:cache cli in
-  Alcotest.(check bool) "merge a" false (Key.get context key_a);
-  Alcotest.(check int) "merge b" 2 (Key.get context key_b);
-  Alcotest.(check (option string))
-    "merge c" (Some "foo") (Key.get context key_c)
+  let diff = Context.diff ~base:cache cli in
+  Alcotest.(check (list string)) "diff" [ "a" ] diff
 
 let key = Alcotest.testable Key.pp Key.equal
 
@@ -117,7 +114,7 @@ let suite =
       ("eval", test_eval);
       ("get", test_get);
       ("find", test_find);
-      ("merge", test_merge);
+      ("diff", test_diff);
       ("cmdliner", test_cmdliner);
       ("opt-all", test_opt_all);
     ]

--- a/test/mirage/describe/config.ml
+++ b/test/mirage/describe/config.ml
@@ -1,0 +1,5 @@
+open Mirage
+
+let device = generic_stackv4v6 default_network
+let main = main "App" (stackv4v6 @-> job)
+let () = register ~src:`None "describe" [ main $ device ]

--- a/test/mirage/describe/dune
+++ b/test/mirage/describe/dune
@@ -1,0 +1,8 @@
+(executable
+ (name config)
+ (modules config)
+ (libraries mirage))
+
+(cram
+ (package mirage)
+ (deps config.exe))

--- a/test/mirage/describe/run.t
+++ b/test/mirage/describe/run.t
@@ -1,0 +1,232 @@
+Describe before configure (using defaults)
+  $ ./config.exe describe -t spt
+  Name       describe
+  Keys      
+    accept-router-advertisements=true (default),
+    allocation-policy=next-fit (default),
+    backtrace=true (default),
+    custom-major-ratio= (default),
+    custom-minor-max-size= (default),
+    custom-minor-ratio= (default),
+    dhcp=false (default),
+    gc-verbosity= (default),
+    gc-window-size= (default),
+    interface=0 (default),
+    interface=service (default),
+    interface=tap0 (default),
+    ipv4=0.0.0.0/0 (default),
+    ipv4=10.0.0.2/24 (default),
+    ipv4-gateway= (default),
+    ipv4-only=false (default),
+    ipv4-only=false (default),
+    ipv6= (default),
+    ipv6= (default),
+    ipv6-gateway= (default),
+    ipv6-only=false (default),
+    ipv6-only=false (default),
+    logs= (default),
+    major-heap-increment= (default),
+    max-space-overhead= (default),
+    minor-heap-size= (default),
+    net= (default),
+    randomize-hashtables=true (default),
+    space-overhead= (default),
+    target=spt
+
+Describe before configure (no eval)
+  $ ./config.exe describe --no-eval --dot -o-
+  Name       describe
+  Keys      
+    accept-router-advertisements=true (default),
+    allocation-policy=next-fit (default),
+    backtrace=true (default),
+    custom-major-ratio= (default),
+    custom-minor-max-size= (default),
+    custom-minor-ratio= (default),
+    dhcp=false (default),
+    gc-verbosity= (default),
+    gc-window-size= (default),
+    interface=0 (default),
+    interface=service (default),
+    interface=tap0 (default),
+    ipv4=0.0.0.0/0 (default),
+    ipv4=10.0.0.2/24 (default),
+    ipv4-gateway= (default),
+    ipv4-only=false (default),
+    ipv4-only=false (default),
+    ipv6= (default),
+    ipv6= (default),
+    ipv6-gateway= (default),
+    ipv6-only=false (default),
+    ipv6-only=false (default),
+    logs= (default),
+    major-heap-increment= (default),
+    max-space-overhead= (default),
+    minor-heap-size= (default),
+    net= (default),
+    randomize-hashtables=true (default),
+    space-overhead= (default),
+    target=macosx (default)
+  Output     -digraph G {
+                ordering=out;
+                1 [label="tcpv4v6_socket__1\nTcpv4v6_socket\nipv4-only, ipv6-only, ipv4, ipv6", shape="box"];
+                2 [label="udpv4v6_socket__2\nUdpv4v6_socket\nipv4-only, ipv6-only, ipv4, ipv6", shape="box"];
+                3 [label="tcpip_stack_socket_v4v6__3\nTcpip_stack_socket.V4V6\n", shape="box"];
+                4 [label="mclock__4\nMclock\n", shape="box"];
+                5 [label="unix_os_time__5\nUnix_os.Time\n", shape="box"];
+                6 [label="xen_os_time__6\nXen_os.Time\n", shape="box"];
+                7 [label="solo5_os_time__7\nSolo5_os.Time\n", shape="box"];
+                8 [label="If\ntarget"];
+                9 [label="mirage_crypto_rng_mirage_make__9\nMirage_crypto_rng_mirage.Make\n", shape="box"];
+                10 [label="netif__10\nNetif\ninterface", shape="box"];
+                11 [label="netif__11\nNetif\ninterface", shape="box"];
+                12 [label="netif__12\nNetif\ninterface", shape="box"];
+                13 [label="netif__13\nNetif\ninterface", shape="box"];
+                14 [label="netif__14\nNetif\ninterface", shape="box"];
+                15 [label="netif__15\nNetif\ninterface", shape="box"];
+                16 [label="netif__16\nNetif\ninterface", shape="box"];
+                17 [label="netif__17\nNetif\ninterface", shape="box"];
+                18 [label="If\ntarget"];
+                19 [label="ethernet_make__19\nEthernet.Make\n", shape="box"];
+                20 [label="ipv6_make__20\nIpv6.Make\nipv6, ipv6-gateway, accept-router-advertisements, ipv4-only", shape="box"];
+                21 [label="arp_make__21\nArp.Make\n", shape="box"];
+                22 [label="qubes_db__22\nQubes.DB\n", shape="box"];
+                23 [label="qubesdb_ipv4_make__23\nQubesdb_ipv4.Make\n", shape="box"];
+                24 [label="dhcp_ipv4_make__24\nDhcp_ipv4.Make\n", shape="box"];
+                25 [label="static_ipv4_make__25\nStatic_ipv4.Make\nipv6-only, ipv4-gateway, ipv4", shape="box"];
+                26 [label="If\ndhcp, net,\ntarget"];
+                27 [label="tcpip_stack_direct_ipv4v6__27\nTcpip_stack_direct.IPV4V6\nipv4-only, ipv6-only", shape="box"];
+                28 [label="tcp_flow_make__28\nTcp.Flow.Make\n", shape="box"];
+                29 [label="udp_make__29\nUdp.Make\n", shape="box"];
+                30 [label="icmpv4_make__30\nIcmpv4.Make\n", shape="box"];
+                31 [label="tcpip_stack_direct_makev4v6__31\nTcpip_stack_direct.MakeV4V6\n", shape="box"];
+                32 [label="If\ndhcp, net,\ntarget"];
+                33 [label="app__33\nApp\n", shape="box"];
+                34 [label="pclock__34\nPclock\n", shape="box"];
+                35 [label="mirage_logs_make__35\nMirage_logs.Make\nlogs", shape="box"];
+                36 [label="gc__36\nGc\nallocation-policy, minor-heap-size, major-heap-increment, space-overhead, max-space-overhead, gc-verbosity, gc-window-size, custom-major-ratio, custom-minor-ratio, custom-minor-max-size", shape="box"];
+                37 [label="hashtbl__37\nHashtbl\nrandomize-hashtables", shape="box"];
+                38 [label="printexc__38\nPrintexc\nbacktrace", shape="box"];
+                39 [label="bootvar__39\nBootvar\n", shape="box"];
+                40 [label="bootvar__40\nBootvar\n", shape="box"];
+                41 [label="bootvar__41\nBootvar\n", shape="box"];
+                42 [label="If\ntarget"];
+                43 [label="key_gen__43\nKey_gen\n", shape="box"];
+                44 [label="mirage_runtime__44\nMirage_runtime\ntarget", shape="box"];
+                
+                3 -> 2 [style="dashed"];
+                3 -> 1 [style="dashed"];
+                8 -> 5 [style="dotted", headport="n"];
+                8 -> 5 [style="dotted", headport="n"];
+                8 -> 6 [style="dotted", headport="n"];
+                8 -> 6 [style="dotted", headport="n"];
+                8 -> 7 [style="dotted", headport="n"];
+                8 -> 7 [style="dotted", headport="n"];
+                8 -> 7 [style="dotted", headport="n"];
+                8 -> 7 [style="dotted", headport="n"];
+                8 -> 7 [style="dotted", headport="n"];
+                8 -> 5 [style="bold", style="dotted", headport="n"];
+                9 -> 8 [];
+                9 -> 4 [];
+                18 -> 10 [style="dotted", headport="n"];
+                18 -> 11 [style="dotted", headport="n"];
+                18 -> 12 [style="dotted", headport="n"];
+                18 -> 13 [style="dotted", headport="n"];
+                18 -> 14 [style="dotted", headport="n"];
+                18 -> 15 [style="dotted", headport="n"];
+                18 -> 16 [style="dotted", headport="n"];
+                18 -> 17 [style="bold", style="dotted", headport="n"];
+                19 -> 18 [];
+                20 -> 18 [];
+                20 -> 19 [];
+                20 -> 9 [];
+                20 -> 8 [];
+                20 -> 4 [];
+                21 -> 19 [];
+                21 -> 8 [];
+                23 -> 22 [];
+                23 -> 9 [];
+                23 -> 4 [];
+                23 -> 19 [];
+                23 -> 21 [];
+                24 -> 9 [];
+                24 -> 4 [];
+                24 -> 8 [];
+                24 -> 18 [];
+                24 -> 19 [];
+                24 -> 21 [];
+                25 -> 9 [];
+                25 -> 4 [];
+                25 -> 19 [];
+                25 -> 21 [];
+                26 -> 23 [style="dotted", headport="n"];
+                26 -> 24 [style="dotted", headport="n"];
+                26 -> 25 [style="bold", style="dotted", headport="n"];
+                27 -> 26 [];
+                27 -> 20 [];
+                28 -> 27 [];
+                28 -> 8 [];
+                28 -> 4 [];
+                28 -> 9 [];
+                29 -> 27 [];
+                29 -> 9 [];
+                30 -> 26 [];
+                31 -> 8 [];
+                31 -> 9 [];
+                31 -> 18 [];
+                31 -> 19 [];
+                31 -> 21 [];
+                31 -> 27 [];
+                31 -> 30 [];
+                31 -> 29 [];
+                31 -> 28 [];
+                32 -> 3 [style="dotted", headport="n"];
+                32 -> 31 [style="bold", style="dotted", headport="n"];
+                33 -> 32 [];
+                35 -> 34 [];
+                42 -> 39 [style="dotted", headport="n"];
+                42 -> 39 [style="dotted", headport="n"];
+                42 -> 40 [style="dotted", headport="n"];
+                42 -> 40 [style="dotted", headport="n"];
+                42 -> 40 [style="dotted", headport="n"];
+                42 -> 40 [style="dotted", headport="n"];
+                42 -> 40 [style="dotted", headport="n"];
+                42 -> 41 [style="bold", style="dotted", headport="n"];
+                43 -> 42 [style="dashed"];
+                44 -> 43 [style="dashed"];
+                44 -> 38 [style="dashed"];
+                44 -> 37 [style="dashed"];
+                44 -> 36 [style="dashed"];
+                44 -> 35 [style="dashed"];
+                44 -> 33 [style="dashed"];
+                }
+
+Describe after configure
+  $ echo '-t\nxen' > context
+  $ ./config.exe describe --context-file=context
+  Name       describe
+  Keys      
+    accept-router-advertisements=true (default),
+    allocation-policy=next-fit (default),
+    backtrace=true (default),
+    custom-major-ratio= (default),
+    custom-minor-max-size= (default),
+    custom-minor-ratio= (default),
+    dhcp=false (default),
+    gc-verbosity= (default),
+    gc-window-size= (default),
+    interface=0 (default),
+    ipv4=10.0.0.2/24 (default),
+    ipv4-gateway= (default),
+    ipv4-only=false (default),
+    ipv6= (default),
+    ipv6-gateway= (default),
+    ipv6-only=false (default),
+    logs= (default),
+    major-heap-increment= (default),
+    max-space-overhead= (default),
+    minor-heap-size= (default),
+    net= (default),
+    randomize-hashtables=true (default),
+    space-overhead= (default),
+    target=xen


### PR DESCRIPTION
This is a (potentially breaking) user-facing change. But I do think it's necessary.

This PR makes `--config-file` always have priority over the CLI arguments. I find the current behaviour (where we merge keys on both the file and the cached file) a bit confusing. We also warn the user if something weird is happening (like passing different options on the CLI and in the config file).

The way it is handled currently is all of this was very clever but super confusing :-)

Also: Cmdliner does not distinguish between default and lack of arguments. So the tricks we were playing won't work if we remove our partial custom implementation of Cmdliner to use the upstream version. /cc @dbuenzli -- as maybe there's a way to use something like `env` to read arg values from a file instead from the environment. I did try to overwrite the `env` parameter that is passed to `Cmd.eval`, but this feels like a hack, and I don't have an easy process to map env variables and parameter names.