### PR TITLE
mirage-runtime.opam: avoid ipaddr dependency

### DIFF
--- a/mirage-runtime.opam
+++ b/mirage-runtime.opam
@@ -19,7 +19,6 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.9.0"}
-  "ipaddr"             {>= "5.0.0"}
   "functoria-runtime"  {= version}
   "logs"
   "lwt" {>= "4.0.0"}


### PR DESCRIPTION
//cc @samoht based on his work #1437