### PR TITLE
allow passing a tcp to the direct_stackv4v6

### DIFF
--- a/lib/mirage/impl/mirage_impl_stack.ml
+++ b/lib/mirage/impl/mirage_impl_stack.ml
@@ -47,7 +47,7 @@ let stackv4v6_direct_conf () =
     @-> stackv4v6)
 
 let direct_stackv4v6 ?(mclock = default_monotonic_clock)
-    ?(random = default_random) ?(time = default_time) ~ipv4_only ~ipv6_only
+    ?(random = default_random) ?(time = default_time) ?tcp ~ipv4_only ~ipv6_only
     network eth arp ipv4 ipv6 =
   let ip = keyed_ipv4v6 ~ipv4_only ~ipv6_only ipv4 ipv6 in
   stackv4v6_direct_conf ()
@@ -59,7 +59,8 @@ let direct_stackv4v6 ?(mclock = default_monotonic_clock)
   $ ip
   $ Mirage_impl_icmp.direct_icmpv4 ipv4
   $ direct_udp ~random ip
-  $ direct_tcp ~mclock ~random ~time ip
+  $
+  match tcp with None -> direct_tcp ~mclock ~random ~time ip | Some tcp -> tcp
 
 let static_ipv4v6_stack ?group ?ipv6_config ?ipv4_config ?(arp = arp ?time:None)
     tap =

--- a/lib/mirage/impl/mirage_impl_stack.mli
+++ b/lib/mirage/impl/mirage_impl_stack.mli
@@ -25,6 +25,7 @@ val static_ipv4v6_stack :
   ?ipv6_config:Mirage_impl_ip.ipv6_config ->
   ?ipv4_config:Mirage_impl_ip.ipv4_config ->
   ?arp:(Mirage_impl_ethernet.ethernet impl -> Mirage_impl_arpv4.arpv4 impl) ->
+  ?tcp:Mirage_impl_tcp.tcpv4v6 impl ->
   Mirage_impl_network.network impl ->
   stackv4v6 impl
 
@@ -34,5 +35,6 @@ val generic_stackv4v6 :
   ?ipv4_config:Mirage_impl_ip.ipv4_config ->
   ?dhcp_key:bool value ->
   ?net_key:[ `Direct | `Socket ] option value ->
+  ?tcp:Mirage_impl_tcp.tcpv4v6 impl ->
   Mirage_impl_network.network impl ->
   stackv4v6 impl

--- a/lib/mirage/impl/mirage_impl_stack.mli
+++ b/lib/mirage/impl/mirage_impl_stack.mli
@@ -8,6 +8,7 @@ val direct_stackv4v6 :
   ?mclock:Mirage_impl_mclock.mclock impl ->
   ?random:Mirage_impl_random.random impl ->
   ?time:Mirage_impl_time.time impl ->
+  ?tcp:Mirage_impl_tcp.tcpv4v6 impl ->
   ipv4_only:bool Mirage_key.key ->
   ipv6_only:bool Mirage_key.key ->
   Mirage_impl_network.network impl ->

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -558,6 +558,7 @@ val direct_stackv4v6 :
   ?mclock:mclock impl ->
   ?random:random impl ->
   ?time:time impl ->
+  ?tcp:tcpv4v6 impl ->
   ipv4_only:bool Key.key ->
   ipv6_only:bool Key.key ->
   network impl ->

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -577,6 +577,7 @@ val static_ipv4v6_stack :
   ?ipv6_config:ipv6_config ->
   ?ipv4_config:ipv4_config ->
   ?arp:(ethernet impl -> arpv4 impl) ->
+  ?tcp:tcpv4v6 impl ->
   network impl ->
   stackv4v6 impl
 (** Build a stackv4v6 by checking the {!Key.V6.network}, and {!Key.V6.gateway}
@@ -589,6 +590,7 @@ val generic_stackv4v6 :
   ?ipv4_config:ipv4_config ->
   ?dhcp_key:bool value ->
   ?net_key:[ `Direct | `Socket ] option value ->
+  ?tcp:tcpv4v6 impl ->
   network impl ->
   stackv4v6 impl
 (** Generic stack using a [net] keys: {!Key.net}.


### PR DESCRIPTION
this allows to more easily test utcp. since it is an optional argument, it won't break existing unikernels.