### PR TITLE
fix log_threshold documentation

### DIFF
--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -197,9 +197,9 @@ let logs =
   let docs = unikernel_section in
   let logs = Arg.list Conv.log_threshold in
   let doc =
-    "Be more or less verbose. $(docv) must be of the form@ \
-     $(b,*:info,foo:debug) means that that the log threshold is set to@ \
-     $(b,info) for every log sources but the $(b,foo) which is set to@ \
+    "Be more or less verbose. $(docv) must be of the form \
+     $(b,*:info,foo:debug) means that that the log threshold is set to \
+     $(b,info) for every log sources but the $(b,foo) which is set to \
      $(b,debug)."
   in
   let doc = Arg.info ~env ~docv:"LEVEL" ~doc ~docs [ "l"; "logs" ] in

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -193,7 +193,6 @@ let custom_minor_max_size =
   Arg.(value & opt (some int) None doc)
 
 let logs =
-  let env = Cmd.Env.info "MIRAGE_LOGS" in
   let docs = unikernel_section in
   let logs = Arg.list Conv.log_threshold in
   let doc =
@@ -202,7 +201,7 @@ let logs =
      $(b,info) for every log sources but the $(b,foo) which is set to \
      $(b,debug)."
   in
-  let doc = Arg.info ~env ~docv:"LEVEL" ~doc ~docs [ "l"; "logs" ] in
+  let doc = Arg.info ~docv:"LEVEL" ~doc ~docs [ "l"; "logs" ] in
   Arg.(value & opt logs [] doc)
 
 (** {3 Blocks} *)

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -205,7 +205,7 @@ let logs =
   let doc = Arg.info ~env ~docv:"LEVEL" ~doc ~docs [ "l"; "logs" ] in
   Arg.(value & opt logs [] doc)
 
-(** {3 Blocks *)
+(** {3 Blocks} *)
 
 let disk =
   let doc =

--- a/lib_runtime/mirage/mirage_runtime.mli
+++ b/lib_runtime/mirage/mirage_runtime.mli
@@ -73,7 +73,7 @@ val custom_major_ratio : int option Term.t
 val custom_minor_ratio : int option Term.t
 val custom_minor_max_size : int option Term.t
 
-(** {3 Blocks *)
+(** {3 Blocks} *)
 
 val disk : string Term.t
 val analyze : bool Term.t


### PR DESCRIPTION
previously, the rendered `--help` included `@` characters