### PR TITLE
Allow a mirage version in config.ml

### DIFF
--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -32,76 +32,86 @@ end
 
 let check_version ~name ~version data =
   let ( let* ) = Result.bind in
-  let first_str = "(* " ^ name ^ " " in
-  let fl = String.length first_str in
-  if fl < String.length data && String.equal (String.sub data 0 fl) first_str
-  then
-    let* lower_version, upper_version =
-      let vs =
-        String.split_on_char ' ' (String.sub data fl (String.length data - fl))
+  let extract_version v =
+    try Ok (Scanf.sscanf v "%u.%u.%u" (fun ma mi pa -> (ma, mi, pa))) with
+    | Scanf.Scan_failure _ | End_of_file -> (
+        try Ok (Scanf.sscanf v "%u.%u" (fun ma mi -> (ma, mi, 0))) with
+        | Scanf.Scan_failure _ | End_of_file -> (
+            try Ok (Scanf.sscanf v "%u" (fun ma -> (ma, 0, 0)))
+            with Scanf.Scan_failure _ | Failure _ | End_of_file ->
+              Error ("couldn't extract version (%u) from " ^ v))
+        | Failure f ->
+            Error ("couldn't extract version (%u.%u) from " ^ v ^ ": " ^ f))
+    | Failure f ->
+        Error ("couldn't extract version (%u.%u.%u) from " ^ v ^ ": " ^ f)
+  in
+  if String.equal version ("%%" ^ "VERSION%%") then (
+    Log.info (fun m ->
+        m "Skipping version check, since our_version is not watermarked");
+    Ok ())
+  else
+    let* version' = extract_version version in
+    let first_str = "(* " ^ name ^ " " in
+    let fl = String.length first_str in
+    if fl < String.length data && String.equal (String.sub data 0 fl) first_str
+    then
+      let* lower_version, upper_version =
+        let vs =
+          String.split_on_char ' '
+            (String.sub data fl (String.length data - fl))
+        in
+        let rec go lower upper = function
+          | "&" :: tl -> go lower upper tl
+          | ">=" :: v :: tl ->
+              if lower = None then go (Some v) upper tl
+              else Error "Bad comment, multiple >= constraints"
+          | "<" :: v :: tl ->
+              if upper = None then go lower (Some v) tl
+              else Error "Bad comment, multiple < constraints"
+          | "*)" :: _ -> Ok (lower, upper)
+          | "" :: tl -> go lower upper tl
+          | _ ->
+              Error
+                (Fmt.str
+                   "Unknown first line, must be (* %s [>= a.b.c] [&] [< d.e.f] \
+                    *)"
+                   name)
+        in
+        go None None vs
       in
