### PR TITLE
Rename Runtime_key to Runtime_arg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
   * API changes:
     - There is no more `~stage` parameter for `Key.Arg.info`.
     - `Key` now define configure-time keys only.
-    - There is a new module `Runtime_key` to define runtime keys.
+    - There is a new module `Runtime_arg` to define runtime keys.
     - As there are no more keys type `'Both`, users are now expected to create
       two separated keys in that case (one for configure-time, one for runtime)
       or decide if the key is useful at runtime of configure-time.
@@ -26,7 +26,7 @@
     - Similar keys will produce reproducible binaries to be uploaded to artifact
       repositories like Docker Hub or https://builds.robur.coop/.
 
-  * Intended use of runtime keys (values of type `a runtime_key`):
+  * Intended use of runtime keys (values of type `a runtime_arg`):
     - Allow users to customize deployments by changing device
       configuration, like IP addresses, secrets, block device names,
       etc., post downloading of binaries.
@@ -59,6 +59,7 @@
      - Configure-time keys are not registerd anymore. This means that
        they are not available `key_gen.ml` anymore. As a consequence,
        `Key_gen.target` has been removed.
+
 - BUGFIX: fix `mirage describe` output (#1446 @samoht), add test (#1458 @samoht)
 - Remove ipaddr from runtime (#1437 @samoht, #1465 @hannesm)
 - BREAKING: Mirage.register (and Functoria.register) no longer have `?packages`

--- a/lib/functoria/DSL.ml
+++ b/lib/functoria/DSL.ml
@@ -17,7 +17,7 @@
  *)
 
 type 'a key = 'a Key.key
-type 'a runtime_key = 'a Runtime_key.key
+type 'a runtime_arg = 'a Runtime_arg.arg
 type 'a value = 'a Key.value
 type abstract_key = Key.t
 type package = Package.t
@@ -40,10 +40,10 @@ let dep = Impl.abstract
 let if_impl = Impl.if_
 let match_impl = Impl.match_
 
-let impl ?packages ?packages_v ?install ?install_v ?keys ?runtime_keys
+let impl ?packages ?packages_v ?install ?install_v ?keys ?runtime_args
     ?extra_deps ?connect ?dune ?configure ?files module_name module_type =
   of_device
-  @@ Device.v ?packages ?packages_v ?install ?install_v ?keys ?runtime_keys
+  @@ Device.v ?packages ?packages_v ?install ?install_v ?keys ?runtime_args
        ?extra_deps ?connect ?dune ?configure ?files module_name module_type
 
 let main ?packages ?packages_v ?extra_deps module_name ty =

--- a/lib/functoria/DSL.mli
+++ b/lib/functoria/DSL.mli
@@ -66,7 +66,7 @@ val dep : 'a impl -> abstract_impl
 type 'a key = 'a Key.key
 (** The type for command-line parameters. *)
 
-type 'a runtime_key = 'a Runtime_key.key
+type 'a runtime_arg = 'a Runtime_arg.arg
 (** The type for command-line parameters. *)
 
 type abstract_key = Key.t
@@ -165,7 +165,7 @@ val impl :
   ?install:(Info.t -> Install.t) ->
   ?install_v:(Info.t -> Install.t Key.value) ->
   ?keys:Key.t list ->
-  ?runtime_keys:Runtime_key.t list ->
+  ?runtime_args:Runtime_arg.t list ->
   ?extra_deps:abstract_impl list ->
   ?connect:(info -> string -> string list -> string) ->
   ?dune:(info -> Dune.stanza list) ->

--- a/lib/functoria/device.ml
+++ b/lib/functoria/device.ml
@@ -29,7 +29,7 @@ type ('a, 'impl) t = {
   module_name : string;
   module_type : 'a Type.t;
   keys : Key.t list;
-  runtime_keys : Runtime_key.t list;
+  runtime_args : Runtime_arg.t list;
   packages : package list value;
   install : info -> Install.t value;
   connect : info -> string -> string list -> 'a code;
@@ -76,7 +76,7 @@ let merge_packages = merge [] List.append
 let merge_install = merge Install.empty Install.union
 
 let v ?packages ?packages_v ?install ?install_v ?(keys = [])
-    ?(runtime_keys = []) ?(extra_deps = []) ?(connect = default_connect)
+    ?(runtime_args = []) ?(extra_deps = []) ?(connect = default_connect)
     ?(dune = nil) ?(configure = niet) ?files module_name module_type =
   let id = Typeid.gen () in
   let packages = merge_packages packages packages_v in
@@ -89,7 +89,7 @@ let v ?packages ?packages_v ?install ?install_v ?(keys = [])
     id;
     module_name;
     keys;
-    runtime_keys;
+    runtime_args;
     connect;
     packages;
     install;
@@ -115,7 +115,7 @@ let files t i =
 
 let dune t = t.dune
 let keys t = t.keys
-let runtime_keys t = t.runtime_keys
+let runtime_args t = t.runtime_args
 let extra_deps t = t.extra_deps
 
 let start impl_name args =

--- a/lib/functoria/device.mli
+++ b/lib/functoria/device.mli
@@ -63,11 +63,11 @@ val files : ('a, 'b) t -> Info.t -> Fpath.Set.t
 (** [files t info s] is the list of files generated configure-time. *)
 
 val keys : ('a, 'b) t -> Key.t list
-(** [keys t] is the list of command-line keys which can be used to configure
-    [t]. *)
+(** [keys t] is the list of keys which can be used to configure [t]. *)
 
-val runtime_keys : ('a, 'b) t -> Runtime_key.t list
-(** [keys t] is the list of command-line keys which can be used to run [t]. *)
+val runtime_args : ('a, 'b) t -> Runtime_arg.t list
+(** [runtime_args t] is the list of command-line arguments which can be used to
+    configure [t] at runtime. *)
 
 (** {1 Code Generation} *)
 
@@ -109,7 +109,7 @@ val v :
   ?install:(Info.t -> Install.t) ->
   ?install_v:(Info.t -> Install.t Key.value) ->
   ?keys:Key.t list ->
-  ?runtime_keys:Runtime_key.t list ->
+  ?runtime_args:Runtime_arg.t list ->
   ?extra_deps:'b list ->
   ?connect:(Info.t -> string -> string list -> 'a code) ->
   ?dune:(Info.t -> Dune.stanza list) ->

--- a/lib/functoria/engine.mli
+++ b/lib/functoria/engine.mli
@@ -21,8 +21,11 @@
 val if_keys : Impl.abstract -> Key.Set.t
 (** [if_keys t] is the set of [if] keys in the graph [t]. *)
 
-val all_keys : Impl.abstract -> Key.Set.t * Runtime_key.Set.t
-(** [all_keys t] is the set of keys in the graph [t]. *)
+val keys : Impl.abstract -> Key.Set.t
+(** [keys t] is the set of keys in the graph [t]. *)
+
+val runtime_args : Impl.abstract -> Runtime_arg.Set.t
+(** [runtime_args t] is the set of runtime arguments in the graph [t]. *)
 
 val packages : Impl.abstract -> Package.t list Key.value
 (** [packages t] is the set of packages in the graph [t]. *)

--- a/lib/functoria/functoria.ml
+++ b/lib/functoria/functoria.ml
@@ -18,7 +18,7 @@
 
 module Context = Context
 module Key = Key
-module Runtime_key = Runtime_key
+module Runtime_arg = Runtime_arg
 module Package = Package
 module Info = Info
 module Type = Type
@@ -44,11 +44,11 @@ module type KEY =
      and type t = Key.t
      and type Set.t = Key.Set.t
 
-module type RUNTIME_KEY =
-  module type of Runtime_key
-    with type 'a key = 'a Runtime_key.key
-     and type t = Runtime_key.t
-     and type Set.t = Runtime_key.Set.t
+module type RUNTIME_ARG =
+  module type of Runtime_arg
+    with type 'a arg = 'a Runtime_arg.arg
+     and type t = Runtime_arg.t
+     and type Set.t = Runtime_arg.Set.t
 
 (** Devices *)
 

--- a/lib/functoria/functoria.mli
+++ b/lib/functoria/functoria.mli
@@ -133,11 +133,11 @@ module type KEY =
      and type Set.t = Key.Set.t
 
 (** The signature for run-time command-line keys. *)
-module type RUNTIME_KEY =
-  module type of Runtime_key
-    with type 'a key = 'a Runtime_key.key
-     and type t = Runtime_key.t
-     and type Set.t = Runtime_key.Set.t
+module type RUNTIME_ARG =
+  module type of Runtime_arg
+    with type 'a arg = 'a Runtime_arg.arg
+     and type t = Runtime_arg.t
+     and type Set.t = Runtime_arg.Set.t
 
 module Package = Package
 module Info = Info
@@ -172,7 +172,7 @@ module Type = Type
 module Impl = Impl
 module Context = Context
 module Key = Key
-module Runtime_key = Runtime_key
+module Runtime_arg = Runtime_arg
 module Opam = Opam
 module Lib = Lib
 module Tool = Tool

--- a/lib/functoria/info.ml
+++ b/lib/functoria/info.ml
@@ -23,7 +23,7 @@ type t = {
   name : string;
   output : string option;
   keys : Key.Set.t;
-  runtime_keys : Runtime_key.Set.t;
+  runtime_args : Runtime_arg.Set.t;
   context : Context.t;
   packages : Package.t String.Map.t;
   opam :
@@ -62,13 +62,13 @@ let pins packages =
     [] packages
 
 let keys t = Key.Set.elements t.keys
-let runtime_keys t = Runtime_key.Set.elements t.runtime_keys
+let runtime_args t = Runtime_arg.Set.elements t.runtime_args
 let context t = t.context
 
-let v ?(config_file = Fpath.v "config.ml") ~packages ~keys ~runtime_keys
+let v ?(config_file = Fpath.v "config.ml") ~packages ~keys ~runtime_args
     ~context ?configure_cmd ?pre_build_cmd ?lock_location ~build_cmd ~src name =
   let keys = Key.Set.of_list keys in
-  let runtime_keys = Runtime_key.Set.of_list runtime_keys in
+  let runtime_args = Runtime_arg.Set.of_list runtime_args in
   let opam ~extra_repo ~install ~opam_name =
     Opam.v ~depends:packages ~install ~pins:(pins packages) ~extra_repo
       ?configure:configure_cmd ?pre_build:pre_build_cmd ?lock_location
@@ -90,7 +90,7 @@ let v ?(config_file = Fpath.v "config.ml") ~packages ~keys ~runtime_keys
     config_file;
     name;
     keys;
-    runtime_keys;
+    runtime_args;
     packages;
     context;
     output = None;
@@ -121,7 +121,7 @@ let pp verbose ppf ({ name; keys; context; output; _ } as t) =
 
 let t =
   let i =
-    v ~config_file:(Fpath.v "config.ml") ~packages:[] ~keys:[] ~runtime_keys:[]
+    v ~config_file:(Fpath.v "config.ml") ~packages:[] ~keys:[] ~runtime_args:[]
       ~build_cmd:"dummy" ~context:Context.empty ~src:`None "dummy"
   in
   Type.v i

--- a/lib/functoria/info.mli
+++ b/lib/functoria/info.mli
@@ -51,11 +51,11 @@ val opam :
 (** [opam scope t] is [t]'opam file to install in the [scope] context.*)
 
 val keys : t -> Key.t list
-(** [keys t] are the configure-time keys declared by the project. *)
+(** [keys t] is the list of keys which can be used to configure [t]. *)
 
-val runtime_keys : t -> Runtime_key.t list
-(** [keys t] are the runtime keys declared by the project and used by the
-    declared devices. *)
+val runtime_args : t -> Runtime_arg.t list
+(** [runtime_args t] is the list of command-line arguments which can be used to
+    configure [t] at runtime. *)
 
 val context : t -> Context.t
 (** [parsed t] is a value representing the command-line argument being parsed. *)
@@ -67,7 +67,7 @@ val v :
   ?config_file:Fpath.t ->
   packages:Package.t list ->
   keys:Key.t list ->
-  runtime_keys:Runtime_key.t list ->
+  runtime_args:Runtime_arg.t list ->
   context:Context.t ->
   ?configure_cmd:string ->
   ?pre_build_cmd:(Fpath.t option -> string) ->

--- a/lib/functoria/job.ml
+++ b/lib/functoria/job.ml
@@ -32,9 +32,9 @@ module Keys = struct
   let configure ~file i =
     Log.info (fun m -> m "Generating: %a (keys)" Fpath.pp file);
     Action.with_output ~path:file ~purpose:"key_gen file" (fun ppf ->
-        let keys = Runtime_key.Set.of_list @@ Info.runtime_keys i in
+        let keys = Runtime_arg.Set.of_list @@ Info.runtime_args i in
         Fmt.pf ppf "@[<v>%a@]@."
-          Fmt.(iter Runtime_key.Set.iter Runtime_key.serialize)
+          Fmt.(iter Runtime_arg.Set.iter Runtime_arg.serialize)
           keys)
 end
 
@@ -42,13 +42,13 @@ let keys ?(runtime_package = "functoria-runtime")
     ?(runtime_modname = "Functoria_runtime") (argv : Argv.t Impl.t) =
   let packages = [ Package.v runtime_package ] in
   let extra_deps = [ Impl.abstract argv ] in
-  let key_gen = Runtime_key.module_name in
+  let key_gen = Runtime_arg.module_name in
   let file = Fpath.(v (String.Ascii.lowercase key_gen) + "ml") in
   let configure = Keys.configure ~file in
   let files _ = [ file ] in
   let connect info _ = function
     | [ argv ] ->
-        Fmt.str "return %s.(with_argv (runtime_keys ()) %S %s)" runtime_modname
+        Fmt.str "return %s.(with_argv (runtime_args ()) %S %s)" runtime_modname
           (Info.name info) argv
     | _ -> failwith "The keys connect should receive exactly one argument."
   in

--- a/lib/functoria/runtime_arg.ml
+++ b/lib/functoria/runtime_arg.ml
@@ -16,8 +16,8 @@
 
 open Misc
 
-type 'a key = { name : string; code : string; packages : Package.t list }
-type t = Any : 'a key -> t
+type 'a arg = { name : string; code : string; packages : Package.t list }
+type t = Any : 'a arg -> t
 
 (* Set of keys, where keys with the same name but with different
    defaults are distinguished. This is useful to build the graph of
@@ -56,7 +56,7 @@ let module_name = "Key_gen"
 let ocaml_name k = String.lowercase_ascii (Name.ocamlify k)
 
 let serialize fmt (Any k) =
-  Format.fprintf fmt "@[<2>let %s =@ @[Functoria_runtime.key@ %s@]@]@,"
+  Format.fprintf fmt "@[<2>let %s =@ @[Functoria_runtime.register@ %s@]@]@,"
     (ocaml_name k.name) k.code
 
 let call fmt k = Fmt.pf fmt "(%s.%s ())" module_name (ocaml_name k.name)

--- a/lib/functoria/runtime_arg.mli
+++ b/lib/functoria/runtime_arg.mli
@@ -16,18 +16,17 @@
 
 (** Runtime command-line arguments. *)
 
-type 'a key
-(** The type for runtime keys. Keys are used to retrieve the cross-stage values
-    they are holding. *)
+type 'a arg
+(** The type for command-line arguments that parses values of type ['a].. *)
 
-val create : ?name:string -> ?packages:Package.t list -> string -> 'a key
+val create : ?name:string -> ?packages:Package.t list -> string -> 'a arg
 
 type t
 (** The type for abstract {{!type:key} keys}. *)
 
 val packages : t -> Package.t list
 
-val v : 'a key -> t
+val v : 'a arg -> t
 (** [v k] is the [k] with its type hidden. *)
 
 (** [Set] implements sets over [t] elements. *)
@@ -40,7 +39,7 @@ end
 
 (** {1 Code Serialization} *)
 
-val call : 'a key Fmt.t
+val call : 'a arg Fmt.t
 (** [call fmt k] outputs [name ()] to [fmt], where [n] is [k]'s {{!ocaml_name}
     OCaml name}. *)
 

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -212,7 +212,7 @@ module Make (P : S) = struct
     let context =
       (* Extract all the keys directly. Useful to pre-resolve the keys
          provided by the specialized DSL. *)
-      let base_keys, _ = Engine.all_keys @@ Impl.abstract @@ P.create [] in
+      let base_keys = Engine.keys @@ Impl.abstract @@ P.create [] in
       Cmdliner.Term.(const (fun _ -> Action.ok ()) $ Key.context base_keys)
     in
     let result =

--- a/lib/mirage/dune
+++ b/lib/mirage/dune
@@ -3,10 +3,10 @@
  (name mirage_key)
  (wrapped false)
  (libraries ipaddr functoria mirage-runtime bos)
- (modules mirage_key mirage_runtime_key))
+ (modules mirage_key mirage_runtime_arg))
 
 (library
  (public_name mirage)
  (wrapped false)
  (libraries mirage.impl mirage.target)
- (modules :standard \ mirage_key mirage_runtime_key))
+ (modules :standard \ mirage_key mirage_runtime_arg))

--- a/lib/mirage/impl/mirage_impl_block.mli
+++ b/lib/mirage/impl/mirage_impl_block.mli
@@ -21,7 +21,7 @@ val docteur :
   ?mode:[ `Fast | `Light ] ->
   ?name:string key ->
   ?output:string key ->
-  ?analyze:bool runtime_key ->
+  ?analyze:bool runtime_arg ->
   ?branch:string ->
   ?extra_deps:string list ->
   string ->
@@ -32,11 +32,11 @@ type block_t = { filename : string; number : int }
 val all_blocks : (string, block_t) Hashtbl.t
 
 val chamelon :
-  program_block_size:int runtime_key ->
+  program_block_size:int runtime_arg ->
   (block -> Mirage_impl_pclock.pclock -> Mirage_impl_kv.rw) impl
 
 val tar_kv_rw :
   Mirage_impl_pclock.pclock impl -> block impl -> Mirage_impl_kv.rw impl
 
 val ccm_block :
-  ?nonce_len:int -> string option runtime_key -> (block -> block) impl
+  ?nonce_len:int -> string option runtime_arg -> (block -> block) impl

--- a/lib/mirage/impl/mirage_impl_dns.ml
+++ b/lib/mirage/impl/mirage_impl_dns.ml
@@ -11,26 +11,26 @@ let dns_client = Type.v Dns_client
 
 let generic_dns_client timeout nameservers =
   let packages = [ package "dns-client-mirage" ~min:"7.0.0" ~max:"8.0.0" ] in
-  let runtime_keys =
+  let runtime_args =
     match (nameservers, timeout) with
     | None, None -> []
-    | None, Some timeout -> Runtime_key.[ v timeout ]
-    | Some nameservers, None -> Runtime_key.[ v nameservers ]
-    | Some nameservers, Some timeout -> Runtime_key.[ v nameservers; v timeout ]
+    | None, Some timeout -> Runtime_arg.[ v timeout ]
+    | Some nameservers, None -> Runtime_arg.[ v nameservers ]
+    | Some nameservers, Some timeout -> Runtime_arg.[ v nameservers; v timeout ]
   in
   let connect _info modname = function
     | [ _random; _time; _mclock; _pclock; stackv4v6 ] ->
         let pp_nameservers ppf = function
           | None -> Fmt.string ppf "[]"
-          | Some nameservers -> Runtime_key.call ppf nameservers
+          | Some nameservers -> Runtime_arg.call ppf nameservers
         in
         let pp_timeout ppf = function
           | None -> ()
-          | Some timeout -> Fmt.pf ppf "?timeout:%a " Runtime_key.call timeout
+          | Some timeout -> Fmt.pf ppf "?timeout:%a " Runtime_arg.call timeout
         in
         Fmt.str {ocaml|%s.connect ~nameservers:%a %a%s|ocaml} modname
           pp_nameservers nameservers pp_timeout timeout stackv4v6
     | _ -> assert false
   in
-  impl ~runtime_keys ~packages ~connect "Dns_client_mirage.Make"
+  impl ~runtime_args ~packages ~connect "Dns_client_mirage.Make"
     (random @-> time @-> mclock @-> pclock @-> stackv4v6 @-> dns_client)

--- a/lib/mirage/impl/mirage_impl_dns.mli
+++ b/lib/mirage/impl/mirage_impl_dns.mli
@@ -5,8 +5,8 @@ type dns_client
 val dns_client : dns_client typ
 
 val generic_dns_client :
-  int64 option runtime_key option ->
-  string list runtime_key option ->
+  int64 option runtime_arg option ->
+  string list runtime_arg option ->
   (Mirage_impl_random.random ->
   Mirage_impl_time.time ->
   Mirage_impl_mclock.mclock ->

--- a/lib/mirage/impl/mirage_impl_git.ml
+++ b/lib/mirage/impl/mirage_impl_git.ml
@@ -40,36 +40,36 @@ let git_ssh ?authenticator key password =
         | None ->
             Fmt.str
               {ocaml|%s.connect %s >>= %s.with_optionnal_key ~key:%a ~password:%a|ocaml}
-              modname ctx modname Runtime_key.call key Runtime_key.call password
+              modname ctx modname Runtime_arg.call key Runtime_arg.call password
         | Some authenticator ->
             Fmt.str
               {ocaml|%s.connect %s >>= %s.with_optionnal_key ?authenticator:%a ~key:%a ~password:%a|ocaml}
-              modname ctx modname Runtime_key.call authenticator
-              Runtime_key.call key Runtime_key.call password)
+              modname ctx modname Runtime_arg.call authenticator
+              Runtime_arg.call key Runtime_arg.call password)
     | _ -> assert false
   in
-  let runtime_keys =
-    Runtime_key.v key
-    :: Runtime_key.v password
-    :: List.map Runtime_key.v (Option.to_list authenticator)
+  let runtime_args =
+    Runtime_arg.v key
+    :: Runtime_arg.v password
+    :: List.map Runtime_arg.v (Option.to_list authenticator)
   in
-  impl ~packages ~connect ~runtime_keys "Git_mirage_ssh.Make"
+  impl ~packages ~connect ~runtime_args "Git_mirage_ssh.Make"
     (mclock @-> tcpv4v6 @-> time @-> mimic @-> git_client)
 
 let git_http ?authenticator headers =
   let packages =
     [ package "git-mirage" ~sublibs:[ "http" ] ~min:"3.10.0" ~max:"3.16.0" ]
   in
-  let runtime_keys =
+  let runtime_args =
     let keys = [] in
     let keys =
       match headers with
-      | Some headers -> Runtime_key.v headers :: keys
+      | Some headers -> Runtime_arg.v headers :: keys
       | None -> keys
     in
     let keys =
       match authenticator with
-      | Some authenticator -> Runtime_key.v authenticator :: keys
+      | Some authenticator -> Runtime_arg.v authenticator :: keys
       | None -> []
     in
     keys
@@ -78,12 +78,12 @@ let git_http ?authenticator headers =
     | [ _pclock; _tcpv4v6; ctx ] ->
         let serialize_headers ppf = function
           | None -> ()
-          | Some headers -> Fmt.pf ppf " ?headers:%a" Runtime_key.call headers
+          | Some headers -> Fmt.pf ppf " ?headers:%a" Runtime_arg.call headers
         in
         let serialize_authenticator ppf = function
           | None -> ()
           | Some authenticator ->
-              Fmt.pf ppf " ?authenticator:%a" Runtime_key.call authenticator
+              Fmt.pf ppf " ?authenticator:%a" Runtime_arg.call authenticator
         in
         Fmt.str
           {ocaml|%s.connect %s >>= fun ctx -> %s.with_optional_tls_config_and_headers%a%a ctx|ocaml}
@@ -91,5 +91,5 @@ let git_http ?authenticator headers =
           serialize_headers headers
     | _ -> assert false
   in
-  impl ~packages ~connect ~runtime_keys "Git_mirage_http.Make"
+  impl ~packages ~connect ~runtime_args "Git_mirage_http.Make"
     (pclock @-> tcpv4v6 @-> mimic @-> git_client)

--- a/lib/mirage/impl/mirage_impl_git.mli
+++ b/lib/mirage/impl/mirage_impl_git.mli
@@ -9,9 +9,9 @@ val git_tcp :
   (Mirage_impl_tcp.tcpv4v6 -> Mirage_impl_mimic.mimic -> git_client) impl
 
 val git_ssh :
-  ?authenticator:string option runtime_key ->
-  string option runtime_key ->
-  string option runtime_key ->
+  ?authenticator:string option runtime_arg ->
+  string option runtime_arg ->
+  string option runtime_arg ->
   (Mirage_impl_mclock.mclock ->
   Mirage_impl_tcp.tcpv4v6 ->
   Mirage_impl_time.time ->
@@ -20,8 +20,8 @@ val git_ssh :
   impl
 
 val git_http :
-  ?authenticator:string option runtime_key ->
-  (string * string) list runtime_key option ->
+  ?authenticator:string option runtime_arg ->
+  (string * string) list runtime_arg option ->
   (Mirage_impl_pclock.pclock ->
   Mirage_impl_tcp.tcpv4v6 ->
   Mirage_impl_mimic.mimic ->

--- a/lib/mirage/impl/mirage_impl_happy_eyeballs.ml
+++ b/lib/mirage/impl/mirage_impl_happy_eyeballs.ml
@@ -13,20 +13,20 @@ let generic_happy_eyeballs aaaa_timeout connect_delay connect_timeout
   let packages =
     [ package "happy-eyeballs-mirage" ~min:"0.6.0" ~max:"1.0.0" ]
   in
-  let runtime_keys =
+  let runtime_args =
     let cons_if_some v l = match v with Some x -> x :: l | None -> l in
     cons_if_some aaaa_timeout []
     |> cons_if_some connect_delay
     |> cons_if_some resolve_timeout
     |> cons_if_some resolve_retries
     |> cons_if_some timer_interval
-    |> List.map Runtime_key.v
+    |> List.map Runtime_arg.v
   in
   let connect _info modname = function
     | [ _time; _mclock; stack; dns ] ->
         let pp_optional_argument ~name ppf = function
           | None -> ()
-          | Some key -> Fmt.pf ppf "?%s:%a " name Runtime_key.call key
+          | Some key -> Fmt.pf ppf "?%s:%a " name Runtime_arg.call key
         in
         Fmt.str {ocaml|%s.connect_device %a%a%a%a%a%a %s %s|ocaml} modname
           (pp_optional_argument ~name:"aaaa_timeout")
@@ -43,5 +43,5 @@ let generic_happy_eyeballs aaaa_timeout connect_delay connect_timeout
           timer_interval dns stack
     | _ -> assert false
   in
-  impl ~runtime_keys ~packages ~connect "Happy_eyeballs_mirage.Make"
+  impl ~runtime_args ~packages ~connect "Happy_eyeballs_mirage.Make"
     (time @-> mclock @-> stackv4v6 @-> dns_client @-> happy_eyeballs)

--- a/lib/mirage/impl/mirage_impl_happy_eyeballs.mli
+++ b/lib/mirage/impl/mirage_impl_happy_eyeballs.mli
@@ -5,12 +5,12 @@ type happy_eyeballs
 val happy_eyeballs : happy_eyeballs typ
 
 val generic_happy_eyeballs :
-  int64 option runtime_key option ->
-  int64 option runtime_key option ->
-  int64 option runtime_key option ->
-  int64 option runtime_key option ->
-  int64 option runtime_key option ->
-  int64 option runtime_key option ->
+  int64 option runtime_arg option ->
+  int64 option runtime_arg option ->
+  int64 option runtime_arg option ->
+  int64 option runtime_arg option ->
+  int64 option runtime_arg option ->
+  int64 option runtime_arg option ->
   (Mirage_impl_time.time ->
   Mirage_impl_mclock.mclock ->
   Mirage_impl_stack.stackv4v6 ->

--- a/lib/mirage/impl/mirage_impl_http.ml
+++ b/lib/mirage/impl/mirage_impl_http.ml
@@ -51,15 +51,15 @@ let http_server = Type.v HTTP_server
 let paf_server port =
   let connect _ modname = function
     | [ tcpv4v6 ] ->
-        Fmt.str {ocaml|%s.init ~port:%a %s|ocaml} modname Runtime_key.call port
+        Fmt.str {ocaml|%s.init ~port:%a %s|ocaml} modname Runtime_arg.call port
           tcpv4v6
     | _ -> assert false
   in
   let packages =
     [ package "paf" ~sublibs:[ "mirage" ] ~min:"0.3.0" ~max:"0.6.0" ]
   in
-  let runtime_keys = Runtime_key.[ v port ] in
-  impl ~connect ~packages ~runtime_keys "Paf_mirage.Make"
+  let runtime_args = Runtime_arg.[ v port ] in
+  impl ~connect ~packages ~runtime_args "Paf_mirage.Make"
     (tcpv4v6 @-> http_server)
 
 type alpn_client = ALPN_client

--- a/lib/mirage/impl/mirage_impl_http.mli
+++ b/lib/mirage/impl/mirage_impl_http.mli
@@ -21,7 +21,7 @@ type http_server
 val http_server : http_server typ
 
 val paf_server :
-  int runtime_key -> (Mirage_impl_tcp.tcpv4v6 -> http_server) impl
+  int runtime_arg -> (Mirage_impl_tcp.tcpv4v6 -> http_server) impl
 
 type alpn_client
 

--- a/lib/mirage/impl/mirage_impl_ip.mli
+++ b/lib/mirage/impl/mirage_impl_ip.mli
@@ -32,7 +32,7 @@ type ipv6_config = {
 val create_ipv4 :
   ?group:string ->
   ?config:ipv4_config ->
-  ?no_init:bool runtime_key ->
+  ?no_init:bool runtime_arg ->
   ?random:random impl ->
   ?clock:mclock impl ->
   ethernet impl ->
@@ -45,7 +45,7 @@ val create_ipv6 :
   ?clock:mclock impl ->
   ?group:string ->
   ?config:ipv6_config ->
-  ?no_init:bool runtime_key ->
+  ?no_init:bool runtime_arg ->
   network impl ->
   ethernet impl ->
   ipv6 impl
@@ -70,8 +70,8 @@ val ipv4_qubes :
 val create_ipv4v6 : ?group:string -> ipv4 impl -> ipv6 impl -> ipv4v6 impl
 
 val keyed_ipv4v6 :
-  ipv4_only:bool runtime_key ->
-  ipv6_only:bool runtime_key ->
+  ipv4_only:bool runtime_arg ->
+  ipv6_only:bool runtime_arg ->
   ipv4 impl ->
   ipv6 impl ->
   ipv4v6 impl

--- a/lib/mirage/impl/mirage_impl_misc.ml
+++ b/lib/mirage/impl/mirage_impl_misc.ml
@@ -6,7 +6,7 @@ let connect_err name number =
   Fmt.str "The %s connect expects exactly %d argument%s" name number
     (if number = 1 then "" else "s")
 
-let pp_key fmt k = Runtime_key.call fmt k
+let pp_key fmt k = Runtime_arg.call fmt k
 
 let terminal () =
   let dumb = try Sys.getenv "TERM" = "dumb" with Not_found -> true in

--- a/lib/mirage/impl/mirage_impl_misc.mli
+++ b/lib/mirage/impl/mirage_impl_misc.mli
@@ -2,5 +2,5 @@ open Functoria
 
 val get_target : Info.t -> Mirage_key.mode
 val connect_err : string -> int -> string
-val pp_key : Format.formatter -> 'a Mirage_runtime_key.key -> unit
+val pp_key : Format.formatter -> 'a Mirage_runtime_arg.arg -> unit
 val terminal : unit -> bool

--- a/lib/mirage/impl/mirage_impl_network.ml
+++ b/lib/mirage/impl/mirage_impl_network.ml
@@ -1,6 +1,6 @@
 open Functoria
 module Key = Mirage_key
-module Runtime_key = Mirage_runtime_key
+module Runtime_arg = Mirage_runtime_arg
 
 type network = NETWORK
 
@@ -8,8 +8,8 @@ let network = Type.v NETWORK
 let all_networks = ref []
 let add_new_network name = all_networks := name :: !all_networks
 
-let network_conf ?(intf : string runtime_key option) name =
-  let runtime_keys = Option.to_list (Option.map Runtime_key.v intf) in
+let network_conf ?(intf : string runtime_arg option) name =
+  let runtime_args = Option.to_list (Option.map Runtime_arg.v intf) in
   let packages_v =
     Key.match_ Key.(value target) @@ function
     | `Unix -> [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-net-unix" ]
@@ -26,7 +26,7 @@ let network_conf ?(intf : string runtime_key option) name =
   let connect _ modname _ =
     let name =
       Option.value ~default:(Printf.sprintf "%S" name)
-        (Option.map (Fmt.to_to_string Runtime_key.call) intf)
+        (Option.map (Fmt.to_to_string Runtime_arg.call) intf)
     in
     Fmt.str "%s.connect %s" modname name
   in
@@ -34,11 +34,11 @@ let network_conf ?(intf : string runtime_key option) name =
     add_new_network name;
     Action.ok ()
   in
-  impl ~runtime_keys ~packages_v ~connect ~configure "Netif" network
+  impl ~runtime_args ~packages_v ~connect ~configure "Netif" network
 
 let netif ?group dev =
   if_impl Key.is_solo5 (network_conf dev)
-    (network_conf ~intf:(Runtime_key.interface ?group dev) dev)
+    (network_conf ~intf:(Runtime_arg.interface ?group dev) dev)
 
 let default_network =
   match_impl

--- a/lib/mirage/impl/mirage_impl_reporter.ml
+++ b/lib/mirage/impl/mirage_impl_reporter.ml
@@ -1,6 +1,6 @@
 open Functoria
 module Key = Mirage_key
-module Runtime_key = Mirage_runtime_key
+module Runtime_arg = Mirage_runtime_arg
 open Mirage_impl_pclock
 open Mirage_impl_misc
 
@@ -17,9 +17,9 @@ let pp_level ppf = function
   | None -> Fmt.string ppf "None"
 
 let mirage_log ~default () =
-  let logs = Runtime_key.logs in
+  let logs = Runtime_arg.logs in
   let packages = [ package ~min:"2.0.0" ~max:"3.0.0" "mirage-logs" ] in
-  let runtime_keys = [ Runtime_key.v logs ] in
+  let runtime_args = [ Runtime_arg.v logs ] in
   let connect _ modname = function
     | [ _pclock ] ->
         Fmt.str
@@ -28,7 +28,7 @@ let mirage_log ~default () =
           modname pp_level default pp_key logs
     | _ -> failwith (connect_err "log" 1)
   in
-  impl ~packages ~runtime_keys ~connect "Mirage_logs.Make" (pclock @-> reporter)
+  impl ~packages ~runtime_args ~connect "Mirage_logs.Make" (pclock @-> reporter)
 
 let default_reporter ?(clock = default_posix_clock) ?(level = Some Logs.Info) ()
     =

--- a/lib/mirage/impl/mirage_impl_resolver.ml
+++ b/lib/mirage/impl/mirage_impl_resolver.ml
@@ -6,7 +6,7 @@ open Mirage_impl_stack
 open Mirage_impl_random
 open Mirage_impl_time
 module Key = Mirage_key
-module Runtime_key = Mirage_runtime_key
+module Runtime_arg = Mirage_runtime_arg
 
 type resolver = Resolver
 
@@ -31,7 +31,7 @@ let resolver_unix_system =
 
 let resolver_dns_conf ~ns =
   let packages = [ Mirage_impl_conduit.pkg ] in
-  let runtime_keys = Runtime_key.[ v ns ] in
+  let runtime_args = Runtime_arg.[ v ns ] in
   let connect _ modname = function
     | [ _r; _t; _m; _p; stack ] ->
         Fmt.str
@@ -42,10 +42,10 @@ let resolver_dns_conf ~ns =
           pp_key ns modname stack
     | _ -> failwith (connect_err "resolver" 3)
   in
-  impl ~packages ~runtime_keys ~connect "Resolver_mirage.Make"
+  impl ~packages ~runtime_args ~connect "Resolver_mirage.Make"
     (random @-> time @-> mclock @-> pclock @-> stackv4v6 @-> resolver)
 
 let resolver_dns ?ns ?(time = default_time) ?(mclock = default_monotonic_clock)
     ?(pclock = default_posix_clock) ?(random = default_random) stack =
-  let ns = Runtime_key.resolver ?default:ns () in
+  let ns = Runtime_arg.resolver ?default:ns () in
   resolver_dns_conf ~ns $ random $ time $ mclock $ pclock $ stack

--- a/lib/mirage/impl/mirage_impl_stack.ml
+++ b/lib/mirage/impl/mirage_impl_stack.ml
@@ -11,7 +11,7 @@ open Mirage_impl_tcp
 open Mirage_impl_time
 open Mirage_impl_udp
 module Key = Mirage_key
-module Runtime_key = Mirage_runtime_key
+module Runtime_arg = Mirage_runtime_arg
 
 let dhcp_ipv4 ?random ?clock ?time tap e a =
   ipv4_of_dhcp ?random ?clock ?time tap e a
@@ -65,8 +65,8 @@ let direct_stackv4v6 ?(mclock = default_monotonic_clock)
 
 let static_ipv4v6_stack ?group ?ipv6_config ?ipv4_config ?(arp = arp ?time:None)
     ?tcp tap =
-  let ipv4_only = Runtime_key.ipv4_only ?group ()
-  and ipv6_only = Runtime_key.ipv6_only ?group () in
+  let ipv4_only = Runtime_arg.ipv4_only ?group ()
+  and ipv6_only = Runtime_arg.ipv6_only ?group () in
   let e = etif tap in
   let a = arp e in
   let i4 = create_ipv4 ?group ?config:ipv4_config ~no_init:ipv6_only e a in
@@ -75,8 +75,8 @@ let static_ipv4v6_stack ?group ?ipv6_config ?ipv4_config ?(arp = arp ?time:None)
 
 let generic_ipv4v6_stack p ?group ?ipv6_config ?ipv4_config
     ?(arp = arp ?time:None) ?tcp tap =
-  let ipv4_only = Runtime_key.ipv4_only ?group ()
-  and ipv6_only = Runtime_key.ipv6_only ?group () in
+  let ipv4_only = Runtime_arg.ipv4_only ?group ()
+  and ipv6_only = Runtime_arg.ipv6_only ?group () in
   let e = etif tap in
   let a = arp e in
   let i4 =
@@ -88,10 +88,10 @@ let generic_ipv4v6_stack p ?group ?ipv6_config ?ipv4_config
   direct_stackv4v6 ~ipv4_only ~ipv6_only ?tcp tap e a i4 i6
 
 let socket_stackv4v6 ?(group = "") () =
-  let v4key = Runtime_key.V4.network ~group Ipaddr.V4.Prefix.global in
-  let v6key = Runtime_key.V6.network ~group None in
-  let ipv4_only = Runtime_key.ipv4_only ~group () in
-  let ipv6_only = Runtime_key.ipv6_only ~group () in
+  let v4key = Runtime_arg.V4.network ~group Ipaddr.V4.Prefix.global in
+  let v6key = Runtime_arg.V6.network ~group None in
+  let ipv4_only = Runtime_arg.ipv4_only ~group () in
+  let ipv6_only = Runtime_arg.ipv6_only ~group () in
   let packages_v = right_tcpip_library ~sublibs:[ "stack-socket" ] "tcpip" in
   let extra_deps =
     [

--- a/lib/mirage/impl/mirage_impl_stack.mli
+++ b/lib/mirage/impl/mirage_impl_stack.mli
@@ -9,8 +9,8 @@ val direct_stackv4v6 :
   ?random:Mirage_impl_random.random impl ->
   ?time:Mirage_impl_time.time impl ->
   ?tcp:Mirage_impl_tcp.tcpv4v6 impl ->
-  ipv4_only:bool runtime_key ->
-  ipv6_only:bool runtime_key ->
+  ipv4_only:bool runtime_arg ->
+  ipv6_only:bool runtime_arg ->
   Mirage_impl_network.network impl ->
   Mirage_impl_ethernet.ethernet impl ->
   Mirage_impl_arpv4.arpv4 impl ->

--- a/lib/mirage/impl/mirage_impl_syslog.ml
+++ b/lib/mirage/impl/mirage_impl_syslog.ml
@@ -3,7 +3,7 @@ open Mirage_impl_misc
 open Mirage_impl_pclock
 open Mirage_impl_stack
 module Key = Mirage_key
-module Runtime_key = Mirage_runtime_key
+module Runtime_arg = Mirage_runtime_arg
 
 type syslog_config = {
   hostname : string;
@@ -31,11 +31,11 @@ let opt_string = opt (fun pp v -> Format.fprintf pp "%S" v)
 let pkg sublibs = [ package ~min:"0.4.0" ~max:"0.5.0" ~sublibs "logs-syslog" ]
 
 let syslog_udp_conf config =
-  let endpoint = Runtime_key.syslog config.server in
-  let port = Runtime_key.syslog_port config.port in
-  let hostname = Runtime_key.syslog_hostname config.hostname in
+  let endpoint = Runtime_arg.syslog config.server in
+  let port = Runtime_arg.syslog_port config.port in
+  let hostname = Runtime_arg.syslog_hostname config.hostname in
   let packages = pkg [ "mirage" ] in
-  let runtime_keys = Runtime_key.[ v endpoint; v hostname; v port ] in
+  let runtime_args = Runtime_arg.[ v endpoint; v hostname; v port ] in
   let connect _i modname = function
     | [ pclock; stack ] ->
         Fmt.str
@@ -47,7 +47,7 @@ let syslog_udp_conf config =
           (opt_int "truncate") config.truncate
     | _ -> failwith (connect_err "syslog udp" 2)
   in
-  impl ~packages ~runtime_keys ~connect "Logs_syslog_mirage.Udp"
+  impl ~packages ~runtime_args ~connect "Logs_syslog_mirage.Udp"
     (pclock @-> stackv4v6 @-> syslog)
 
 let syslog_udp ?(config = default_syslog_config) ?(clock = default_posix_clock)
@@ -55,11 +55,11 @@ let syslog_udp ?(config = default_syslog_config) ?(clock = default_posix_clock)
   syslog_udp_conf config $ clock $ stack
 
 let syslog_tcp_conf config =
-  let endpoint = Runtime_key.syslog config.server in
-  let port = Runtime_key.syslog_port config.port in
-  let hostname = Runtime_key.syslog_hostname config.hostname in
+  let endpoint = Runtime_arg.syslog config.server in
+  let port = Runtime_arg.syslog_port config.port in
+  let hostname = Runtime_arg.syslog_hostname config.hostname in
   let packages = pkg [ "mirage" ] in
-  let runtime_keys = Runtime_key.[ v endpoint; v hostname; v port ] in
+  let runtime_args = Runtime_arg.[ v endpoint; v hostname; v port ] in
   let connect _i modname = function
     | [ pclock; stack ] ->
         Fmt.str
@@ -71,7 +71,7 @@ let syslog_tcp_conf config =
           (opt_int "truncate") config.truncate
     | _ -> failwith (connect_err "syslog tcp" 2)
   in
-  impl ~packages ~runtime_keys ~connect "Logs_syslog_mirage.Tcp"
+  impl ~packages ~runtime_args ~connect "Logs_syslog_mirage.Tcp"
     (pclock @-> stackv4v6 @-> syslog)
 
 let syslog_tcp ?(config = default_syslog_config) ?(clock = default_posix_clock)
@@ -79,11 +79,11 @@ let syslog_tcp ?(config = default_syslog_config) ?(clock = default_posix_clock)
   syslog_tcp_conf config $ clock $ stack
 
 let syslog_tls_conf ?keyname config =
-  let endpoint = Runtime_key.syslog config.server in
-  let port = Runtime_key.syslog_port config.port in
-  let hostname = Runtime_key.syslog_hostname config.hostname in
+  let endpoint = Runtime_arg.syslog config.server in
+  let port = Runtime_arg.syslog_port config.port in
+  let hostname = Runtime_arg.syslog_hostname config.hostname in
   let packages = pkg [ "mirage"; "mirage.tls" ] in
-  let runtime_keys = Runtime_key.[ v endpoint; v hostname; v port ] in
+  let runtime_args = Runtime_arg.[ v endpoint; v hostname; v port ] in
   let connect _i modname = function
     | [ pclock; stack; kv ] ->
         Fmt.str
@@ -95,7 +95,7 @@ let syslog_tls_conf ?keyname config =
           (opt_int "truncate") config.truncate (opt_string "keyname") keyname
     | _ -> failwith (connect_err "syslog tls" 3)
   in
-  impl ~packages ~runtime_keys ~connect "Logs_syslog_mirage_tls.Tls"
+  impl ~packages ~runtime_args ~connect "Logs_syslog_mirage_tls.Tls"
     (pclock @-> stackv4v6 @-> Mirage_impl_kv.ro @-> syslog)
 
 let syslog_tls ?(config = default_syslog_config) ?keyname

--- a/lib/mirage/impl/mirage_impl_tcp.ml
+++ b/lib/mirage/impl/mirage_impl_tcp.ml
@@ -5,7 +5,7 @@ open Mirage_impl_misc
 open Mirage_impl_random
 open Mirage_impl_time
 module Key = Mirage_key
-module Runtime_key = Mirage_runtime_key
+module Runtime_arg = Mirage_runtime_arg
 
 type 'a tcp = TCP
 type tcpv4v6 = v4v6 tcp
@@ -28,8 +28,8 @@ let direct_tcp ?(mclock = default_monotonic_clock) ?(time = default_time)
   tcp_direct_func () $ ip $ time $ mclock $ random
 
 let tcpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
-  let v = Runtime_key.v in
-  let runtime_keys = [ v ipv4_only; v ipv6_only; v ipv4_key; v ipv6_key ] in
+  let v = Runtime_arg.v in
+  let runtime_args = [ v ipv4_only; v ipv6_only; v ipv4_key; v ipv6_key ] in
   let packages_v = right_tcpip_library ~sublibs:[ "tcpv4v6-socket" ] "tcpip" in
   let configure i =
     match get_target i with
@@ -40,7 +40,7 @@ let tcpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
     Fmt.str "%s.connect ~ipv4_only:%a ~ipv6_only:%a %a %a" modname pp_key
       ipv4_only pp_key ipv6_only pp_key ipv4_key pp_key ipv6_key
   in
-  impl ~packages_v ~configure ~runtime_keys ~connect "Tcpv4v6_socket" tcpv4v6
+  impl ~packages_v ~configure ~runtime_args ~connect "Tcpv4v6_socket" tcpv4v6
 
 let socket_tcpv4v6 ?group ipv4 ipv6 =
   let ipv4 =
@@ -51,8 +51,8 @@ let socket_tcpv4v6 ?group ipv4 ipv6 =
     match ipv6 with
     | None -> None
     | Some ip -> Some (Ipaddr.V6.Prefix.make 128 ip)
-  and ipv4_only = Runtime_key.ipv4_only ?group ()
-  and ipv6_only = Runtime_key.ipv6_only ?group () in
+  and ipv4_only = Runtime_arg.ipv4_only ?group ()
+  and ipv6_only = Runtime_arg.ipv6_only ?group () in
   tcpv4v6_socket_conf ~ipv4_only ~ipv6_only
-    (Runtime_key.V4.network ?group ipv4)
-    (Runtime_key.V6.network ?group ipv6)
+    (Runtime_arg.V4.network ?group ipv4)
+    (Runtime_arg.V6.network ?group ipv6)

--- a/lib/mirage/impl/mirage_impl_tcp.mli
+++ b/lib/mirage/impl/mirage_impl_tcp.mli
@@ -19,8 +19,8 @@ val socket_tcpv4v6 :
   ?group:string -> Ipaddr.V4.t option -> Ipaddr.V6.t option -> tcpv4v6 impl
 
 val tcpv4v6_socket_conf :
-  ipv4_only:bool runtime_key ->
-  ipv6_only:bool runtime_key ->
-  Ipaddr.V4.Prefix.t runtime_key ->
-  Ipaddr.V6.Prefix.t option runtime_key ->
+  ipv4_only:bool runtime_arg ->
+  ipv6_only:bool runtime_arg ->
+  Ipaddr.V4.Prefix.t runtime_arg ->
+  Ipaddr.V6.Prefix.t option runtime_arg ->
   tcpv4v6 impl

--- a/lib/mirage/impl/mirage_impl_udp.ml
+++ b/lib/mirage/impl/mirage_impl_udp.ml
@@ -3,7 +3,7 @@ open Mirage_impl_ip
 open Mirage_impl_misc
 open Mirage_impl_random
 module Key = Mirage_key
-module Runtime_key = Mirage_runtime_key
+module Runtime_arg = Mirage_runtime_arg
 
 type 'a udp = UDP
 type udpv4v6 = v4v6 udp
@@ -23,8 +23,8 @@ let udp_direct_func () =
 let direct_udp ?(random = default_random) ip = udp_direct_func () $ ip $ random
 
 let udpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
-  let v = Runtime_key.v in
-  let runtime_keys = [ v ipv4_only; v ipv6_only; v ipv4_key; v ipv6_key ] in
+  let v = Runtime_arg.v in
+  let runtime_args = [ v ipv4_only; v ipv6_only; v ipv4_key; v ipv6_key ] in
   let packages_v = right_tcpip_library ~sublibs:[ "udpv4v6-socket" ] "tcpip" in
   let configure i =
     match get_target i with
@@ -35,7 +35,7 @@ let udpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
     Fmt.str "%s.connect ~ipv4_only:%a ~ipv6_only:%a %a %a" modname pp_key
       ipv4_only pp_key ipv6_only pp_key ipv4_key pp_key ipv6_key
   in
-  impl ~runtime_keys ~packages_v ~configure ~connect "Udpv4v6_socket" udpv4v6
+  impl ~runtime_args ~packages_v ~configure ~connect "Udpv4v6_socket" udpv4v6
 
 let socket_udpv4v6 ?group ipv4 ipv6 =
   let ipv4 =
@@ -46,8 +46,8 @@ let socket_udpv4v6 ?group ipv4 ipv6 =
     match ipv6 with
     | None -> None
     | Some ip -> Some (Ipaddr.V6.Prefix.make 128 ip)
-  and ipv4_only = Runtime_key.ipv4_only ?group ()
-  and ipv6_only = Runtime_key.ipv6_only ?group () in
+  and ipv4_only = Runtime_arg.ipv4_only ?group ()
+  and ipv6_only = Runtime_arg.ipv6_only ?group () in
   udpv4v6_socket_conf ~ipv4_only ~ipv6_only
-    (Runtime_key.V4.network ?group ipv4)
-    (Runtime_key.V6.network ?group ipv6)
+    (Runtime_arg.V4.network ?group ipv4)
+    (Runtime_arg.V6.network ?group ipv6)

--- a/lib/mirage/impl/mirage_impl_udp.mli
+++ b/lib/mirage/impl/mirage_impl_udp.mli
@@ -17,8 +17,8 @@ val socket_udpv4v6 :
   ?group:string -> Ipaddr.V4.t option -> Ipaddr.V6.t option -> udpv4v6 impl
 
 val udpv4v6_socket_conf :
-  ipv4_only:bool runtime_key ->
-  ipv6_only:bool runtime_key ->
-  Ipaddr.V4.Prefix.t runtime_key ->
-  Ipaddr.V6.Prefix.t option runtime_key ->
+  ipv4_only:bool runtime_arg ->
+  ipv6_only:bool runtime_arg ->
+  Ipaddr.V4.Prefix.t runtime_arg ->
+  Ipaddr.V6.Prefix.t option runtime_arg ->
   udpv4v6 impl

--- a/lib/mirage/mirage.ml
+++ b/lib/mirage/mirage.ml
@@ -22,7 +22,7 @@ module Impl = Impl
 module Info = Info
 module Dune = Dune
 module Key = Mirage_key
-module Runtime_key = Mirage_runtime_key
+module Runtime_arg = Mirage_runtime_arg
 module Context = Context
 include Functoria.DSL
 
@@ -299,8 +299,8 @@ let git_http ?authenticator ?headers ?(pclock = default_posix_clock) tcpv4v6 ctx
 let delay = job
 
 let delay_startup =
-  let delay_key = Runtime_key.delay in
-  let runtime_keys = [ Runtime_key.v delay_key ] in
+  let delay_key = Runtime_arg.delay in
+  let runtime_args = [ Runtime_arg.v delay_key ] in
   let packages = [ package ~max:"1.0.0" "duration" ] in
   let connect i _ _ =
     let modname =
@@ -312,7 +312,7 @@ let delay_startup =
     Fmt.str "%s.sleep_ns (Duration.of_sec %a)" modname Mirage_impl_misc.pp_key
       delay_key
   in
-  impl ~packages ~runtime_keys ~connect "Mirage_runtime" delay
+  impl ~packages ~runtime_args ~connect "Mirage_runtime" delay
 
 (** Functoria devices *)
 
@@ -400,20 +400,20 @@ include Lib.Make (Project)
 module Tool = Tool.Make (Project)
 
 let backtrace =
-  let runtime_keys = Runtime_key.[ v backtrace ] in
+  let runtime_args = Runtime_arg.[ v backtrace ] in
   let connect _ _ _ =
     Fmt.str "return (Printexc.record_backtrace %a)" Mirage_impl_misc.pp_key
-      Runtime_key.backtrace
+      Runtime_arg.backtrace
   in
-  impl ~runtime_keys ~connect "Printexc" job
+  impl ~runtime_args ~connect "Printexc" job
 
 let randomize_hashtables =
-  let runtime_keys = Runtime_key.[ v randomize_hashtables ] in
+  let runtime_args = Runtime_arg.[ v randomize_hashtables ] in
   let connect _ _ _ =
     Fmt.str "return (if %a then Hashtbl.randomize ())" Mirage_impl_misc.pp_key
-      Runtime_key.randomize_hashtables
+      Runtime_arg.randomize_hashtables
   in
-  impl ~runtime_keys ~connect "Hashtbl" job
+  impl ~runtime_args ~connect "Hashtbl" job
 
 let gc_control =
   let pp_pol ~name =
@@ -432,8 +432,8 @@ let gc_control =
       ++ any " "
       ++ Mirage_impl_misc.pp_key)
   in
-  let runtime_keys =
-    Runtime_key.
+  let runtime_args =
+    Runtime_arg.
       [
         v allocation_policy;
         v minor_heap_size;
@@ -452,25 +452,25 @@ let gc_control =
       "return (@.@[<v 2>let open Gc in@ let ctrl = get () in@ set { ctrl with \
        %a;@ %a;@ %a;@ %a;@ %a;@ %a;@ %a;@ %a;@ %a;@ %a }@]@.)"
       (pp_pol ~name:"allocation_policy")
-      Runtime_key.allocation_policy
+      Runtime_arg.allocation_policy
       (pp_k ~name:"minor_heap_size")
-      Runtime_key.minor_heap_size
+      Runtime_arg.minor_heap_size
       (pp_k ~name:"major_heap_increment")
-      Runtime_key.major_heap_increment
+      Runtime_arg.major_heap_increment
       (pp_k ~name:"space_overhead")
-      Runtime_key.space_overhead
+      Runtime_arg.space_overhead
       (pp_k ~name:"max_overhead")
-      Runtime_key.max_space_overhead (pp_k ~name:"verbose")
-      Runtime_key.gc_verbosity (pp_k ~name:"window_size")
-      Runtime_key.gc_window_size
+      Runtime_arg.max_space_overhead (pp_k ~name:"verbose")
+      Runtime_arg.gc_verbosity (pp_k ~name:"window_size")
+      Runtime_arg.gc_window_size
       (pp_k ~name:"custom_major_ratio")
-      Runtime_key.custom_major_ratio
+      Runtime_arg.custom_major_ratio
       (pp_k ~name:"custom_minor_ratio")
-      Runtime_key.custom_minor_ratio
+      Runtime_arg.custom_minor_ratio
       (pp_k ~name:"custom_minor_max_size")
-      Runtime_key.custom_minor_max_size
+      Runtime_arg.custom_minor_max_size
   in
-  impl ~runtime_keys ~connect "Gc" job
+  impl ~runtime_args ~connect "Gc" job
 
 (** Custom registration *)
 

--- a/lib/mirage/mirage.mli
+++ b/lib/mirage/mirage.mli
@@ -128,8 +128,8 @@ module Key : module type of struct
 end
 
 (** Configuration keys. *)
-module Runtime_key : module type of struct
-  include Mirage_runtime_key
+module Runtime_arg : module type of struct
+  include Mirage_runtime_arg
   (** @inline *)
 end
 
@@ -265,7 +265,7 @@ val docteur :
   ?mode:[ `Fast | `Light ] ->
   ?name:string key ->
   ?output:string key ->
-  ?analyze:bool runtime_key ->
+  ?analyze:bool runtime_arg ->
   ?branch:string ->
   ?extra_deps:string list ->
   string ->
@@ -336,7 +336,7 @@ val kv_rw_mem : ?clock:pclock impl -> unit -> kv_rw impl
 (** An in-memory key-value store using [mirage-kv-mem]. *)
 
 val chamelon :
-  program_block_size:int runtime_key ->
+  program_block_size:int runtime_arg ->
   ?pclock:pclock impl ->
   block impl ->
   kv_rw impl
@@ -373,7 +373,7 @@ val tar_kv_rw : ?pclock:pclock impl -> block impl -> kv_rw impl
     works on what is allocated, and there are restrictions on [rename]. *)
 
 val ccm_block :
-  ?nonce_len:int -> string option runtime_key -> block impl -> block impl
+  ?nonce_len:int -> string option runtime_arg -> block impl -> block impl
 (** [ccm_block key block] returns a new block which is a AES-CCM encrypted disk.
 
     {b Note} also that the available size of an encrypted block is always
@@ -492,7 +492,7 @@ type ipv6_config = {
 val create_ipv4 :
   ?group:string ->
   ?config:ipv4_config ->
-  ?no_init:bool runtime_key ->
+  ?no_init:bool runtime_arg ->
   ?random:random impl ->
   ?clock:mclock impl ->
   ethernet impl ->
@@ -518,7 +518,7 @@ val create_ipv6 :
   ?clock:mclock impl ->
   ?group:string ->
   ?config:ipv6_config ->
-  ?no_init:bool runtime_key ->
+  ?no_init:bool runtime_arg ->
   network impl ->
   ethernet impl ->
   ipv6 impl
@@ -574,8 +574,8 @@ val direct_stackv4v6 :
   ?random:random impl ->
   ?time:time impl ->
   ?tcp:tcpv4v6 impl ->
-  ipv4_only:bool runtime_key ->
-  ipv6_only:bool runtime_key ->
+  ipv4_only:bool runtime_arg ->
+  ipv6_only:bool runtime_arg ->
   network impl ->
   ethernet impl ->
   arpv4 impl ->
@@ -652,8 +652,8 @@ type dns_client
 val dns_client : dns_client typ
 
 val generic_dns_client :
-  ?timeout:int64 option runtime_key ->
-  ?nameservers:string list runtime_key ->
+  ?timeout:int64 option runtime_arg ->
+  ?nameservers:string list runtime_arg ->
   ?random:random impl ->
   ?time:time impl ->
   ?mclock:mclock impl ->
@@ -691,12 +691,12 @@ type happy_eyeballs
 val happy_eyeballs : happy_eyeballs typ
 
 val generic_happy_eyeballs :
-  ?aaaa_timeout:int64 option runtime_key ->
-  ?connect_delay:int64 option runtime_key ->
-  ?connect_timeout:int64 option runtime_key ->
-  ?resolve_timeout:int64 option runtime_key ->
-  ?resolve_retries:int64 option runtime_key ->
-  ?timer_interval:int64 option runtime_key ->
+  ?aaaa_timeout:int64 option runtime_arg ->
+  ?connect_delay:int64 option runtime_arg ->
+  ?connect_timeout:int64 option runtime_arg ->
+  ?resolve_timeout:int64 option runtime_arg ->
+  ?resolve_retries:int64 option runtime_arg ->
+  ?timer_interval:int64 option runtime_arg ->
   ?time:time impl ->
   ?mclock:mclock impl ->
   stackv4v6 impl ->
@@ -822,7 +822,7 @@ type http_server
 
 val http_server : http_server typ
 
-val paf_server : port:int runtime_key -> tcpv4v6 impl -> http_server impl
+val paf_server : port:int runtime_arg -> tcpv4v6 impl -> http_server impl
 (** [paf_server ~port tcpv4v6] creates an instance which will start to
     {i listen} on the given [port]. With this instance and the produced module
     [HTTP_server], the user can initiate:
@@ -985,9 +985,9 @@ val git_tcp : tcpv4v6 impl -> mimic impl -> git_client impl
     using TCP/IP. *)
 
 val git_ssh :
-  ?authenticator:string option runtime_key ->
-  key:string option runtime_key ->
-  password:string option runtime_key ->
+  ?authenticator:string option runtime_arg ->
+  key:string option runtime_arg ->
+  password:string option runtime_arg ->
   ?mclock:mclock impl ->
   ?time:time impl ->
   tcpv4v6 impl ->
@@ -1011,8 +1011,8 @@ val git_ssh :
     ]} *)
 
 val git_http :
-  ?authenticator:string option runtime_key ->
-  ?headers:(string * string) list runtime_key ->
+  ?authenticator:string option runtime_arg ->
+  ?headers:(string * string) list runtime_arg ->
   ?pclock:pclock impl ->
   tcpv4v6 impl ->
   mimic impl ->

--- a/lib/mirage/mirage_runtime_arg.ml
+++ b/lib/mirage/mirage_runtime_arg.ml
@@ -15,39 +15,39 @@
  *)
 
 open Functoria
-include Runtime_key
+include Runtime_arg
 
 (** {2 OCaml runtime} *)
 
-let runtime_key name =
-  Runtime_key.create ~name
+let runtime_arg name =
+  Runtime_arg.create ~name
     ~packages:[ package "mirage-runtime" ]
     (Fmt.str "Mirage_runtime.%s" name)
 
-let runtime_keyf ~name fmt =
+let runtime_argf ~name fmt =
   Fmt.kstr
-    (Runtime_key.create ~name ~packages:[ package "mirage-runtime" ])
+    (Runtime_arg.create ~name ~packages:[ package "mirage-runtime" ])
     ("Mirage_runtime." ^^ fmt)
 
 let runtime_network_key ~name fmt =
   Fmt.kstr
-    (Runtime_key.create ~name
+    (Runtime_arg.create ~name
        ~packages:[ package "mirage-runtime" ~sublibs:[ "network" ] ])
     ("(Mirage_runtime_network." ^^ fmt ^^ ")")
 
-let delay = runtime_key "delay"
-let backtrace = runtime_key "backtrace"
-let randomize_hashtables = runtime_key "randomize_hashtables"
-let allocation_policy = runtime_key "allocation_policy"
-let minor_heap_size = runtime_key "minor_heap_size"
-let major_heap_increment = runtime_key "major_heap_increment"
-let space_overhead = runtime_key "space_overhead"
-let max_space_overhead = runtime_key "max_space_overhead"
-let gc_verbosity = runtime_key "gc_verbosity"
-let gc_window_size = runtime_key "gc_window_size"
-let custom_major_ratio = runtime_key "custom_major_ratio"
-let custom_minor_ratio = runtime_key "custom_minor_ratio"
-let custom_minor_max_size = runtime_key "custom_minor_max_size"
+let delay = runtime_arg "delay"
+let backtrace = runtime_arg "backtrace"
+let randomize_hashtables = runtime_arg "randomize_hashtables"
+let allocation_policy = runtime_arg "allocation_policy"
+let minor_heap_size = runtime_arg "minor_heap_size"
+let major_heap_increment = runtime_arg "major_heap_increment"
+let space_overhead = runtime_arg "space_overhead"
+let max_space_overhead = runtime_arg "max_space_overhead"
+let gc_verbosity = runtime_arg "gc_verbosity"
+let gc_window_size = runtime_arg "gc_window_size"
+let custom_major_ratio = runtime_arg "custom_major_ratio"
+let custom_minor_ratio = runtime_arg "custom_minor_ratio"
+let custom_minor_max_size = runtime_arg "custom_minor_max_size"
 
 let pp_group ppf = function
   | None | Some "" -> ()
@@ -128,12 +128,12 @@ let resolver ?(default = []) () =
 let pp_ipaddr ppf p = Fmt.pf ppf "Ipaddr.of_string %a" (escape Ipaddr.pp) p
 
 let syslog default =
-  runtime_keyf ~name:"syslog" "syslog %a" (pp_option pp_ipaddr) default
+  runtime_argf ~name:"syslog" "syslog %a" (pp_option pp_ipaddr) default
 
 let syslog_port default =
-  runtime_keyf ~name:"syslog_port" "syslog_port %a" (pp_option Fmt.int) default
+  runtime_argf ~name:"syslog_port" "syslog_port %a" (pp_option Fmt.int) default
 
 let syslog_hostname default =
-  runtime_keyf ~name:"syslog_hostname" "syslog_hostname %S" default
+  runtime_argf ~name:"syslog_hostname" "syslog_hostname %S" default
 
-let logs = runtime_key "logs"
+let logs = runtime_arg "logs"

--- a/lib/mirage/mirage_runtime_arg.mli
+++ b/lib/mirage/mirage_runtime_arg.mli
@@ -17,18 +17,18 @@
 (** Runtime key for the Mirage tool. *)
 
 open Functoria
-include RUNTIME_KEY
+include RUNTIME_ARG
 
 (** {2 OCaml runtime keys}
 
     The OCaml runtime is usually configurable via the [OCAMLRUNPARAM]
     environment variable. We provide boot parameters covering these options. *)
 
-val backtrace : bool runtime_key
+val backtrace : bool runtime_arg
 (** [--backtrace]: Output a backtrace if an uncaught exception terminated the
     unikernel. *)
 
-val randomize_hashtables : bool runtime_key
+val randomize_hashtables : bool runtime_arg
 (** [--randomize-hashtables]: Randomize all hash tables. *)
 
 (** {3 GC control}
@@ -39,30 +39,30 @@ val randomize_hashtables : bool runtime_key
 
     The following keys allow boot time configuration. *)
 
-val allocation_policy : [ `Next_fit | `First_fit | `Best_fit ] runtime_key
-val minor_heap_size : int option runtime_key
-val major_heap_increment : int option runtime_key
-val space_overhead : int option runtime_key
-val max_space_overhead : int option runtime_key
-val gc_verbosity : int option runtime_key
-val gc_window_size : int option runtime_key
-val custom_major_ratio : int option runtime_key
-val custom_minor_ratio : int option runtime_key
-val custom_minor_max_size : int option runtime_key
+val allocation_policy : [ `Next_fit | `First_fit | `Best_fit ] runtime_arg
+val minor_heap_size : int option runtime_arg
+val major_heap_increment : int option runtime_arg
+val space_overhead : int option runtime_arg
+val max_space_overhead : int option runtime_arg
+val gc_verbosity : int option runtime_arg
+val gc_window_size : int option runtime_arg
+val custom_major_ratio : int option runtime_arg
+val custom_minor_ratio : int option runtime_arg
+val custom_minor_max_size : int option runtime_arg
 
 (** {3 Network keys} *)
 
-val interface : ?group:string -> string -> string runtime_key
+val interface : ?group:string -> string -> string runtime_arg
 (** A network interface. *)
 
 (** Ipv4 keys. *)
 module V4 : sig
   open Ipaddr.V4
 
-  val network : ?group:string -> Prefix.t -> Prefix.t runtime_key
+  val network : ?group:string -> Prefix.t -> Prefix.t runtime_arg
   (** A network defined by an address and netmask. *)
 
-  val gateway : ?group:string -> t option -> t option runtime_key
+  val gateway : ?group:string -> t option -> t option runtime_arg
   (** A default gateway option. *)
 end
 
@@ -70,41 +70,41 @@ end
 module V6 : sig
   open Ipaddr.V6
 
-  val network : ?group:string -> Prefix.t option -> Prefix.t option runtime_key
+  val network : ?group:string -> Prefix.t option -> Prefix.t option runtime_arg
   (** A network defined by an address and netmask. *)
 
-  val gateway : ?group:string -> t option -> t option runtime_key
+  val gateway : ?group:string -> t option -> t option runtime_arg
   (** A default gateway option. *)
 
-  val accept_router_advertisements : ?group:string -> unit -> bool runtime_key
+  val accept_router_advertisements : ?group:string -> unit -> bool runtime_arg
   (** An option whether to accept router advertisements. *)
 end
 
-val ipv4_only : ?group:string -> unit -> bool runtime_key
+val ipv4_only : ?group:string -> unit -> bool runtime_arg
 (** An option for dual stack to only use IPv4. *)
 
-val ipv6_only : ?group:string -> unit -> bool runtime_key
+val ipv6_only : ?group:string -> unit -> bool runtime_arg
 (** An option for dual stack to only use IPv6. *)
 
-val resolver : ?default:string list -> unit -> string list option runtime_key
+val resolver : ?default:string list -> unit -> string list option runtime_arg
 (** The address of the DNS resolver to use. See $REFERENCE for format. *)
 
-val syslog : Ipaddr.t option -> Ipaddr.t option runtime_key
+val syslog : Ipaddr.t option -> Ipaddr.t option runtime_arg
 (** The address to send syslog frames to. *)
 
-val syslog_port : int option -> int option runtime_key
+val syslog_port : int option -> int option runtime_arg
 (** The port to send syslog frames to. *)
 
-val syslog_hostname : string -> string runtime_key
+val syslog_hostname : string -> string runtime_arg
 (** The hostname to use in syslog frames. *)
 
 (** {3 Logs} *)
 
-val logs : Mirage_runtime.log_threshold list runtime_key
+val logs : Mirage_runtime.log_threshold list runtime_arg
 
 (** {3 Startup delay} *)
 
-val delay : int runtime_key
+val delay : int runtime_arg
 (** The initial delay, specified in seconds, before a unikernel starting up.
     Defaults to 0. Useful for tenders and environments that take some time to
     bring devices up. *)

--- a/lib_runtime/functoria/functoria_runtime.ml
+++ b/lib_runtime/functoria/functoria_runtime.ml
@@ -14,10 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let runtime_keys_r = ref []
-let runtime_keys () = !runtime_keys_r
+let runtime_args_r = ref []
+let runtime_args () = !runtime_args_r
 
-module Key = struct
+module Arg = struct
   type 'a t = { arg : 'a Cmdliner.Term.t; mutable value : 'a option }
 
   let create arg = { arg; value = None }
@@ -26,8 +26,8 @@ module Key = struct
     match t.value with
     | None ->
         invalid_arg
-          "Key.get: Called too early. Please delay this call after cmdliner's \
-           evaluation."
+          "Functoria_runtime.Arg.get: Called too early. Please delay this call \
+           after cmdliner's evaluation."
     | Some v -> v
 
   let term (type a) (t : a t) =
@@ -39,10 +39,10 @@ module Key = struct
     Cmdliner.Arg.conv (of_string, pp)
 end
 
-let key t =
-  let u = Key.create t in
-  runtime_keys_r := Key.term u :: !runtime_keys_r;
-  fun () -> Key.get u
+let register t =
+  let u = Arg.create t in
+  runtime_args_r := Arg.term u :: !runtime_args_r;
+  fun () -> Arg.get u
 
 let initialized = ref false
 let help_version = 63

--- a/lib_runtime/functoria/functoria_runtime.mli
+++ b/lib_runtime/functoria/functoria_runtime.mli
@@ -18,16 +18,17 @@
 
 (** Functoria runtime. *)
 
-(** [Key] defines values that can be set by runtime command-line arguments. This
-    module is the runtime companion of {!Key}. *)
-module Key : sig
-  (** {1 Runtime keys} *)
+(** [Arg] defines values that can be set by runtime command-line arguments. This
+    module is the runtime companion of {!Functoria.Runtime_argq}. *)
+module Arg : sig
+  (** {1 Command-line Arguments} *)
 
   type 'a t
-  (** The type for runtime keys containing a value of type ['a]. *)
+  (** The type for runtime keys parsing values of type ['a]. *)
 
   val create : 'a Cmdliner.Term.t -> 'a t
-  (** [create conv] create a new runtime key. *)
+  (** [create t] is the command-line argument built from the [Cmdliner] term
+      [t]. *)
 
   val conv :
     (string -> ('a, [ `Msg of string ]) result) ->
@@ -35,7 +36,7 @@ module Key : sig
     'a Cmdliner.Arg.conv
 end
 
-val key : 'a Cmdliner.Term.t -> unit -> 'a
+val register : 'a Cmdliner.Term.t -> unit -> 'a
 (** [key t] registers the Cmdliner term [k] as a runtime key and return a
     callback [f] that evaluates to [t]s' value passed on the command-line.
 
@@ -50,4 +51,4 @@ val with_argv : unit Cmdliner.Term.t list -> string -> string array -> unit
     application calls [exit(3)] with status [64]. If [`Help] or [`Version] were
     evaluated, [exit(3)] is called with status [63]. *)
 
-val runtime_keys : unit -> unit Cmdliner.Term.t list
+val runtime_args : unit -> unit Cmdliner.Term.t list

--- a/lib_runtime/mirage/mirage_runtime.ml
+++ b/lib_runtime/mirage/mirage_runtime.ml
@@ -15,7 +15,6 @@
  *)
 
 open Cmdliner
-include Functoria_runtime
 
 let ocaml_section = "OCAML RUNTIME PARAMETERS"
 let unikernel_section = "UNIKERNEL PARAMETERS"
@@ -250,3 +249,5 @@ let run_leave_iter_hooks () = run leave_iter_hooks
 let at_exit f = add f exit_hooks
 let at_leave_iter f = add f leave_iter_hooks
 let at_enter_iter f = add f enter_iter_hooks
+
+include Functoria_runtime

--- a/lib_runtime/mirage/mirage_runtime_network.ml
+++ b/lib_runtime/mirage/mirage_runtime_network.ml
@@ -8,7 +8,7 @@ let pp_group ppf = function
   | None -> pf ppf "the unikernel"
   | Some s -> pf ppf "the %s group" s
 
-let runtime_key ?(group = "") ~doc ~default c name =
+let runtime_arg ?(group = "") ~doc ~default c name =
   let prefix = if group = "" then group else group ^ "-" in
   let doc =
     Arg.info ~docs:unikernel_section
@@ -20,7 +20,7 @@ let runtime_key ?(group = "") ~doc ~default c name =
 
 let interface ?group default =
   let doc = str "The network interface listened by %a." pp_group group in
-  runtime_key ~doc ~default ?group Arg.string "interface"
+  runtime_arg ~doc ~default ?group Arg.string "interface"
 
 let conv of_string to_string : _ Cmdliner.Arg.conv =
   let pp ppf v = Format.pp_print_string ppf (to_string v) in
@@ -40,11 +40,11 @@ module V4 = struct
          192.168.0.1/16 ."
         pp_group group
     in
-    runtime_key ~doc ~default ?group ipv4 "ipv4"
+    runtime_arg ~doc ~default ?group ipv4 "ipv4"
 
   let gateway ?group default =
     let doc = str "The gateway of %a." pp_group group in
-    runtime_key ~doc ~default ?group Arg.(some ipv4_address) "ipv4-gateway"
+    runtime_arg ~doc ~default ?group Arg.(some ipv4_address) "ipv4-gateway"
 end
 
 module V6 = struct
@@ -53,38 +53,38 @@ module V6 = struct
       str "The network of %a specified as IPv6 address and prefix length."
         pp_group group
     in
-    runtime_key ~doc ~default ?group Arg.(some ipv6) "ipv6"
+    runtime_arg ~doc ~default ?group Arg.(some ipv6) "ipv6"
 
   let gateway ?group default =
     let doc = str "The gateway of %a." pp_group group in
-    runtime_key ~doc ~default ?group Arg.(some ipv6_address) "ipv6-gateway"
+    runtime_arg ~doc ~default ?group Arg.(some ipv6_address) "ipv6-gateway"
 
   let accept_router_advertisements ?group () =
     let doc = str "Accept router advertisements for %a." pp_group group in
-    runtime_key ~doc ?group ~default:true Arg.bool
+    runtime_arg ~doc ?group ~default:true Arg.bool
       "accept-router-advertisements"
 end
 
 let ipv4_only ?group () =
   let doc = str "Only use IPv4 for %a." pp_group group in
-  runtime_key ~doc ?group ~default:false Arg.bool "ipv4-only"
+  runtime_arg ~doc ?group ~default:false Arg.bool "ipv4-only"
 
 let ipv6_only ?group () =
   let doc = str "Only use IPv6 for %a." pp_group group in
-  runtime_key ~doc ?group ~default:false Arg.bool "ipv6-only"
+  runtime_arg ~doc ?group ~default:false Arg.bool "ipv6-only"
 
 let resolver ?default () =
   let doc = str "DNS resolver (default to anycast.censurfridns.dk)" in
-  runtime_key ~doc ~default Arg.(some (list string)) "resolver"
+  runtime_arg ~doc ~default Arg.(some (list string)) "resolver"
 
 let syslog default =
   let doc = str "syslog server" in
-  runtime_key ~doc ~default Arg.(some ip_address) "syslog"
+  runtime_arg ~doc ~default Arg.(some ip_address) "syslog"
 
 let syslog_port default =
   let doc = str "syslog server port" in
-  runtime_key ~doc ~default Arg.(some int) "syslog-port"
+  runtime_arg ~doc ~default Arg.(some int) "syslog-port"
 
 let syslog_hostname default =
   let doc = str "hostname to report to syslog" in
-  runtime_key ~doc ~default Arg.string "syslog-hostname"
+  runtime_arg ~doc ~default Arg.string "syslog-hostname"

--- a/test/functoria-test/functoria_test.ml
+++ b/test/functoria-test/functoria_test.ml
@@ -15,12 +15,13 @@ let run x = x
 let run ?(keys = []) ?init context device =
   let t = Impl.abstract device in
   let t = Impl.simplify ~full:false ~context t in
-  let all_keys, runtime_keys = Engine.all_keys t in
+  let all_keys = Engine.keys t in
+  let all_runtime_args = Engine.runtime_args t in
   let keys = keys @ Key.Set.elements all_keys in
-  let runtime_keys = Runtime_key.Set.elements runtime_keys in
+  let runtime_args = Runtime_arg.Set.elements all_runtime_args in
   let packages = Key.eval context (Engine.packages t) in
   let info =
-    Functoria.Info.v ~packages ~context ~keys ~runtime_keys
+    Functoria.Info.v ~packages ~context ~keys ~runtime_args
       ~build_cmd:"build me" ~src:`None "foo"
   in
   let t = Impl.eval ~context t in

--- a/test/functoria/e2e/app/app.ml
+++ b/test/functoria/e2e/app/app.ml
@@ -19,14 +19,14 @@ let required =
 let hello =
   let doc = Arg.info ~doc:"How to say hello." [ "hello" ] in
   let key = Arg.(value @@ opt string "Hello World!" doc) in
-  Functoria_runtime.key key
+  Functoria_runtime.register key
 
 let arg =
   let doc =
     Arg.info ~docs:"APPLICATION OPTIONS" ~doc:"A runtime argument." [ "arg" ]
   in
   let key = Arg.(value & opt string "-" doc) in
-  Functoria_runtime.key key
+  Functoria_runtime.register key
 
 module Make (_ : sig end) = struct
   let start () = Fmt.pr "Success: hello=%s arg=%s\n%!" (hello ()) (arg ())

--- a/test/functoria/e2e/app/config.ml
+++ b/test/functoria/e2e/app/config.ml
@@ -1,10 +1,10 @@
 open Functoria
 open E2e
 
-let opt : string runtime_key = Runtime_key.create "App.opt"
-let opt_all : string list runtime_key = Runtime_key.create "App.opt_all"
-let flag : bool runtime_key = Runtime_key.create "App.flag"
-let required : string runtime_key = Runtime_key.create "App.required"
+let opt : string runtime_arg = Runtime_arg.create "App.opt"
+let opt_all : string list runtime_arg = Runtime_arg.create "App.opt_all"
+let flag : bool runtime_arg = Runtime_arg.create "App.flag"
+let required : string runtime_arg = Runtime_arg.create "App.required"
 
 let keys =
   let connect _ _ _ =
@@ -16,11 +16,11 @@ let keys =
       and _ : string = %a
       in
       return ()|}
-      Runtime_key.call opt Runtime_key.call opt_all Runtime_key.call flag
-      Runtime_key.call required
+      Runtime_arg.call opt Runtime_arg.call opt_all Runtime_arg.call flag
+      Runtime_arg.call required
   in
-  let runtime_keys = Runtime_key.[ v opt; v opt_all; v flag; v required ] in
-  impl ~connect ~runtime_keys "Unit" job
+  let runtime_args = Runtime_arg.[ v opt; v opt_all; v flag; v required ] in
+  impl ~connect ~runtime_args "Unit" job
 
 let main = main "App.Make" (job @-> job)
 let () = register "noop" [ main $ keys ]

--- a/test/functoria/gen-1/main.ml.expected
+++ b/test/functoria/gen-1/main.ml.expected
@@ -13,7 +13,7 @@ let sys__1 = lazy (
 let key_gen__2 = lazy (
   let __sys__1 = Lazy.force sys__1 in
   __sys__1 >>= fun _sys__1 ->
-  return Functoria_runtime.(with_argv (runtime_keys ()) "foo" _sys__1)
+  return Functoria_runtime.(with_argv (runtime_args ()) "foo" _sys__1)
   )
 
 let app_make__3 = lazy (

--- a/test/functoria/gen-2/main.ml.expected
+++ b/test/functoria/gen-2/main.ml.expected
@@ -13,7 +13,7 @@ let sys__1 = lazy (
 let key_gen__2 = lazy (
   let __sys__1 = Lazy.force sys__1 in
   __sys__1 >>= fun _sys__1 ->
-  return Functoria_runtime.(with_argv (runtime_keys ()) "foo" _sys__1)
+  return Functoria_runtime.(with_argv (runtime_args ()) "foo" _sys__1)
   )
 
 let unit__3 = lazy (

--- a/test/mirage/action/test.ml
+++ b/test/mirage/action/test.ml
@@ -14,7 +14,7 @@ let print_banner s =
   print_newline ()
 
 let info context =
-  Info.v ~packages:[] ~keys:[] ~runtime_keys:[] ~build_cmd:"mirage build"
+  Info.v ~packages:[] ~keys:[] ~runtime_args:[] ~build_cmd:"mirage build"
     ~context ~src:`None "NAME"
 
 let test target =

--- a/test/mirage/info_gen/main.ml.expected
+++ b/test/mirage/info_gen/main.ml.expected
@@ -13,7 +13,7 @@ let bootvar__1 = lazy (
 let key_gen__2 = lazy (
   let __bootvar__1 = Lazy.force bootvar__1 in
   __bootvar__1 >>= fun _bootvar__1 ->
-  return Mirage_runtime.(with_argv (runtime_keys ()) "foo" _bootvar__1)
+  return Mirage_runtime.(with_argv (runtime_args ()) "foo" _bootvar__1)
   )
 
 let app_make__3 = lazy (

--- a/test/mirage/random-unix/key_gen.ml.expected
+++ b/test/mirage/random-unix/key_gen.ml.expected
@@ -1,31 +1,34 @@
-let key_flag = Functoria_runtime.key Key.flag
+let key_flag = Functoria_runtime.register Key.flag
 
-let key_opt = Functoria_runtime.key Key.opt
+let key_opt = Functoria_runtime.register Key.opt
 
-let key_opt_all = Functoria_runtime.key Key.opt_all
+let key_opt_all = Functoria_runtime.register Key.opt_all
 
-let key_required = Functoria_runtime.key Key.required
+let key_required = Functoria_runtime.register Key.required
 
 let accept_router_advertisements =
-  Functoria_runtime.key
+  Functoria_runtime.register
   (Mirage_runtime_network.V6.accept_router_advertisements ())
 
 let interface =
-  Functoria_runtime.key (Mirage_runtime_network.interface "tap0")
+  Functoria_runtime.register (Mirage_runtime_network.interface "tap0")
 
 let ipv4 =
-  Functoria_runtime.key
+  Functoria_runtime.register
   (Mirage_runtime_network.V4.network (Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24"))
 
 let ipv4_gateway =
-  Functoria_runtime.key (Mirage_runtime_network.V4.gateway None)
+  Functoria_runtime.register (Mirage_runtime_network.V4.gateway None)
 
-let ipv4_only = Functoria_runtime.key (Mirage_runtime_network.ipv4_only ())
+let ipv4_only =
+  Functoria_runtime.register (Mirage_runtime_network.ipv4_only ())
 
-let ipv6 = Functoria_runtime.key (Mirage_runtime_network.V6.network None)
+let ipv6 =
+  Functoria_runtime.register (Mirage_runtime_network.V6.network None)
 
 let ipv6_gateway =
-  Functoria_runtime.key (Mirage_runtime_network.V6.gateway None)
+  Functoria_runtime.register (Mirage_runtime_network.V6.gateway None)
 
-let ipv6_only = Functoria_runtime.key (Mirage_runtime_network.ipv6_only ())
+let ipv6_only =
+  Functoria_runtime.register (Mirage_runtime_network.ipv6_only ())
 

--- a/test/mirage/random-unix/main.ml.expected
+++ b/test/mirage/random-unix/main.ml.expected
@@ -207,7 +207,7 @@ let sys__17 = lazy (
 let key_gen__18 = lazy (
   let __sys__17 = Lazy.force sys__17 in
   __sys__17 >>= fun _sys__17 ->
-  return Functoria_runtime.(with_argv (runtime_keys ()) "foo" _sys__17)
+  return Functoria_runtime.(with_argv (runtime_args ()) "foo" _sys__17)
   )
 
 let functoria_runtime__19 = lazy (

--- a/test/mirage/random-unix/test.ml
+++ b/test/mirage/random-unix/test.ml
@@ -1,9 +1,9 @@
 open Mirage
 
-let opt = Runtime_key.create "Key.opt"
-let opt_all = Runtime_key.create "Key.opt_all"
-let flag = Runtime_key.create "Key.flag"
-let required = Runtime_key.create "Key.required"
+let opt = Runtime_arg.create "Key.opt"
+let opt_all = Runtime_arg.create "Key.opt_all"
+let flag = Runtime_arg.create "Key.flag"
+let required = Runtime_arg.create "Key.required"
 
 let test () =
   let context = Key.add_to_context Key.target `Unix Context.empty in
@@ -13,8 +13,8 @@ let test () =
   let arp = arp etif in
   let ipv4 = create_ipv4 etif arp in
   let ipv6 = create_ipv6 network etif in
-  let ipv4_only = Runtime_key.ipv4_only () in
-  let ipv6_only = Runtime_key.ipv6_only () in
+  let ipv4_only = Runtime_arg.ipv4_only () in
+  let ipv6_only = Runtime_arg.ipv6_only () in
   let stackv4v6 =
     direct_stackv4v6 ~ipv4_only ~ipv6_only network etif arp ipv4 ipv6
   in
@@ -26,7 +26,7 @@ let test () =
   let job =
     let connect _ _ _ = "return ()" in
     Functoria.impl
-      ~runtime_keys:Runtime_key.[ v opt; v opt_all; v flag; v required ]
+      ~runtime_args:Runtime_arg.[ v opt; v opt_all; v flag; v required ]
       ~extra_deps:[ dep job; dep init ]
       "Functoria_runtime" ~connect Functoria.job
   in

--- a/test/mirage/random-xen/test.ml
+++ b/test/mirage/random-xen/test.ml
@@ -9,8 +9,8 @@ let test () =
   let arp = arp etif in
   let ipv4 = create_ipv4 etif arp in
   let ipv6 = create_ipv6 network etif in
-  let ipv4_only = Runtime_key.ipv4_only () in
-  let ipv6_only = Runtime_key.ipv6_only () in
+  let ipv4_only = Runtime_arg.ipv4_only () in
+  let ipv6_only = Runtime_arg.ipv6_only () in
   let stackv4v6 =
     direct_stackv4v6 ~ipv4_only ~ipv6_only network etif arp ipv4 ipv6
   in


### PR DESCRIPTION
These are very different from the other configuration-time keys. They should have a different name.

Extracted from #1493 

To test with https://github.com/mirage/mirage-skeleton/pull/384