### PR TITLE
WIP: Use ppxlib.metaquot instead of raw strings for runtime keys

### DIFF
--- a/lib/mirage/dune
+++ b/lib/mirage/dune
@@ -2,7 +2,8 @@
  (public_name mirage.key)
  (name mirage_key)
  (wrapped false)
- (libraries ipaddr functoria mirage-runtime bos)
+ (preprocess (pps ppxlib.metaquot))
+ (libraries ppxlib ipaddr functoria mirage-runtime bos)
  (modules mirage_key mirage_runtime_key))
 
 (library

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -69,21 +69,6 @@ module Conv = struct
     (Arg.enum enum, Arg.doc_alts_enum enum)
 end
 
-let backtrace =
-  let doc =
-    "Trigger the printing of a stack backtrace when an uncaught exception \
-     aborts the unikernel."
-  in
-  let doc = Arg.info ~docs:ocaml_section ~docv:"BOOL" ~doc [ "backtrace" ] in
-  Arg.(value & opt bool true doc)
-
-let randomize_hashtables =
-  let doc = "Turn on randomization of all hash tables by default." in
-  let doc =
-    Arg.info ~docs:ocaml_section ~docv:"BOOL" ~doc [ "randomize-hashtables" ]
-  in
-  Arg.(value & opt bool true doc)
-
 let allocation_policy =
   let doc =
     Printf.sprintf
@@ -224,13 +209,6 @@ let analyze =
   Arg.(value & opt bool true doc)
 
 (** {3 Initial delay} *)
-
-let delay =
-  let doc =
-    Arg.info ~docs:unikernel_section ~doc:"Delay n seconds before starting up"
-      [ "delay" ]
-  in
-  Arg.(value & opt int 0 doc)
 
 (* Hooks *)
 

--- a/lib_runtime/mirage/mirage_runtime.mli
+++ b/lib_runtime/mirage/mirage_runtime.mli
@@ -42,18 +42,6 @@ module Conv : sig
   (** [allocation_policy] converts allocation policy. *)
 end
 
-(** {2 OCaml runtime keys}
-
-    The OCaml runtime is usually configurable via the [OCAMLRUNPARAM]
-    environment variable. We provide boot parameters covering these options. *)
-
-val backtrace : bool Term.t
-(** [--backtrace]: Output a backtrace if an uncaught exception terminated the
-    unikernel. *)
-
-val randomize_hashtables : bool Term.t
-(** [--randomize-hashtables]: Randomize all hash tables. *)
-
 (** {3 GC control}
 
     The OCaml garbage collector can be configured, as described in detail in
@@ -77,13 +65,6 @@ val custom_minor_max_size : int option Term.t
 
 val disk : string Term.t
 val analyze : bool Term.t
-
-(** {3 Startup delay} *)
-
-val delay : int Term.t
-(** The initial delay, specified in seconds, before a unikernel starting up.
-    Defaults to 0. Useful for tenders and environments that take some time to
-    bring devices up. *)
 
 include module type of Functoria_runtime
 


### PR DESCRIPTION
I'm opening this to open the discussion. The AST fragments are not typed yet but we could make this happen if we think that's useful.

See https://github.com/mirage/mirage/pull/1488 for an alternative using raw strings.