### PR TITLE
Use Cmdliner.Arg.doc_alts_enum

### DIFF
--- a/lib/mirage/mirage_key.ml
+++ b/lib/mirage/mirage_key.ml
@@ -34,22 +34,22 @@ type mode_xen = [ `Xen | `Qubes ]
 type mode_solo5 = [ `Hvt | `Spt | `Virtio | `Muen | `Genode ]
 type mode = [ mode_unix | mode_xen | mode_solo5 ]
 
-let target_conv : mode Cmdliner.Arg.conv =
-  let parser, printer =
-    Cmdliner.Arg.enum
-      [
-        ("unix", `Unix);
-        ("macosx", `MacOSX);
-        ("xen", `Xen);
-        ("virtio", `Virtio);
-        ("hvt", `Hvt);
-        ("muen", `Muen);
-        ("qubes", `Qubes);
-        ("genode", `Genode);
-        ("spt", `Spt);
-      ]
+let (target_conv : mode Cmdliner.Arg.conv), target_doc_alts =
+  let enum =
+    [
+      ("unix", `Unix);
+      ("macosx", `MacOSX);
+      ("xen", `Xen);
+      ("virtio", `Virtio);
+      ("hvt", `Hvt);
+      ("muen", `Muen);
+      ("qubes", `Qubes);
+      ("genode", `Genode);
+      ("spt", `Spt);
+    ]
   in
-  (parser, printer)
+  let parser, printer = Cmdliner.Arg.enum enum in
+  ((parser, printer), Cmdliner.Arg.doc_alts_enum enum)
 
 let pp_target fmt m = snd target_conv fmt m
 
@@ -64,9 +64,8 @@ let default_target =
 
 let target =
   let doc =
-    "Target platform to compile the unikernel for. Valid values are: $(i,xen), \
-     $(i,qubes), $(i,unix), $(i,macosx), $(i,virtio), $(i,hvt), $(i,spt), \
-     $(i,muen), $(i,genode)."
+    Fmt.str "Target platform to compile the unikernel for. Valid values are: %s"
+      target_doc_alts
   in
   let doc =
     Arg.info ~docs:mirage_section ~docv:"TARGET" ~doc [ "t"; "target" ]
@@ -106,24 +105,24 @@ let configure_key ?(group = "") ~doc ~default conv name =
 (** {3 File system keys} *)
 
 let kv_ro ?group () =
-  let conv = Cmdliner.Arg.enum [ ("crunch", `Crunch); ("direct", `Direct) ] in
+  let enum = [ ("crunch", `Crunch); ("direct", `Direct) ] in
+  let conv = Cmdliner.Arg.enum enum in
   let doc =
-    Fmt.str
-      "Use a $(i,crunch) or $(i,direct) pass-through implementation for %a."
+    Fmt.str "Use %s pass-through implementation for %a."
+      (Cmdliner.Arg.doc_alts_enum enum)
       pp_group group
   in
   configure_key ~doc ?group ~default:`Crunch conv "kv_ro"
 
 (** {3 Block device keys} *)
 let block ?group () =
-  let conv =
-    Arg.enum
-      [ ("xenstore", `XenstoreId); ("file", `BlockFile); ("ramdisk", `Ramdisk) ]
+  let enum =
+    [ ("xenstore", `XenstoreId); ("file", `BlockFile); ("ramdisk", `Ramdisk) ]
   in
+  let conv = Arg.enum enum in
   let doc =
-    Fmt.str
-      "Use a $(i,ramdisk), $(i,xenstore), or $(i,file) pass-through \
-       implementation for %a."
+    Fmt.str "Use %s pass-through implementation for %a."
+      (Cmdliner.Arg.doc_alts_enum enum)
       pp_group group
   in
   configure_key ~doc ?group ~default:`Ramdisk conv "block"
@@ -135,9 +134,12 @@ let dhcp ?group () =
   configure_key ~doc ?group ~default:false Arg.bool "dhcp"
 
 let net ?group () : [ `Socket | `Direct ] option Key.key =
-  let conv = Cmdliner.Arg.enum [ ("socket", `Socket); ("direct", `Direct) ] in
+  let enum = [ ("socket", `Socket); ("direct", `Direct) ] in
+  let conv = Cmdliner.Arg.enum enum in
   let doc =
-    Fmt.str "Use $(i,socket) or $(i,direct) group for %a." pp_group group
+    Fmt.str "Use %s group for %a."
+      (Cmdliner.Arg.doc_alts_enum enum)
+      pp_group group
   in
   configure_key ~doc ?group ~default:None (Arg.some conv) "net"
 

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -58,13 +58,15 @@ module Conv = struct
     in
     Arg.conv (parser, serialize)
 
-  let allocation_policy =
-    Arg.enum
+  let allocation_policy, allocation_policy_doc_alts =
+    let enum =
       [
         ("next-fit", `Next_fit);
         ("first-fit", `First_fit);
         ("best-fit", `Best_fit);
       ]