-      let rec go lower upper = function
-        | "&" :: tl -> go lower upper tl
-        | ">=" :: v :: tl ->
-            if lower = None then go (Some v) upper tl
-            else Error "Bad comment, multiple >= constraints"
-        | "<" :: v :: tl ->
-            if upper = None then go lower (Some v) tl
-            else Error "Bad comment, multiple < constraints"
-        | "*)" :: _ -> Ok (lower, upper)
-        | "" :: tl -> go lower upper tl
-        | _ ->
-            Error
-              (Fmt.str
-                 "Unknown first line, must be (* %s [>= a.b.c] [&] [< d.e.f] *)"
-                 name)
+      let cmp ~eq (ma, mi, pa) (ma', mi', pa') =
+        ma > ma'
+        || (ma = ma' && mi > mi')
+        || (ma = ma' && mi = mi' && pa > pa')
+        || (ma = ma' && mi = mi' && pa = pa' && eq)
       in
-      go None None vs
-    in
-    let rec cmp ~eq a b =
-      match (a, b) with
-      | [], [] -> eq
-      | _, [] -> true
-      | [], _ -> false
-      | a :: tla, b :: tlb -> (
-          let aint = int_of_string_opt a and bint = int_of_string_opt b in
-          match (aint, bint) with
-          | Some a, Some b -> a > b || (a = b && cmp ~eq tla tlb)
-          | _ -> false)
-    in
-    let* () =
-      match lower_version with
+      let* () =
+        match lower_version with
+        | None -> Ok ()
+        | Some v ->
+            let* v' = extract_version v in
+            if cmp ~eq:true version' v' then Ok ()
+            else
+              Error
+                (Fmt.str
+                   "Version mismatch: required is %s >= %s, but %s is \
+                    installed. Please upgrade your installation (opam update; \
+                    opam install '%s>=%s')"
+                   name v version name v)
+      in
+      match upper_version with
       | None -> Ok ()
       | Some v ->
-          if
-            cmp ~eq:true
-              (String.split_on_char '.' version)
-              (String.split_on_char '.' v)
-          then Ok ()
+          let* v' = extract_version v in
+          if cmp ~eq:false v' version' then Ok ()
           else
             Error
               (Fmt.str
-                 "Version mismatch: required is %s >= %s, but %s is installed. \
-                  Please upgrade your installation (opam update; opam install \
-                  '%s>=%s')"
+                 "Version mismatch: required is %s < %s, but %s is installed. \
+                  Please downgrade your installation (opam update; opam \
+                  install '%s<%s')"
                  name v version name v)
-    in
-    match upper_version with
-    | None -> Ok ()
-    | Some v ->
-        if
-          cmp ~eq:false
-            (String.split_on_char '.' v)
-            (String.split_on_char '.' version)
-        then Ok ()
-        else
-          Error
-            (Fmt.str
-               "Version mismatch: required is %s < %s, but %s is installed. \
-                Please downgrade your installation (opam update; opam install \
-                '%s<%s')"
-               name v version name v)
-  else Ok ()
+    else Ok ()
 
 module Make (P : S) = struct
   module Filegen = Filegen.Make (P)
@@ -283,10 +293,16 @@ module Make (P : S) = struct
         let cmd = Bos.Cmd.(v "head" % "-1" % p file) in
         Action.run_cmd_out ~err:`Null cmd
       in
+      let version =
+        let v = P.version in
+        if String.length v > 0 && String.get v 0 = 'v' then
+          String.sub v 1 (String.length v - 1)
+        else v
+      in
       Result.fold
         ~ok:(fun () -> Action.ok ())
         ~error:(fun msg -> Action.error msg)
-        (check_version ~name:P.name ~version:P.version data)
+        (check_version ~name:P.name ~version data)
     in
     (* Files to build config.ml *)
     with_project_skeleton ~save_args:true args ?ppf ?err_ppf argv @@ fun () ->

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -197,16 +197,12 @@ module Make (P : S) = struct
     rm_gen_files ()
 
   (* App builder configuration *)
-  let with_alias ~save_args args ~depext:_ ~extra_repo:_ ?ppf ?err_ppf argv =
+  let configure ({ args; _ } : _ Cli.configure_args) ?ppf ?err_ppf argv =
     (* Files to build config.ml *)
-    with_project_skeleton ~save_args args ?ppf ?err_ppf argv @@ fun () ->
+    with_project_skeleton ~save_args:true args ?ppf ?err_ppf argv @@ fun () ->
     Log.info (fun f -> f "Set-up config skeleton.");
     (* Launch config.exe: additional generated files for the application. *)
     re_exec_cli args argv
-
-  let configure ({ args; depext; extra_repo } : _ Cli.configure_args) ?ppf
-      ?err_ppf argv =
-    with_alias ~save_args:true args ~depext ~extra_repo ?ppf ?err_ppf argv
 
   let try_to_re_exec args ?ppf ?err_ppf argv =
     with_project_skeleton ~save_args:false args ?ppf ?err_ppf argv @@ fun () ->

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -30,6 +30,79 @@ module type S = sig
   val create : job impl list -> job impl
 end
 
+let check_version ~name ~version data =
+  let ( let* ) = Result.bind in
+  let first_str = "(* " ^ name ^ " " in
+  let fl = String.length first_str in
+  if fl < String.length data && String.equal (String.sub data 0 fl) first_str
+  then
+    let* lower_version, upper_version =
+      let vs =
+        String.split_on_char ' ' (String.sub data fl (String.length data - fl))
+      in
+      let rec go lower upper = function
+        | "&" :: tl -> go lower upper tl
+        | ">=" :: v :: tl ->
+            if lower = None then go (Some v) upper tl
+            else Error "Bad comment, multiple >= constraints"
+        | "<" :: v :: tl ->
+            if upper = None then go lower (Some v) tl
+            else Error "Bad comment, multiple < constraints"
+        | "*)" :: _ -> Ok (lower, upper)
+        | "" :: tl -> go lower upper tl
+        | _ ->
+            Error
+              (Fmt.str
+                 "Unknown first line, must be (* %s [>= a.b.c] [&] [< d.e.f] *)"
+                 name)
+      in
+      go None None vs
+    in
+    let rec cmp ~eq a b =
+      match (a, b) with
+      | [], [] -> eq
+      | _, [] -> true
+      | [], _ -> false
+      | a :: tla, b :: tlb -> (
+          let aint = int_of_string_opt a and bint = int_of_string_opt b in
+          match (aint, bint) with
+          | Some a, Some b -> a > b || (a = b && cmp ~eq tla tlb)
+          | _ -> false)
+    in
+    let* () =
+      match lower_version with
+      | None -> Ok ()
+      | Some v ->
+          if
+            cmp ~eq:true
+              (String.split_on_char '.' version)
+              (String.split_on_char '.' v)
+          then Ok ()
+          else
+            Error
+              (Fmt.str
+                 "Version mismatch: required is %s >= %s, but %s is installed. \
+                  Please upgrade your installation (opam update; opam install \
+                  '%s>=%s')"
+                 name v version name v)
+    in
+    match upper_version with
+    | None -> Ok ()
+    | Some v ->
+        if
+          cmp ~eq:false
+            (String.split_on_char '.' v)
+            (String.split_on_char '.' version)
+        then Ok ()
+        else
+          Error
+            (Fmt.str
+               "Version mismatch: required is %s < %s, but %s is installed. \
+                Please downgrade your installation (opam update; opam install \
+                '%s<%s')"
+               name v version name v)
+  else Ok ()
+
 module Make (P : S) = struct
   module Filegen = Filegen.Make (P)
 
@@ -210,84 +283,10 @@ module Make (P : S) = struct
         let cmd = Bos.Cmd.(v "head" % "-1" % p file) in
         Action.run_cmd_out ~err:`Null cmd
       in
-      let pkg = P.name in
-      let first_str = "(* " ^ pkg in
-      let fl = String.length first_str in
-      if
-        fl < String.length data && String.equal (String.sub data 0 fl) first_str
-      then
-        let our_version = "%%VERSION_NUM%%" in
-        let v_pct = "%%" ^ "VERSION_NUM%%" in
-        if String.equal our_version v_pct then (
-          Log.info (fun m ->
-              m "Skipping version check, since our_version is not watermarked");
-          Action.ok ())
-        else
-          let* lower_version, upper_version =
-            let vs =
-              String.split_on_char ' '
-                (String.sub data fl (String.length data - fl))
-            in
-            let rec go lower upper = function
-              | "&" :: tl -> go lower upper tl
-              | ">=" :: v :: tl ->
-                  if lower = None then go (Some v) upper tl
-                  else Action.error "Bad comment, multiple >= constraints"
-              | "<" :: v :: tl ->
-                  if upper = None then go lower (Some v) tl
-                  else Action.error "Bad comment, multiple < constraints"
-              | "*)" :: _ | [] -> Action.ok (lower, upper)
-              | "" :: tl -> go lower upper tl
-              | _ ->
-                  Action.errorf
-                    "Unknown first line, must be (* %s [>= a.b.c] [&] [< \
-                     d.e.f] *)"
-                    pkg
-            in
-            go None None vs
-          in
-          let rec cmp ~eq a b =
-            match (a, b) with
-            | [], [] -> eq
-            | _, [] -> true
-            | [], _ -> false
-            | a :: tla, b :: tlb -> (
-                let aint = int_of_string_opt a and bint = int_of_string_opt b in
-                match (aint, bint) with
-                | Some a, Some b -> a > b || (a = b && cmp ~eq tla tlb)
-                | _ -> false)
-          in
-          let* () =
-            match lower_version with
-            | None -> Action.ok ()
-            | Some v ->
-                if
-                  cmp ~eq:true
-                    (String.split_on_char '.' our_version)
-                    (String.split_on_char '.' v)
-                then Action.ok ()
-                else
-                  Action.errorf
-                    "Version mismatch: required is %s >= %s, but %s is \
-                     installed. Please upgrade your installation (opam update; \
-                     opam install '%s>=%s')"
-                    pkg v our_version pkg v
-          in
-          match upper_version with
-          | None -> Action.ok ()
-          | Some v ->
-              if
-                cmp ~eq:false
-                  (String.split_on_char '.' v)
-                  (String.split_on_char '.' our_version)
-              then Action.ok ()
-              else
-                Action.errorf
-                  "Version mismatch: required is %s < %s, but %s is installed. \
-                   Please downgrade your installation (opam update; opam \
-                   install '%s<%s')"
-                  pkg v our_version pkg v
-      else Action.ok ()
+      Result.fold
+        ~ok:(fun () -> Action.ok ())
+        ~error:(fun msg -> Action.error msg)
+        (check_version ~name:P.name ~version:P.version data)
     in
     (* Files to build config.ml *)
     with_project_skeleton ~save_args:true args ?ppf ?err_ppf argv @@ fun () ->

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -198,112 +198,95 @@ module Make (P : S) = struct
 
   (* App builder configuration *)
   let configure ({ args; _ } : _ Cli.configure_args) ?ppf ?err_ppf argv =
+    let file = args.Cli.config_file in
     let* () =
-      match
-        Bos.(
-          OS.Cmd.out_string
-            (OS.Cmd.run_out ~err:OS.Cmd.err_null
-               Cmd.(v "head" % "-1" % p args.Cli.config_file)))
-      with
-      | Ok (data, _) ->
-          let pkg = "%%NAME%%" in
-          let first_str = "(* " ^ pkg in
-          let fl = String.length first_str in
-          if
-            fl < String.length data
-            && String.equal (String.sub data 0 fl) first_str
-          then
-            let our_version = "%%VERSION_NUM%%" in
-            let v_pct = "%%" ^ "VERSION_NUM%%" in
-            if String.equal our_version v_pct then (
-              Log.info (fun m ->
-                  m
-                    "Skipping version check, since our_version is not \
-                     watermarked");
-              Action.ok ())
-            else
-              let* lower_version, upper_version =
-                let vs =
-                  String.split_on_char ' '
-                    (String.sub data fl (String.length data - fl))
-                in
-                let rec go lower upper = function
-                  | "&&" :: tl -> go lower upper tl
-                  | ">=" :: v :: tl ->
-                      if lower = None then go (Some v) upper tl
-                      else Action.error "Bad comment, multiple >= constraints"
-                  | "<" :: v :: tl ->
-                      if upper = None then go lower (Some v) tl
-                      else Action.error "Bad comment, multiple < constraints"
-                  | "*)" :: _ -> Action.ok (lower, upper)
-                  | _ ->
-                      Action.error
-                        ("Unknown first line, must be (* "
-                        ^ pkg
-                        ^ " >= a.b.c *)")
-                in
-                go None None vs
-              in
-              let rec cmp ~eq a b =
-                match (a, b) with
-                | [], [] -> eq
-                | _, [] -> true
-                | [], _ -> false
-                | a :: tla, b :: tlb -> (
-                    let aint = int_of_string_opt a
-                    and bint = int_of_string_opt b in
-                    match (aint, bint) with
-                    | Some a, Some b -> a > b || (a = b && cmp ~eq tla tlb)
-                    | _ -> false)
-              in
-              let* () =
-                match lower_version with
-                | None -> Action.ok ()
-                | Some v ->
-                    if
-                      cmp ~eq:true
-                        (String.split_on_char '.' our_version)
-                        (String.split_on_char '.' v)
-                    then Action.ok ()
-                    else
-                      Action.error
-                        ("Version mismatch: required is "
-                        ^ pkg
-                        ^ " >= "
-                        ^ v
-                        ^ ", but only "
-                        ^ our_version
-                        ^ " is installed. Please upgrade your installation \
-                           (opam update && opam install '"
-                        ^ pkg
-                        ^ ">="
-                        ^ v
-                        ^ "')")
-              in
-              match upper_version with
-              | None -> Action.ok ()
-              | Some v ->
-                  if
-                    cmp ~eq:false
-                      (String.split_on_char '.' v)
-                      (String.split_on_char '.' our_version)
-                  then Action.ok ()
-                  else
-                    Action.error
-                      ("Version mismatch: required is "
-                      ^ pkg
-                      ^ " < "
-                      ^ v
-                      ^ ", but "
-                      ^ our_version
-                      ^ " is installed. Please downgrade your installation \
-                         (opam update && opam install '"
-                      ^ pkg
-                      ^ "<"
-                      ^ v
-                      ^ "')")
-          else Action.ok ()
-      | Error (`Msg e) -> Action.error e
+      let* is_file = Action.is_file file in
+      if not is_file then
+        Action.errorf "configuration file %a missing" Fpath.pp file
+      else Action.ok ()
+    in
+    let* () =
+      let* data =
+        let cmd = Bos.Cmd.(v "head" % "-1" % p file) in
+        Action.run_cmd_out ~err:`Null cmd
+      in
+      let pkg = "%%NAME%%" in
+      let first_str = "(* " ^ pkg in
+      let fl = String.length first_str in
+      if
+        fl < String.length data && String.equal (String.sub data 0 fl) first_str
+      then
+        let our_version = "%%VERSION_NUM%%" in
+        let v_pct = "%%" ^ "VERSION_NUM%%" in
+        if String.equal our_version v_pct then (
+          Log.info (fun m ->
+              m "Skipping version check, since our_version is not watermarked");
+          Action.ok ())
+        else
+          let* lower_version, upper_version =
+            let vs =
+              String.split_on_char ' '
+                (String.sub data fl (String.length data - fl))
+            in
+            let rec go lower upper = function
+              | "&&" :: tl -> go lower upper tl
+              | ">=" :: v :: tl ->
+                  if lower = None then go (Some v) upper tl
+                  else Action.error "Bad comment, multiple >= constraints"
+              | "<" :: v :: tl ->
+                  if upper = None then go lower (Some v) tl
+                  else Action.error "Bad comment, multiple < constraints"
+              | "*)" :: _ -> Action.ok (lower, upper)
+              | _ ->
+                  Action.errorf
+                    "Unknown first line, must be (* %s [>= a.b.c] [&&] [< \
+                     d.e.f] *)"
+                    pkg
+            in
+            go None None vs
+          in
+          let rec cmp ~eq a b =
+            match (a, b) with
+            | [], [] -> eq
+            | _, [] -> true
+            | [], _ -> false
+            | a :: tla, b :: tlb -> (
+                let aint = int_of_string_opt a and bint = int_of_string_opt b in
+                match (aint, bint) with
+                | Some a, Some b -> a > b || (a = b && cmp ~eq tla tlb)
+                | _ -> false)
+          in
+          let* () =
+            match lower_version with
+            | None -> Action.ok ()
+            | Some v ->
+                if
+                  cmp ~eq:true
+                    (String.split_on_char '.' our_version)
+                    (String.split_on_char '.' v)
+                then Action.ok ()
+                else
+                  Action.errorf
+                    "Version mismatch: required is %s >= %s, but %s is \
+                     installed. Please upgrade your installation (opam update \
+                     && opam install '%s>=%s')"
+                    pkg v our_version pkg v
+          in
+          match upper_version with
+          | None -> Action.ok ()
+          | Some v ->
+              if
+                cmp ~eq:false
+                  (String.split_on_char '.' v)
+                  (String.split_on_char '.' our_version)
+              then Action.ok ()
+              else
+                Action.errorf
+                  "Version mismatch: required is %s < %s, but %s is installed. \
+                   Please downgrade your installation (opam update && opam \
+                   install '%s<%s')"
+                  pkg v our_version pkg v
+      else Action.ok ()
     in
     (* Files to build config.ml *)
     with_project_skeleton ~save_args:true args ?ppf ?err_ppf argv @@ fun () ->

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -229,7 +229,7 @@ module Make (P : S) = struct
                 (String.sub data fl (String.length data - fl))
             in
             let rec go lower upper = function
-              | "&&" :: tl -> go lower upper tl
+              | "&" :: tl -> go lower upper tl
               | ">=" :: v :: tl ->
                   if lower = None then go (Some v) upper tl
                   else Action.error "Bad comment, multiple >= constraints"
@@ -237,11 +237,13 @@ module Make (P : S) = struct
                   if upper = None then go lower (Some v) tl
                   else Action.error "Bad comment, multiple < constraints"
               | "*)" :: _ -> Action.ok (lower, upper)
-              | _ ->
+              | "" :: tl -> go lower upper tl
+              | x :: xs ->
                   Action.errorf
-                    "Unknown first line, must be (* %s [>= a.b.c] [&&] [< \
-                     d.e.f] *)"
-                    pkg
+                    "Unknown first line (token %s, tl %s), must be (* %s [>= \
+                     a.b.c] [&] [< d.e.f] *)"
+                    x (String.concat " " xs) pkg
+              | [] -> Action.ok (lower, upper)
             in
             go None None vs
           in
@@ -268,8 +270,8 @@ module Make (P : S) = struct
                 else
                   Action.errorf
                     "Version mismatch: required is %s >= %s, but %s is \
-                     installed. Please upgrade your installation (opam update \
-                     && opam install '%s>=%s')"
+                     installed. Please upgrade your installation (opam update; \
+                     opam install '%s>=%s')"
                     pkg v our_version pkg v
           in
           match upper_version with
@@ -283,7 +285,7 @@ module Make (P : S) = struct
               else
                 Action.errorf
                   "Version mismatch: required is %s < %s, but %s is installed. \
-                   Please downgrade your installation (opam update && opam \
+                   Please downgrade your installation (opam update; opam \
                    install '%s<%s')"
                   pkg v our_version pkg v
       else Action.ok ()

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -274,7 +274,7 @@ module Make (P : S) = struct
                         ^ ", but only "
                         ^ our_version
                         ^ " is installed. Please upgrade your installation \
-                           (opam update && opam upgrade '"
+                           (opam update && opam install '"
                         ^ pkg
                         ^ ">="
                         ^ v
@@ -297,7 +297,7 @@ module Make (P : S) = struct
                       ^ ", but "
                       ^ our_version
                       ^ " is installed. Please downgrade your installation \
-                         (opam update && opam upgrade '"
+                         (opam update && opam install '"
                       ^ pkg
                       ^ "<"
                       ^ v

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -236,14 +236,13 @@ module Make (P : S) = struct
               | "<" :: v :: tl ->
                   if upper = None then go lower (Some v) tl
                   else Action.error "Bad comment, multiple < constraints"
-              | "*)" :: _ -> Action.ok (lower, upper)
+              | "*)" :: _ | [] -> Action.ok (lower, upper)
               | "" :: tl -> go lower upper tl
-              | x :: xs ->
+              | _ ->
                   Action.errorf
-                    "Unknown first line (token %s, tl %s), must be (* %s [>= \
-                     a.b.c] [&] [< d.e.f] *)"
-                    x (String.concat " " xs) pkg
-              | [] -> Action.ok (lower, upper)
+                    "Unknown first line, must be (* %s [>= a.b.c] [&] [< \
+                     d.e.f] *)"
+                    pkg
             in
             go None None vs
           in

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -210,7 +210,7 @@ module Make (P : S) = struct
         let cmd = Bos.Cmd.(v "head" % "-1" % p file) in
         Action.run_cmd_out ~err:`Null cmd
       in
-      let pkg = "%%NAME%%" in
+      let pkg = P.name in
       let first_str = "(* " ^ pkg in
       let fl = String.length first_str in
       if

--- a/lib/functoria/tool.mli
+++ b/lib/functoria/tool.mli
@@ -20,6 +20,13 @@
 
 open DSL
 
+val check_version :
+  name:string -> version:string -> string -> (unit, string) result
+(** [check_version ~name ~version data] checks [data] for version constraints,
+    and if present checks that the [version] matches the bounds. The [data] is
+    expected to be a single line (an OCaml comment):
+    [(* <name> [>= a.b.c] [&] [< d.e.f] *)]. *)
+
 module type S = sig
   val name : string
   (** Name of the tool. *)

--- a/test/functoria/test.ml
+++ b/test/functoria/test.ml
@@ -6,4 +6,5 @@ let () =
       ("graph", Test_graph.suite);
       ("action", Test_action.suite);
       ("key", Test_key.suite);
+      ("version", Test_version.suite);
     ]

--- a/test/functoria/test_version.ml
+++ b/test/functoria/test_version.ml
@@ -1,0 +1,81 @@
+let failed_to_parse_comments =
+  [
+    "(* not a name *)";
+    "not a comment";
+    "(* missing closing thingy";
+    "(* name2 >= bad version *)";
+    "(* name3 >= 1.2.3 && < 2.3.4 *)";
+    "(* name2 \n >= 1.2.3 & < 2.3.4 *)";
+  ]
+
+let test_failed_to_parse_comments () =
+  List.iter
+    (fun data ->
+      match Functoria.Tool.check_version ~name:"name" ~version:"1.2.3" data with
+      | Ok _ -> ()
+      | Error msg ->
+          Alcotest.fail
+            ("expected comment parse failure (and an ok), but got error "
+            ^ msg
+            ^ " for "
+            ^ data))
+    failed_to_parse_comments
+
+let bad_comments =
+  [
+    "(* name >= 1.2.3";
+    "(* name >>= 1.2.3 *)";
+    "(* name > 1.2.3 *)";
+    "(* name >= 1.2.3 && < 2.3.4 *)";
+    "(* name >= 1.2.3 & >= 2.3.4 *)";
+    "(* name < 1.2.3 & < 2.3.4 *)";
+  ]
+
+let test_bad_comments () =
+  List.iter
+    (fun data ->
+      match Functoria.Tool.check_version ~name:"name" ~version:"1.2.3" data with
+      | Ok _ -> Alcotest.fail ("expected bad comment to be bad for " ^ data)
+      | Error _ -> ())
+    bad_comments
+
+let good_comments =
+  [
+    "(* name >= 1.2.3 *)";
+    "(* name < 2.0.0 *)";
+    "(* name >= 1.0.0 & < 2.0.0 *)";
+    "(* name >= 1.0.0 *)";
+  ]
+
+let test_good_comments () =
+  List.iter
+    (fun data ->
+      match Functoria.Tool.check_version ~name:"name" ~version:"1.2.3" data with
+      | Ok _ -> ()
+      | Error _ -> Alcotest.fail ("expected good comment to be met for " ^ data))
+    good_comments
+
+let unmet_comments =
+  [
+    "(* name >= 1.2.3 *)";
+    "(* name < 0.1.2 *)";
+    "(* name >= 1.0.0 & < 2.0.0 *)";
+    "(* name >= 1.0.0 *)";
+  ]
+
+let test_unmet_comments () =
+  List.iter
+    (fun data ->
+      match Functoria.Tool.check_version ~name:"name" ~version:"0.1.2" data with
+      | Ok _ ->
+          Alcotest.fail ("expected unmet comment to not be met for " ^ data)
+      | Error _ -> ())
+    unmet_comments
+
+let suite =
+  [
+    ("failed_to_parse comments", `Quick, test_failed_to_parse_comments);
+    ("bad comment", `Quick, test_bad_comments);
+    ("good comment", `Quick, test_good_comments);
+    ("unmet comment", `Quick, test_unmet_comments);
+  ]

--- a/test/functoria/test_version.ml
+++ b/test/functoria/test_version.ml
@@ -45,6 +45,11 @@ let good_comments =
     "(* name < 2.0.0 *)";
     "(* name >= 1.0.0 & < 2.0.0 *)";
     "(* name >= 1.0.0 *)";
+    "(* name >= 1.2 *)";
+    "(* name >= 1.0 & < 2.0 *)";
+    "(* name >= 1 & < 2 *)";
+    "(* name < 2.0 *)";
+    "(* name < 2 *)";
   ]
 
 let test_good_comments () =
@@ -52,7 +57,28 @@ let test_good_comments () =
     (fun data ->
       match Functoria.Tool.check_version ~name:"name" ~version:"1.2.3" data with
       | Ok _ -> ()
-      | Error _ -> Alcotest.fail ("expected good comment to be met for " ^ data))
+      | Error _ ->
+          Alcotest.fail
+            ("expected good comment to be met for " ^ data ^ " at version 1.2.3"))
+    good_comments;
+  List.iter
+    (fun data ->
+      match Functoria.Tool.check_version ~name:"name" ~version:"1.3" data with
+      | Ok _ -> ()
+      | Error _ ->
+          Alcotest.fail
+            ("expected good comment to be met for " ^ data ^ " at version 1.3"))
+    good_comments;
+  List.iter
+    (fun data ->
+      match
+        Functoria.Tool.check_version ~name:"name" ~version:"1.2.3-23-g453412"
+          data
+      with
+      | Ok _ -> ()
+      | Error _ ->
+          Alcotest.fail
+            ("expected good comment to be met for " ^ data ^ " at version 1.3"))
     good_comments
 
 let unmet_comments =

--- a/test/functoria/test_version.mli
+++ b/test/functoria/test_version.mli
@@ -1,0 +1,1 @@
+val suite : unit Alcotest.test_case list

--- a/test/functoria/tool/run.t
+++ b/test/functoria/tool/run.t
@@ -4,6 +4,8 @@ Configure
 
   $ cat configure.err
   * Is_file? config.ml -> true
+  * Run_cmd 'head -1 config.ml' (ok)
+  * Is_file? config.ml -> true
   * Mkdir test (created)
   * Is_file? test/dune-workspace.config -> false
   * Write to test/dune-workspace.config (65 bytes)
@@ -162,6 +164,8 @@ Configure help
   $(dune build ./config.exe --root . --workspace ./test/dune-workspace.config)
 
   $ cat configure-help.err
+  * Is_file? config.ml -> true
+  * Run_cmd 'head -1 config.ml' (ok)
   * Is_file? config.ml -> true
   * Mkdir test (created)
   * Is_file? test/dune-workspace.config -> false


### PR DESCRIPTION
Please take a look at the second commit:

check in mirage configure for a version lower bound in config.ml
    
If the first line of config.ml contains:
(* mirage >= a.b.c *) -- an OCaml comment
    
Then, a.b.c.d is checked to be smaller or equal the current version. This allows
within configure to error out early with a reasonable error message if a too old
mirage is attempted to be used with a unikernel.
    
Addresses #1381

I'm pretty sure this can be "optimized", but tbh I waded through the "action.ml" and was unable to figure out the purpose and value (instead of directly calling Bos). I hope someone can shed some light into why it is there.

Of course I'm happy for review and feedback on this PR.

//cc @samoht @TheLortex

~~EDIT: it is completely unclear to me why the mirage-CI fails with the "job without dependencies" exception.~~ (thanks to @samoht I removed the mirage-skeleton PR ref)