### PR TITLE
Revert "use the .opam.locked file for installing the switch dependencies"

### DIFF
--- a/lib/functoria/makefile.ml
+++ b/lib/functoria/makefile.ml
@@ -126,7 +126,7 @@ pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
 	@@echo " ↳ fetch monorepo dependencies in the duniverse folder"
 	@@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
 
-install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
 	@@echo " ↳ opam install switch dependencies"
 	@@$(OPAM) install $< --deps-only --yes%a%a
 

--- a/test/functoria/query/run.t
+++ b/test/functoria/query/run.t
@@ -94,7 +94,7 @@ Query Makefile
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
@@ -150,7 +150,7 @@ Query Makefile without depexts
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes --no-depexts
   
@@ -211,7 +211,7 @@ Query Makefile with depext
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -73,7 +73,7 @@ Query makefile
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -113,7 +113,7 @@ Query Makefile
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
@@ -168,7 +168,7 @@ Query Makefile without depexts
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes --no-depexts
   
@@ -228,7 +228,7 @@ Query Makefile with depext
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -112,7 +112,7 @@ Query Makefile
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
@@ -168,7 +168,7 @@ Query Makefile without depexts
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes --no-depexts
   
@@ -229,7 +229,7 @@ Query Makefile with depext
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
   
-  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile


### PR DESCRIPTION
Reverts mirage/mirage#1462

The issue is outlined in #1476 -- with the code as is, the `opam install --deps-only $<` pin-depends everything (even those packages only meant for the `duniverse`. Let's revert that commit, and suffer from #1415 