### PR TITLE
default to best-fit allocation policy

### DIFF
--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -180,7 +180,7 @@ let allocation_policy =
   let doc =
     Arg.info ~docs:ocaml_section ~docv:"ALLOCATION" ~doc [ "allocation-policy" ]
   in
-  let key = Arg.opt ~stage:`Run conv `Next_fit doc in
+  let key = Arg.opt ~stage:`Run conv `Best_fit doc in
   Key.create "allocation-policy" key
 
 let minor_heap_size =

--- a/test/mirage/describe/run.t
+++ b/test/mirage/describe/run.t
@@ -5,7 +5,7 @@ Describe before configure (using defaults)
   Name       describe
   Keys      
     accept-router-advertisements=true (default),
-    allocation-policy=next-fit (default),
+    allocation-policy=best-fit (default),
     backtrace=true (default),
     custom-major-ratio= (default),
     custom-minor-max-size= (default),
@@ -41,7 +41,7 @@ Describe before configure (no eval)
   Name       describe
   Keys      
     accept-router-advertisements=true (default),
-    allocation-policy=next-fit (default),
+    allocation-policy=best-fit (default),
     backtrace=true (default),
     custom-major-ratio= (default),
     custom-minor-max-size= (default),
@@ -213,7 +213,7 @@ Describe after configure
   Name       describe
   Keys      
     accept-router-advertisements=true (default),
-    allocation-policy=next-fit (default),
+    allocation-policy=best-fit (default),
     backtrace=true (default),
     custom-major-ratio= (default),
     custom-minor-max-size= (default),


### PR DESCRIPTION
OCaml since 4.13 uses best fit as default, but MirageOS never updated...  Thus now, if --allocation-policy is not specified, it got overwritten with next-fit (which is inferior).