### PR TITLE
Add line directives to OCaml files that are copied around

### DIFF
--- a/test/functoria/e2e/configure.t
+++ b/test/functoria/e2e/configure.t
@@ -27,6 +27,7 @@ is passed:
                               "dry_run" = false }
   config.exe: [INFO] Generating: main.ml (main file)
   config.exe: [INFO] Generating: key_gen.ml (keys)
+  config.exe: [INFO] Generating: key_gen.ml (keys)
   config.exe: [INFO] Generating: dune.build (dune.build)
   config.exe: [INFO] Generating: dune-workspace (dune-workspace)
   config.exe: [INFO] Generating: dune-project (dune-project)

--- a/test/functoria/query/run.t
+++ b/test/functoria/query/run.t
@@ -234,7 +234,13 @@ Query version
 
 Query unikernel dune
   $ ./config.exe query dune.build
-  (copy_files ./test/*)
+  (copy_files# ./test/key_gen.ml)
+  
+  (copy_files# ./test/main.ml)
+  
+  (copy_files ./test/vote)
+  
+  (copy_files ./test/warn_error)
   
   (executable
     (public_name f0)

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -1,6 +1,8 @@
 Query unikernel dune
   $ ./config_dash_in_name.exe query dune.build
-  (copy_files ./mirage/*)
+  (copy_files# ./mirage/key_gen.ml)
+  
+  (copy_files# ./mirage/main.ml)
   
   (rule
    (target noop-functor.v0)
@@ -101,7 +103,13 @@ Query dune-project
 
 Query unikernel dune (hvt)
   $ ./config_dash_in_name.exe query --target hvt dune.build
-  (copy_files ./mirage/*)
+  (copy_files# ./mirage/key_gen.ml)
+  
+  (copy_files# ./mirage/main.ml)
+  
+  (copy_files ./mirage/manifest.json)
+  
+  (copy_files# ./mirage/manifest.ml)
   
   (executable
    (enabled_if (= %{context_name} "solo5"))

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -250,7 +250,13 @@ Query version
 
 Query unikernel dune
   $ ./config.exe query --target hvt dune.build
-  (copy_files ./mirage/*)
+  (copy_files# ./mirage/key_gen.ml)
+  
+  (copy_files# ./mirage/main.ml)
+  
+  (copy_files ./mirage/manifest.json)
+  
+  (copy_files# ./mirage/manifest.ml)
   
   (executable
    (enabled_if (= %{context_name} "solo5"))

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -252,7 +252,9 @@ Query version
 
 Query unikernel dune
   $ ./config.exe query dune.build
-  (copy_files ./mirage/*)
+  (copy_files# ./mirage/key_gen.ml)
+  
+  (copy_files# ./mirage/main.ml)
   
   (rule
    (target noop)


### PR DESCRIPTION
This will help to get better locations in error messages.

This is on-top of #1499 and extracted from #1493 