+    in
+    (Arg.enum enum, Arg.doc_alts_enum enum)
 end
 
 let backtrace =
@@ -84,9 +86,10 @@ let randomize_hashtables =
 
 let allocation_policy =
   let doc =
-    "The policy used for allocating in the OCaml heap. Possible values are: \
-     $(i,next-fit), $(i,first-fit), $(i,best-fit). Best-fit is only supported \
-     since OCaml 4.10."
+    Printf.sprintf
+      "The policy used for allocating in the OCaml heap. Possible values are: \
+       %s. Best-fit is only supported since OCaml 4.10."
+      Conv.allocation_policy_doc_alts
   in
   let doc =
     Arg.info ~docs:ocaml_section ~docv:"ALLOCATION" ~doc [ "allocation-policy" ]

--- a/test/mirage/help/clean.t
+++ b/test/mirage/help/clean.t
@@ -15,7 +15,7 @@ Help clean --man-format=plain
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
+             one of unix, macosx, xen, virtio, hvt, muen, qubes, genode or spt
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -89,7 +89,7 @@ Help clean --help=plain
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
+             one of unix, macosx, xen, virtio, hvt, muen, qubes, genode or spt
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)

--- a/test/mirage/help/configure-o.t
+++ b/test/mirage/help/configure-o.t
@@ -14,7 +14,7 @@ Help configure -o --man-format=plain
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
+             one of unix, macosx, xen, virtio, hvt, muen, qubes, genode or spt
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -107,7 +107,7 @@ Help configure -o --help=plain
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
+             one of unix, macosx, xen, virtio, hvt, muen, qubes, genode or spt
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)

--- a/test/mirage/help/configure.t
+++ b/test/mirage/help/configure.t
@@ -14,7 +14,7 @@ Help configure --man-format=plain
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
+             one of unix, macosx, xen, virtio, hvt, muen, qubes, genode or spt
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -107,7 +107,7 @@ Configure help --help=plain
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
+             one of unix, macosx, xen, virtio, hvt, muen, qubes, genode or spt
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)

--- a/test/mirage/help/describe.t
+++ b/test/mirage/help/describe.t
@@ -27,7 +27,7 @@ Help describe --man-format=plain
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
+             one of unix, macosx, xen, virtio, hvt, muen, qubes, genode or spt
   
   DESCRIBE OPTIONS
          --dot
@@ -132,7 +132,7 @@ Help describe --help=plain
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
+             one of unix, macosx, xen, virtio, hvt, muen, qubes, genode or spt
   
   DESCRIBE OPTIONS
          --dot

--- a/test/mirage/help/query.t
+++ b/test/mirage/help/query.t
@@ -32,7 +32,7 @@ Help query --man-format=plain
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
+             one of unix, macosx, xen, virtio, hvt, muen, qubes, genode or spt
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)
@@ -131,7 +131,7 @@ Help query --help=plain
   MIRAGE PARAMETERS
          -t TARGET, --target=TARGET (absent=unix or MODE env)
              Target platform to compile the unikernel for. Valid values are:
-             xen, qubes, unix, macosx, virtio, hvt, spt, muen, genode.
+             one of unix, macosx, xen, virtio, hvt, muen, qubes, genode or spt
   
   CONFIGURE OPTIONS
          --context-file=FILE (absent=mirage.context)


### PR DESCRIPTION
This should make it easier to maintain doc strings.

Downsides are:
- phrasings are changed slightly
- the text is styled differently: instead of italic (or underline in my system) the values are rendered bold.