### PR TITLE
Fix `config.exe query` to use the same code path as code generation

### DIFF
--- a/test/functoria/query/run.t
+++ b/test/functoria/query/run.t
@@ -234,7 +234,7 @@ Query version
 
 Query unikernel dune
   $ ./config.exe query dune.build
-  (copy_files ./config/*)
+  (copy_files ./test/*)
   
   (executable
     (public_name f0)

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -1,6 +1,6 @@
 Query unikernel dune
   $ ./config_dash_in_name.exe query dune.build
-  (copy_files ./config/*)
+  (copy_files ./mirage/*)
   
   (rule
    (target noop-functor.v0)
@@ -101,7 +101,7 @@ Query dune-project
 
 Query unikernel dune (hvt)
   $ ./config_dash_in_name.exe query --target hvt dune.build
-  (copy_files ./config/*)
+  (copy_files ./mirage/*)
   
   (executable
    (enabled_if (= %{context_name} "solo5"))

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -250,7 +250,7 @@ Query version
 
 Query unikernel dune
   $ ./config.exe query --target hvt dune.build
-  (copy_files ./config/*)
+  (copy_files ./mirage/*)
   
   (executable
    (enabled_if (= %{context_name} "solo5"))

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -252,7 +252,7 @@ Query version
 
 Query unikernel dune
   $ ./config.exe query dune.build
-  (copy_files ./config/*)
+  (copy_files ./mirage/*)
   
   (rule
    (target noop)


### PR DESCRIPTION
This ensures that the tests are actually testing the right thing (and fix the tests).

that was initially part of #1493 but is actually an independent fix.