### PR TITLE
Add line locations to device connect functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,11 @@
        they are not available `key_gen.ml` anymore. As a consequence,
        `Key_gen.target` has been removed.
 
+- BREAKING: the `connect` functions passed to create devices (with `impl`)  now
+  take values of type `code` instead of `string`. Value of type `code` are
+  created using a new `code` function, that takes `~pos:__POS__` as parameter.
+  This is used to generate better locations in the generated code, leading to
+  better error messages (#1504, @samoht)
 - BUGFIX: fix `mirage describe` output (#1446 @samoht), add test (#1458 @samoht)
 - Remove ipaddr from runtime (#1437 @samoht, #1465 @hannesm)
 - BREAKING: Mirage.register (and Functoria.register) no longer have `?packages`

--- a/lib/functoria/DSL.ml
+++ b/lib/functoria/DSL.ml
@@ -29,7 +29,9 @@ type 'a device = ('a, Impl.abstract) Device.t
 type context = Context.t
 type job = Job.t
 type info = Info.t
+type 'a code = 'a Device.code
 
+let code = Device.code
 let package = Package.v
 let ( @-> ) = Type.( @-> )
 let typ = Type.v
@@ -46,8 +48,8 @@ let impl ?packages ?packages_v ?install ?install_v ?keys ?runtime_args
   @@ Device.v ?packages ?packages_v ?install ?install_v ?keys ?runtime_args
        ?extra_deps ?connect ?dune ?configure ?files module_name module_type
 
-let main ?packages ?packages_v ?extra_deps module_name ty =
-  let connect _ = Device.start in
+let main ?pos ?packages ?packages_v ?extra_deps module_name ty =
+  let connect _ = Device.start ?pos in
   impl ?packages ?packages_v ?extra_deps ~connect module_name ty
 
 let foreign ?packages ?packages_v ?deps module_name ty =

--- a/lib/functoria/DSL.mli
+++ b/lib/functoria/DSL.mli
@@ -137,6 +137,7 @@ val foreign :
 (** Alias for {!main}, where [?extra_deps] has been renamed to [?deps]. *)
 
 val main :
+  ?pos:string * int * int * int ->
   ?packages:package list ->
   ?packages_v:package list value ->
   ?extra_deps:abstract_impl list ->
@@ -154,6 +155,13 @@ val main :
 
 (** {1 Devices} *)
 
+type 'a code = 'a Device.code
+
+val code :
+  pos:string * int * int * int ->
+  ('a, Format.formatter, unit, 'b code) format4 ->
+  'a
+
 type 'a device = ('a, abstract_impl) Device.t
 
 val of_device : 'a device -> 'a impl
@@ -167,7 +175,7 @@ val impl :
   ?keys:Key.t list ->
   ?runtime_args:Runtime_arg.t list ->
   ?extra_deps:abstract_impl list ->
-  ?connect:(info -> string -> string list -> string) ->
+  ?connect:(info -> string -> string list -> 'a code) ->
   ?dune:(info -> Dune.stanza list) ->
   ?configure:(info -> unit Action.t) ->
   ?files:(info -> Fpath.t list) ->

--- a/lib/functoria/argv.ml
+++ b/lib/functoria/argv.ml
@@ -21,5 +21,5 @@ type t = ARGV
 let argv = Type.v ARGV
 
 let sys_argv =
-  let connect _ _ _ = "return Sys.argv" in
+  let connect _ _ _ = Device.code ~pos:__POS__ "return Sys.argv" in
   Impl.v ~connect "Sys" argv

--- a/lib/functoria/device.ml
+++ b/lib/functoria/device.ml
@@ -22,7 +22,10 @@ open Astring
 type package = Package.t
 type info = Info.t
 type 'a value = 'a Key.value
-type 'a code = string
+type 'a code = { pos : (string * int * int * int) option; code : string }
+
+let code_opt ?pos fmt = Fmt.kstr (fun code -> { pos; code }) fmt
+let code ~pos fmt = Fmt.kstr (fun code -> { pos = Some pos; code }) fmt
 
 type ('a, 'impl) t = {
   id : 'a Typeid.t;
@@ -58,10 +61,7 @@ let pp : type a b. b Fmt.t -> (a, b) t Fmt.t =
 let equal x y = Typeid.equal x.id y.id
 let witness x y = Typeid.witness x.id y.id
 let hash x = Typeid.id x.id
-
-let default_connect _ _ l =
-  Printf.sprintf "return (%s)" (String.concat ~sep:", " l)
-
+let default_connect _ _ l = code_opt "return (%s)" (String.concat ~sep:", " l)
 let niet _ = Action.ok ()
 let nil _ = []
 
@@ -118,8 +118,8 @@ let keys t = t.keys
 let runtime_args t = t.runtime_args
 let extra_deps t = t.extra_deps
 
-let start impl_name args =
-  Fmt.str "@[%s.start@ %a@]" impl_name Fmt.(list ~sep:sp string) args
+let start ?pos impl_name args =
+  code_opt ?pos "@[%s.start@ %a@]" impl_name Fmt.(list ~sep:sp string) args
 
 let uniq t = Fpath.Set.(elements (of_list t))
 let exec_hook i = function None -> Action.ok () | Some h -> h i

--- a/lib/functoria/device.mli
+++ b/lib/functoria/device.mli
@@ -71,8 +71,17 @@ val runtime_args : ('a, 'b) t -> Runtime_arg.t list
 
 (** {1 Code Generation} *)
 
-type 'a code = string
+type 'a code = private {
+  pos : (string * int * int * int) option;
+  code : string;
+}
 (** The type for fragments of code of type ['a]. *)
+
+val code :
+  pos:string * int * int * int ->
+  ('a, Format.formatter, unit, 'b code) format4 ->
+  'a
+(** Generate localised code. *)
 
 val connect : ('a, 'b) t -> Info.t -> string -> string list -> 'a code
 (** [connect t info impl_name args] is the code to execute in order to create a
@@ -80,8 +89,8 @@ val connect : ('a, 'b) t -> Info.t -> string -> string list -> 'a code
     [args], in the context of the project information [info]. The freshly
     created state will be made available in [var_name t] *)
 
-val start : string -> string list -> 'a code
-(** [start impl_name args] is the code [<impl_name>.start <args>]. *)
+val start : ?pos:string * int * int * int -> string -> string list -> 'a code
+(** [start ?pos impl_name args] is the code [<impl_name>.start <args>]. *)
 
 val nice_name : _ t -> string
 (** [nice_name d] provides a identifier unique to [d] which is a valid OCaml

--- a/lib/functoria/impl.ml
+++ b/lib/functoria/impl.ml
@@ -63,8 +63,8 @@ let v ?packages ?packages_v ?keys ?extra_deps ?connect ?dune ?configure ?files
   @@ Device.v ?packages ?packages_v ?keys ?extra_deps ?connect ?dune ?configure
        ?files module_name module_type
 
-let main ?packages ?packages_v ?keys ?extra_deps module_name ty =
-  let connect _ = Device.start in
+let main ?pos ?packages ?packages_v ?keys ?extra_deps module_name ty =
+  let connect _ = Device.start ?pos in
   v ?packages ?packages_v ?keys ?extra_deps ~connect module_name ty
 
 (* If *)

--- a/lib/functoria/impl.mli
+++ b/lib/functoria/impl.mli
@@ -59,7 +59,7 @@ val v :
   ?packages_v:Package.t list Key.value ->
   ?keys:Key.t list ->
   ?extra_deps:abstract list ->
-  ?connect:(Info.t -> string -> string list -> string) ->
+  ?connect:(Info.t -> string -> string list -> 'a Device.code) ->
   ?dune:(Info.t -> Dune.stanza list) ->
   ?configure:(Info.t -> unit Action.t) ->
   ?files:(Info.t -> Fpath.t list) ->
@@ -69,6 +69,7 @@ val v :
 (** [v ...] is [of_device @@ Device.v ...] *)
 
 val main :
+  ?pos:string * int * int * int ->
   ?packages:Package.t list ->
   ?packages_v:Package.t list Key.value ->
   ?keys:Key.t list ->

--- a/lib/functoria/info.ml
+++ b/lib/functoria/info.ml
@@ -21,6 +21,7 @@ open Astring
 type t = {
   config_file : Fpath.t;
   name : string;
+  project_name : string;
   output : string option;
   keys : Key.Set.t;
   runtime_args : Runtime_arg.Set.t;
@@ -34,6 +35,7 @@ type t = {
 }
 
 let name t = t.name
+let project_name t = t.project_name
 let config_file t = t.config_file
 
 let main t =
@@ -66,7 +68,8 @@ let runtime_args t = Runtime_arg.Set.elements t.runtime_args
 let context t = t.context
 
 let v ?(config_file = Fpath.v "config.ml") ~packages ~keys ~runtime_args
-    ~context ?configure_cmd ?pre_build_cmd ?lock_location ~build_cmd ~src name =
+    ~context ?configure_cmd ?pre_build_cmd ?lock_location ~build_cmd ~src
+    ~project_name name =
   let keys = Key.Set.of_list keys in
   let runtime_args = Runtime_arg.Set.of_list runtime_args in
   let opam ~extra_repo ~install ~opam_name =
@@ -89,6 +92,7 @@ let v ?(config_file = Fpath.v "config.ml") ~packages ~keys ~runtime_args
   {
     config_file;
     name;
+    project_name;
     keys;
     runtime_args;
     packages;
@@ -123,5 +127,6 @@ let t =
   let i =
     v ~config_file:(Fpath.v "config.ml") ~packages:[] ~keys:[] ~runtime_args:[]
       ~build_cmd:"dummy" ~context:Context.empty ~src:`None "dummy"
+      ~project_name:"dummy"
   in
   Type.v i

--- a/lib/functoria/info.mli
+++ b/lib/functoria/info.mli
@@ -27,6 +27,9 @@ val config_file : t -> Fpath.t
 val name : t -> string
 (** [name t] is the name of the application. *)
 
+val project_name : t -> string
+(** [project_name t] is the project name. *)
+
 val main : t -> Fpath.t
 (** [main t] is the name of the main application file. *)
 
@@ -74,6 +77,7 @@ val v :
   ?lock_location:(Fpath.t option -> string -> string) ->
   build_cmd:string ->
   src:[ `Auto | `None | `Some of string ] ->
+  project_name:string ->
   string ->
   t
 (** [create context n r] contains information about the application being built. *)

--- a/lib/functoria/job.ml
+++ b/lib/functoria/job.ml
@@ -48,8 +48,8 @@ let keys ?(runtime_package = "functoria-runtime")
   let files _ = [ file ] in
   let connect info _ = function
     | [ argv ] ->
-        Fmt.str "return %s.(with_argv (runtime_args ()) %S %s)" runtime_modname
-          (Info.name info) argv
+        Device.code ~pos:__POS__ "return %s.(with_argv (runtime_args ()) %S %s)"
+          runtime_modname (Info.name info) argv
     | _ -> failwith "The keys connect should receive exactly one argument."
   in
   Impl.v ~files ~configure ~packages ~extra_deps ~connect key_gen t

--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -29,6 +29,7 @@ module Config = struct
   type t = {
     config_file : Fpath.t;
     name : string;
+    project_name : string;
     configure_cmd : string;
     pre_build_cmd : Fpath.t option -> string;
     lock_location : Fpath.t option -> string -> string;
@@ -57,7 +58,7 @@ module Config = struct
     Key.Set.fold f all_keys skeys
 
   let v ?(config_file = Fpath.v "config.ml") ?(init = []) ~configure_cmd
-      ~pre_build_cmd ~lock_location ~build_cmd ~src name jobs =
+      ~pre_build_cmd ~lock_location ~build_cmd ~src ~project_name name jobs =
     let jobs = Impl.abstract jobs in
     let if_keys = get_if_context jobs in
     let runtime_args = Runtime_arg.Set.empty in
@@ -66,6 +67,7 @@ module Config = struct
       if_keys;
       runtime_args;
       name;
+      project_name;
       init;
       configure_cmd;
       pre_build_cmd;
@@ -80,6 +82,7 @@ module Config = struct
       {
         config_file;
         name = n;
+        project_name;
         configure_cmd;
         pre_build_cmd;
         lock_location;
@@ -103,7 +106,8 @@ module Config = struct
     let mk packages _ context =
       let info =
         Info.v ~config_file ~packages ~keys ~runtime_args ~context
-          ~configure_cmd ~pre_build_cmd ~lock_location ~build_cmd ~src n
+          ~configure_cmd ~pre_build_cmd ~lock_location ~build_cmd ~src
+          ~project_name n
       in
       { init; jobs; info; device_graph }
     in
@@ -494,7 +498,7 @@ module Make (P : S) = struct
       let main_dev = P.create (init @ jobs) in
       let c =
         Config.v ~config_file ~init ~configure_cmd ~pre_build_cmd ~lock_location
-          ~build_cmd ~src name main_dev
+          ~build_cmd ~src ~project_name:P.name name main_dev
       in
       run_with_argv argv args c
     in

--- a/lib/mirage/impl/mirage_impl_argv.ml
+++ b/lib/mirage/impl/mirage_impl_argv.ml
@@ -5,21 +5,21 @@ let ty = Functoria.argv
 
 let argv_unix =
   let packages = [ package ~min:"0.1.0" ~max:"0.2.0" "mirage-bootvar-unix" ] in
-  let connect _ _ _ = "Bootvar.argv ()" in
+  let connect _ _ _ = code ~pos:__POS__ "Bootvar.argv ()" in
   impl ~packages ~connect "Bootvar" ty
 
 let argv_solo5 =
   let packages = [ package ~min:"0.6.0" ~max:"0.7.0" "mirage-bootvar-solo5" ] in
-  let connect _ _ _ = "Bootvar.argv ()" in
+  let connect _ _ _ = code ~pos:__POS__ "Bootvar.argv ()" in
   impl ~packages ~connect "Bootvar" ty
 
 let no_argv =
-  let connect _ _ _ = "return [|\"\"|]" in
+  let connect _ _ _ = code ~pos:__POS__ "return [|\"\"|]" in
   impl ~connect "Mirage_runtime" ty
 
 let argv_xen =
   let packages = [ package ~min:"0.8.0" ~max:"0.9.0" "mirage-bootvar-xen" ] in
-  let connect _ _ _ = "Bootvar.argv ()" in
+  let connect _ _ _ = code ~pos:__POS__ "Bootvar.argv ()" in
   impl ~packages ~connect "Bootvar" ty
 
 let default_argv =

--- a/lib/mirage/impl/mirage_impl_arpv4.ml
+++ b/lib/mirage/impl/mirage_impl_arpv4.ml
@@ -13,7 +13,7 @@ let arp_conf =
     [ package ~min:"3.0.0" ~max:"4.0.0" ~sublibs:[ "mirage" ] "arp" ]
   in
   let connect _ modname = function
-    | [ eth; _time ] -> Fmt.str "%s.connect %s" modname eth
+    | [ eth; _time ] -> code ~pos:__POS__ "%s.connect %s" modname eth
     | _ -> connect_err "arp" 2
   in
   impl ~packages ~connect "Arp.Make" (ethernet @-> time @-> arpv4)

--- a/lib/mirage/impl/mirage_impl_conduit.ml
+++ b/lib/mirage/impl/mirage_impl_conduit.ml
@@ -11,7 +11,7 @@ let pkg = package ~min:"6.0.1" ~max:"7.0.0" "conduit-mirage"
 let tcp =
   let packages = [ pkg ] in
   let connect _ _ = function
-    | [ stack ] -> Fmt.str "Lwt.return %s@;" stack
+    | [ stack ] -> code ~pos:__POS__ "Lwt.return %s@;" stack
     | _ -> connect_err "tcp_conduit" 1
   in
   impl ~packages ~connect "Conduit_mirage.TCP" (stackv4v6 @-> conduit)
@@ -20,7 +20,7 @@ let tls random =
   let packages = [ pkg; package ~min:"0.13.0" ~max:"0.18.0" "tls-mirage" ] in
   let extra_deps = [ dep random ] in
   let connect _ _ = function
-    | [ stack; _random ] -> Fmt.str "Lwt.return %s@;" stack
+    | [ stack; _random ] -> code ~pos:__POS__ "Lwt.return %s@;" stack
     | _ -> connect_err "tls_conduit" 2
   in
   impl ~packages ~connect ~extra_deps "Conduit_mirage.TLS" (conduit @-> conduit)

--- a/lib/mirage/impl/mirage_impl_dns.ml
+++ b/lib/mirage/impl/mirage_impl_dns.ml
@@ -19,7 +19,7 @@ let generic_dns_client timeout nameservers =
   in
   let connect _info modname = function
     | [ _random; _time; _mclock; _pclock; stackv4v6 ] ->
-        Fmt.str {ocaml|%s.connect%a%a %s|ocaml} modname pp_nameservers
+        code ~pos:__POS__ {ocaml|%s.connect%a%a %s|ocaml} modname pp_nameservers
           nameservers (pp_opt "timeout") timeout stackv4v6
     | _ -> connect_err "dns" 5
   in

--- a/lib/mirage/impl/mirage_impl_ethernet.ml
+++ b/lib/mirage/impl/mirage_impl_ethernet.ml
@@ -10,7 +10,7 @@ let ethernet = Type.v ETHERNET
 let etif_conf =
   let packages = [ package ~min:"3.0.0" ~max:"4.0.0" "ethernet" ] in
   let connect _ m = function
-    | [ eth ] -> Fmt.str "%s.connect %s" m eth
+    | [ eth ] -> code ~pos:__POS__ "%s.connect %s" m eth
     | _ -> connect_err "etif" 1
   in
   impl ~packages ~connect "Ethernet.Make" (network @-> ethernet)

--- a/lib/mirage/impl/mirage_impl_happy_eyeballs.ml
+++ b/lib/mirage/impl/mirage_impl_happy_eyeballs.ml
@@ -26,8 +26,8 @@ let generic_happy_eyeballs aaaa_timeout connect_delay connect_timeout
   in
   let connect _info modname = function
     | [ _time; _mclock; stack; dns ] ->
-        Fmt.str {ocaml|%s.connect_device%a%a%a%a%a%a %s %s|ocaml} modname
-          (pp_opt "aaaa_timeout") aaaa_timeout (pp_opt "connect_delay")
+        code ~pos:__POS__ {ocaml|%s.connect_device%a%a%a%a%a%a %s %s|ocaml}
+          modname (pp_opt "aaaa_timeout") aaaa_timeout (pp_opt "connect_delay")
           connect_delay (pp_opt "connect_timeout") connect_timeout
           (pp_opt "resolve_timeout") resolve_timeout (pp_opt "resolve_retries")
           resolve_retries (pp_opt "timer_interval") timer_interval dns stack

--- a/lib/mirage/impl/mirage_impl_http.ml
+++ b/lib/mirage/impl/mirage_impl_http.ml
@@ -15,7 +15,7 @@ type http_client = HTTP_client
 let http_client = Type.v HTTP_client
 
 let connect err _i modname = function
-  | [ conduit ] -> Fmt.str "Lwt.return (%s.listen %s)" modname conduit
+  | [ conduit ] -> code ~pos:__POS__ "Lwt.return (%s.listen %s)" modname conduit
   | _ -> connect_err err 1
 
 let cohttp_server =
@@ -29,7 +29,7 @@ let cohttp_client =
   let packages = [ package ~min:"4.0.0" ~max:"6.0.0" "cohttp-mirage" ] in
   let connect _i modname = function
     | [ _pclock; resolver; conduit ] ->
-        Fmt.str "Lwt.return (%s.ctx %s %s)" modname resolver conduit
+        code ~pos:__POS__ "Lwt.return (%s.ctx %s %s)" modname resolver conduit
     | _ -> connect_err "http" 2
   in
   impl ~packages ~connect "Cohttp_mirage.Client.Make"
@@ -51,8 +51,8 @@ let http_server = Type.v HTTP_server
 let paf_server port =
   let connect _ modname = function
     | [ tcpv4v6 ] ->
-        Fmt.str {ocaml|%s.init ~port:%a %s|ocaml} modname Runtime_arg.call port
-          tcpv4v6
+        code ~pos:__POS__ {ocaml|%s.init ~port:%a %s|ocaml} modname
+          Runtime_arg.call port tcpv4v6
     | _ -> connect_err "paf_server" 1
   in
   let packages =
@@ -70,7 +70,7 @@ let paf_client =
   let packages = [ package "http-mirage-client" ~min:"0.0.1" ~max:"0.1.0" ] in
   let connect _ modname = function
     | [ _pclock; _tcpv4v6; ctx ] ->
-        Fmt.str {ocaml|%s.connect %s|ocaml} modname ctx
+        code ~pos:__POS__ {ocaml|%s.connect %s|ocaml} modname ctx
     | _ -> connect_err "paf_client" 3
   in
   impl ~connect ~packages "Http_mirage_client.Make"

--- a/lib/mirage/impl/mirage_impl_icmp.ml
+++ b/lib/mirage/impl/mirage_impl_icmp.ml
@@ -11,7 +11,7 @@ let icmpv4 : icmpv4 typ = icmp
 let icmpv4_direct () =
   let packages_v = right_tcpip_library ~sublibs:[ "icmpv4" ] "tcpip" in
   let connect _ modname = function
-    | [ ip ] -> Fmt.str "%s.connect %s" modname ip
+    | [ ip ] -> code ~pos:__POS__ "%s.connect %s" modname ip
     | _ -> connect_err "icmpv4" 1
   in
   impl ~packages_v ~connect "Icmpv4.Make" (ip @-> icmp)

--- a/lib/mirage/impl/mirage_impl_ip.ml
+++ b/lib/mirage/impl/mirage_impl_ip.ml
@@ -39,9 +39,9 @@ let ipv4_keyed_conf ~ip ?gateway ?no_init () =
   let runtime_args = runtime_args_opt [ no_init; gateway; Some ip ] in
   let connect _ modname = function
     | [ _random; _mclock; etif; arp ] ->
-        Fmt.str "%s.connect@[%a%a%a@ %s@ %s@]" modname (pp_label "no_init")
-          no_init (pp_label "cidr") (Some ip) (pp_opt "gateway") gateway etif
-          arp
+        code ~pos:__POS__ "%s.connect@[%a%a%a@ %s@ %s@]" modname
+          (pp_label "no_init") no_init (pp_label "cidr") (Some ip)
+          (pp_opt "gateway") gateway etif arp
     | _ -> connect_err "ipv4_keyed" 4
   in
   impl ~packages_v ~runtime_args ~connect "Static_ipv4.Make"
@@ -53,7 +53,8 @@ let ipv4_dhcp_conf =
   in
   let connect _ modname = function
     | [ _random; _mclock; _time; network; ethernet; arp ] ->
-        Fmt.str "%s.connect@[@ %s@ %s@ %s@]" modname network ethernet arp
+        code ~pos:__POS__ "%s.connect@[@ %s@ %s@ %s@]" modname network ethernet
+          arp
     | _ -> connect_err "ipv4_dhcp" 6
   in
   impl ~packages ~connect "Dhcp_ipv4.Make"
@@ -84,7 +85,7 @@ let ipv4_qubes_conf =
   let packages = [ package ~min:"0.9.0" ~max:"0.10.0" "mirage-qubes-ipv4" ] in
   let connect _ modname = function
     | [ db; _random; _mclock; etif; arp ] ->
-        Fmt.str "%s.connect@[@ %s@ %s@ %s@]" modname db etif arp
+        code ~pos:__POS__ "%s.connect@[@ %s@ %s@ %s@]" modname db etif arp
     | _ -> connect_err "ipv4_qubes" 5
   in
   impl ~packages ~connect "Qubesdb_ipv4.Make"
@@ -99,9 +100,9 @@ let ipv6_conf ?ip ?gateway ?handle_ra ?no_init () =
   let runtime_args = runtime_args_opt [ ip; gateway; handle_ra; no_init ] in
   let connect _ modname = function
     | [ netif; etif; _random; _time; _clock ] ->
-        Fmt.str "%s.connect@[%a%a%a%a@ %s@ %s@]" modname (pp_label "no_init")
-          no_init (pp_label "handle_ra") handle_ra (pp_opt "cidr") ip
-          (pp_opt "gateway") gateway netif etif
+        code ~pos:__POS__ "%s.connect@[%a%a%a%a@ %s@ %s@]" modname
+          (pp_label "no_init") no_init (pp_label "handle_ra") handle_ra
+          (pp_opt "cidr") ip (pp_opt "gateway") gateway netif etif
     | _ -> connect_err "ipv6" 5
   in
   impl ~packages_v ~runtime_args ~connect "Ipv6.Make"
@@ -129,8 +130,9 @@ let ipv4v6_conf ?ipv4_only ?ipv6_only () =
   let runtime_args = runtime_args_opt [ ipv4_only; ipv6_only ] in
   let connect _ modname = function
     | [ ipv4; ipv6 ] ->
-        Fmt.str "%s.connect@[%a%a@ %s@ %s@]" modname (pp_label "ipv4_only")
-          ipv4_only (pp_label "ipv6_only") ipv6_only ipv4 ipv6
+        code ~pos:__POS__ "%s.connect@[%a%a@ %s@ %s@]" modname
+          (pp_label "ipv4_only") ipv4_only (pp_label "ipv6_only") ipv6_only ipv4
+          ipv6
     | _ -> connect_err "ipv4v6" 2
   in
   impl ~packages_v ~runtime_args ~connect "Tcpip_stack_direct.IPV4V6"

--- a/lib/mirage/impl/mirage_impl_kv.ml
+++ b/lib/mirage/impl/mirage_impl_kv.ml
@@ -20,7 +20,7 @@ let crunch dirname =
       package ~min:"3.1.0" ~max:"4.0.0" ~build:true "crunch";
     ]
   in
-  let connect _ modname _ = Fmt.str "%s.connect ()" modname in
+  let connect _ modname _ = code ~pos:__POS__ "%s.connect ()" modname in
   let dune _i =
     let dir = Fpath.(v dirname) in
     let file ext = Fpath.(v name + ext) in
@@ -43,7 +43,9 @@ let crunch dirname =
 
 let direct_kv_ro dirname =
   let packages = [ package ~min:"2.1.0" ~max:"3.0.0" "mirage-kv-unix" ] in
-  let connect _ modname _names = Fmt.str "%s.connect \"%s\"" modname dirname in
+  let connect _ modname _names =
+    code ~pos:__POS__ "%s.connect \"%s\"" modname dirname
+  in
   impl ~packages ~connect "Mirage_kv_unix" ro
 
 let direct_kv_ro dirname =
@@ -66,12 +68,14 @@ let rw = Type.v RW
 
 let direct_kv_rw dirname =
   let packages = [ package ~min:"2.1.0" ~max:"3.0.0" "mirage-kv-unix" ] in
-  let connect _ modname _names = Fmt.str "%s.connect \"%s\"" modname dirname in
+  let connect _ modname _names =
+    code ~pos:__POS__ "%s.connect \"%s\"" modname dirname
+  in
   impl ~packages ~connect "Mirage_kv_unix" rw
 
 let mem_kv_rw_config =
   let packages = [ package ~min:"3.0.0" ~max:"4.0.0" "mirage-kv-mem" ] in
-  let connect _ modname _names = Fmt.str "%s.connect ()" modname in
+  let connect _ modname _names = code ~pos:__POS__ "%s.connect ()" modname in
   impl ~packages ~connect "Mirage_kv_mem.Make" (Mirage_impl_pclock.pclock @-> rw)
 
 let mem_kv_rw ?(clock = Mirage_impl_pclock.default_posix_clock) () =

--- a/lib/mirage/impl/mirage_impl_mimic.ml
+++ b/lib/mirage/impl/mirage_impl_mimic.ml
@@ -11,9 +11,9 @@ let mimic = Type.v Mimic
 let mimic_merge =
   let packages = [ package "mimic" ] in
   let connect _ _modname = function
-    | [ a; b ] -> Fmt.str "Lwt.return (Mimic.merge %s %s)" a b
-    | [ x ] -> Fmt.str "%s.ctx" x
-    | _ -> Fmt.str "Lwt.return Mimic.empty"
+    | [ a; b ] -> code ~pos:__POS__ "Lwt.return (Mimic.merge %s %s)" a b
+    | [ x ] -> code ~pos:__POS__ "%s.ctx" x
+    | _ -> code ~pos:__POS__ "Lwt.return Mimic.empty"
   in
   impl ~packages ~connect "Mimic.Merge" (mimic @-> mimic @-> mimic)
 
@@ -21,7 +21,7 @@ let mimic_happy_eyeballs =
   let packages = [ package "mimic-happy-eyeballs" ~min:"0.0.5" ] in
   let connect _ modname = function
     | [ _stackv4v6; _dns_client; happy_eyeballs ] ->
-        Fmt.str {ocaml|%s.connect %s|ocaml} modname happy_eyeballs
+        code ~pos:__POS__ {ocaml|%s.connect %s|ocaml} modname happy_eyeballs
     | _ -> connect_err "mimic" 3
   in
   impl ~packages ~connect "Mimic_happy_eyeballs.Make"

--- a/lib/mirage/impl/mirage_impl_network.ml
+++ b/lib/mirage/impl/mirage_impl_network.ml
@@ -28,7 +28,7 @@ let network_conf ?(intf : string runtime_arg option) name =
       Option.value ~default:(Printf.sprintf "%S" name)
         (Option.map (Fmt.to_to_string Runtime_arg.call) intf)
     in
-    Fmt.str "%s.connect %s" modname name
+    code ~pos:__POS__ "%s.connect %s" modname name
   in
   let configure _ =
     add_new_network name;

--- a/lib/mirage/impl/mirage_impl_qubesdb.ml
+++ b/lib/mirage/impl/mirage_impl_qubesdb.ml
@@ -17,5 +17,7 @@ let default_qubesdb =
           "Qubes DB invoked for an unsupported target; qubes and xen are \
            supported"
   in
-  let connect _ modname _args = Fmt.str "%s.connect ~domid:0 ()" modname in
+  let connect _ modname _args =
+    code ~pos:__POS__ "%s.connect ~domid:0 ()" modname
+  in
   impl ~packages ~configure ~connect "Qubes.DB" qubesdb

--- a/lib/mirage/impl/mirage_impl_random.ml
+++ b/lib/mirage/impl/mirage_impl_random.ml
@@ -15,7 +15,7 @@ let rng ?(time = default_time) ?(mclock = default_monotonic_clock) () =
   in
   let connect _ modname _ =
     (* here we could use the boot argument (--prng) to select the RNG! *)
-    Fmt.str "%s.initialize (module Mirage_crypto_rng.Fortuna)" modname
+    code ~pos:__POS__ "%s.initialize (module Mirage_crypto_rng.Fortuna)" modname
   in
   impl ~packages ~connect "Mirage_crypto_rng_mirage.Make"
     (Mirage_impl_time.time @-> Mirage_impl_mclock.mclock @-> random)

--- a/lib/mirage/impl/mirage_impl_reporter.ml
+++ b/lib/mirage/impl/mirage_impl_reporter.ml
@@ -22,7 +22,7 @@ let mirage_log ~default () =
   let runtime_args = [ Runtime_arg.v logs ] in
   let connect _ modname = function
     | [ _pclock ] ->
-        Fmt.str
+        code ~pos:__POS__
           "@[<v 2>let reporter = %s.create () in@ Mirage_runtime.set_level \
            ~default:%a %a;@ Logs.set_reporter reporter;@ Lwt.return reporter@]"
           modname pp_level default pp_key logs
@@ -35,5 +35,5 @@ let default_reporter ?(clock = default_posix_clock) ?(level = Some Logs.Info) ()
   mirage_log ~default:level () $ clock
 
 let no_reporter =
-  let connect _ _ _ = "assert false" in
+  let connect _ _ _ = code ~pos:__POS__ "assert false" in
   impl ~connect "Mirage_runtime" reporter

--- a/lib/mirage/impl/mirage_impl_resolver.ml
+++ b/lib/mirage/impl/mirage_impl_resolver.ml
@@ -26,7 +26,9 @@ let resolver_unix_system =
     | `Unix | `MacOSX -> Action.ok ()
     | _ -> Action.error "Unix resolver not supported on non-UNIX targets."
   in
-  let connect _ _modname _ = "Lwt.return Resolver_lwt_unix.system" in
+  let connect _ _modname _ =
+    code ~pos:__POS__ "Lwt.return Resolver_lwt_unix.system"
+  in
   impl ~packages_v ~configure ~connect "Resolver_lwt" resolver
 
 let resolver_dns_conf ~ns =
@@ -34,7 +36,7 @@ let resolver_dns_conf ~ns =
   let runtime_args = Runtime_arg.[ v ns ] in
   let connect _ modname = function
     | [ _r; _t; _m; _p; stack ] ->
-        Fmt.str
+        code ~pos:__POS__
           "let nameservers = %a in@;\
            %s.v ?nameservers %s >|= function@;\
            | Ok r -> r@;\

--- a/lib/mirage/impl/mirage_impl_stack.ml
+++ b/lib/mirage/impl/mirage_impl_stack.ml
@@ -31,8 +31,8 @@ let stackv4v6_direct_conf () =
   let packages_v = right_tcpip_library ~sublibs:[ "stack-direct" ] "tcpip" in
   let connect _i modname = function
     | [ _t; _r; interface; ethif; arp; ipv4v6; icmpv4; udp; tcp ] ->
-        Fmt.str "%s.connect %s %s %s %s %s %s %s" modname interface ethif arp
-          ipv4v6 icmpv4 udp tcp
+        code ~pos:__POS__ "%s.connect %s %s %s %s %s %s %s" modname interface
+          ethif arp ipv4v6 icmpv4 udp tcp
     | _ -> connect_err "stackv4v6" 9
   in
   impl ~packages_v ~connect "Tcpip_stack_direct.MakeV4V6"
@@ -100,7 +100,7 @@ let socket_stackv4v6 ?(group = "") () =
     ]
   in
   let connect _i modname = function
-    | [ udp; tcp ] -> Fmt.str "%s.connect %s %s" modname udp tcp
+    | [ udp; tcp ] -> code ~pos:__POS__ "%s.connect %s %s" modname udp tcp
     | _ -> connect_err "socket_stackv4v6" 2
   in
   impl ~packages_v ~extra_deps ~connect "Tcpip_stack_socket.V4V6" stackv4v6

--- a/lib/mirage/impl/mirage_impl_syslog.ml
+++ b/lib/mirage/impl/mirage_impl_syslog.ml
@@ -38,7 +38,7 @@ let syslog_udp_conf config =
   let runtime_args = Runtime_arg.[ v endpoint; v hostname; v port ] in
   let connect _i modname = function
     | [ pclock; stack ] ->
-        Fmt.str
+        code ~pos:__POS__
           "@[<v 2>match %a with@ | None -> Lwt.return_unit@ | Some server ->@ \
            let port = %a in@ let reporter =@ %s.create %s %s ~hostname:%a \
            ?port server %a ()@ in@ Logs.set_reporter reporter;@ \
@@ -62,7 +62,7 @@ let syslog_tcp_conf config =
   let runtime_args = Runtime_arg.[ v endpoint; v hostname; v port ] in
   let connect _i modname = function
     | [ pclock; stack ] ->
-        Fmt.str
+        code ~pos:__POS__
           "@[<v 2>match %a with@ | None -> Lwt.return_unit@ | Some server ->@ \
            let port = %a in@ %s.create %s %s ~hostname:%a ?port server %a () \
            >>= function@ | Ok reporter -> Logs.set_reporter reporter; \
@@ -86,7 +86,7 @@ let syslog_tls_conf ?keyname config =
   let runtime_args = Runtime_arg.[ v endpoint; v hostname; v port ] in
   let connect _i modname = function
     | [ pclock; stack; kv ] ->
-        Fmt.str
+        code ~pos:__POS__
           "@[<v 2>match %a with@ | None -> Lwt.return_unit@ | Some server ->@ \
            let port = %a in@ %s.create %s %s %s ~hostname:%a ?port server %a \
            %a () >>= function@ | Ok reporter -> Logs.set_reporter reporter; \

--- a/lib/mirage/impl/mirage_impl_tcp.ml
+++ b/lib/mirage/impl/mirage_impl_tcp.ml
@@ -17,7 +17,8 @@ let tcpv4v6 : tcpv4v6 typ = tcp
 let tcp_direct_func () =
   let packages_v = right_tcpip_library ~sublibs:[ "tcp" ] "tcpip" in
   let connect _ modname = function
-    | [ ip; _time; _clock; _random ] -> Fmt.str "%s.connect %s" modname ip
+    | [ ip; _time; _clock; _random ] ->
+        code ~pos:__POS__ "%s.connect %s" modname ip
     | _ -> connect_err "tcp" 4
   in
   impl ~packages_v ~connect "Tcp.Flow.Make"
@@ -37,8 +38,8 @@ let tcpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
     | _ -> Action.error "TCPv4v6 socket not supported on non-UNIX targets."
   in
   let connect _ modname _ =
-    Fmt.str "%s.connect ~ipv4_only:%a ~ipv6_only:%a %a %a" modname pp_key
-      ipv4_only pp_key ipv6_only pp_key ipv4_key pp_key ipv6_key
+    code ~pos:__POS__ "%s.connect ~ipv4_only:%a ~ipv6_only:%a %a %a" modname
+      pp_key ipv4_only pp_key ipv6_only pp_key ipv4_key pp_key ipv6_key
   in
   impl ~packages_v ~configure ~runtime_args ~connect "Tcpv4v6_socket" tcpv4v6
 

--- a/lib/mirage/impl/mirage_impl_udp.ml
+++ b/lib/mirage/impl/mirage_impl_udp.ml
@@ -15,7 +15,7 @@ let udpv4v6 : udpv4v6 typ = udp
 let udp_direct_func () =
   let packages_v = right_tcpip_library ~sublibs:[ "udp" ] "tcpip" in
   let connect _ modname = function
-    | [ ip; _random ] -> Fmt.str "%s.connect %s" modname ip
+    | [ ip; _random ] -> code ~pos:__POS__ "%s.connect %s" modname ip
     | _ -> connect_err "udp" 2
   in
   impl ~packages_v ~connect "Udp.Make" (ip @-> random @-> udp)
@@ -32,8 +32,8 @@ let udpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
     | _ -> Action.error "UDPv4v6 socket not supported on non-UNIX targets."
   in
   let connect _ modname _ =
-    Fmt.str "%s.connect ~ipv4_only:%a ~ipv6_only:%a %a %a" modname pp_key
-      ipv4_only pp_key ipv6_only pp_key ipv4_key pp_key ipv6_key
+    code ~pos:__POS__ "%s.connect ~ipv4_only:%a ~ipv6_only:%a %a %a" modname
+      pp_key ipv4_only pp_key ipv6_only pp_key ipv4_key pp_key ipv6_key
   in
   impl ~runtime_args ~packages_v ~configure ~connect "Udpv4v6_socket" udpv4v6
 

--- a/test/f0/f0.ml
+++ b/test/f0/f0.ml
@@ -34,7 +34,7 @@ module C = struct
   let version = "1.0~test"
   let packages = [ package "functoria"; package "f0" ]
   let keys = Key.[ v vote; v warn_error ]
-  let connect _ _ _ = "()"
+  let connect _ _ _ = code ~pos:__POS__ "()"
 
   let dune i =
     let dune =

--- a/test/functoria-test/functoria_test.ml
+++ b/test/functoria-test/functoria_test.ml
@@ -12,7 +12,7 @@ let run x = x
 
 |}
 
-let run ?(keys = []) ?init context device =
+let run ?(keys = []) ?init ?(project_name = "test") context device =
   let t = Impl.abstract device in
   let t = Impl.simplify ~full:false ~context t in
   let all_keys = Engine.keys t in
@@ -22,7 +22,7 @@ let run ?(keys = []) ?init context device =
   let packages = Key.eval context (Engine.packages t) in
   let info =
     Functoria.Info.v ~packages ~context ~keys ~runtime_args
-      ~build_cmd:"build me" ~src:`None "foo"
+      ~build_cmd:"build me" ~project_name ~src:`None "foo"
   in
   let t = Impl.eval ~context t in
   let* () = prelude info in

--- a/test/functoria-test/functoria_test.mli
+++ b/test/functoria-test/functoria_test.mli
@@ -4,6 +4,7 @@ open Functoria.DSL
 val run :
   ?keys:Key.Set.elt list ->
   ?init:job impl list ->
+  ?project_name:string ->
   context ->
   'a impl ->
   unit Action.t

--- a/test/functoria/e2e/app/config.ml
+++ b/test/functoria/e2e/app/config.ml
@@ -8,7 +8,7 @@ let required : string runtime_arg = Runtime_arg.create "App.required"
 
 let keys =
   let connect _ _ _ =
-    Fmt.str
+    code ~pos:__POS__
       {|
       let _ : string = %a
       and _ : string list = %a

--- a/test/functoria/e2e/clean.t
+++ b/test/functoria/e2e/clean.t
@@ -35,6 +35,7 @@ Make sure that clean remove everything:
                      Keys       vote=cat (default),
                                 warn_error=false (default)
   test.exe: [INFO] Skipped ./app
+  test.exe: [INFO] Skipped ./errors
   test.exe: [INFO] Skipped ./help.exe
   test.exe: [INFO] Skipped ./lib
   test.exe: [INFO] Skipped ./test.exe
@@ -82,6 +83,7 @@ Check that clean works with `--output`:
                                 warn_error=false (default)
                      Output     toto
   test.exe: [INFO] Skipped ./app
+  test.exe: [INFO] Skipped ./errors
   test.exe: [INFO] Skipped ./help.exe
   test.exe: [INFO] Skipped ./lib
   test.exe: [INFO] Skipped ./test.exe

--- a/test/functoria/e2e/dune
+++ b/test/functoria/e2e/dune
@@ -14,6 +14,7 @@
   help.exe
   (source_tree app)
   (source_tree lib)
+  (source_tree errors)
   (package functoria)
   (package functoria-runtime))
  (enabled_if

--- a/test/functoria/e2e/errors.t
+++ b/test/functoria/e2e/errors.t
@@ -1,0 +1,27 @@
+Check the locations of error messages when something is wrong in the body
+of a device's connect function:
+
+  $ ./test.exe configure -f errors/in_device.ml
+  $ dune build
+  File "errors/config.ml", line 6, characters 2-26:
+  Error: Unbound value Unikernel_make__4.start'
+  Hint: Did you mean start?
+  [1]
+  $ ./test.exe clean -f errors/in_device.ml
+
+Check what happens when the number of the arguments passed to the functor is
+not the right ones. First, too many parameters:
+
+  $ ./test.exe configure -f errors/in_functor_too_many.ml
+  $ dune build 2>&1 | head -n1 | cut -d',' -f'-2'
+  File "errors/test/main.ml", line 6
+  $ ./test.exe clean -f errors/in_functor_too_many.ml
+
+Then, not enough:
+
+  $ ./test.exe configure -f errors/in_functor_not_enough.ml
+  $ dune build
+  File "errors/test/main.ml", line 29, characters 2-25:
+  Error: The module Unikernel_make__4 is a functor, it cannot have any components
+  [1]
+  $ ./test.exe clean -f errors/in_functor_not_enough.ml

--- a/test/functoria/e2e/errors/in_device.ml
+++ b/test/functoria/e2e/errors/in_device.ml
@@ -1,0 +1,11 @@
+open Functoria
+open E2e
+
+let device =
+  let connect _ modname = function
+    | [ _; _ ] -> code ~pos:__POS__ "%s.start' () ()" modname
+    | _ -> assert false
+  in
+  impl ~connect "Unikernel.Make" (job @-> job @-> job)
+
+let () = register "my-app" [ device $ noop $ noop ]

--- a/test/functoria/e2e/errors/in_functor_not_enough.ml
+++ b/test/functoria/e2e/errors/in_functor_not_enough.ml
@@ -1,0 +1,5 @@
+open Functoria
+open E2e
+
+let device = main "Unikernel.Make" (job @-> job)
+let () = register "my-app" [ device $ noop ]

--- a/test/functoria/e2e/errors/in_functor_too_many.ml
+++ b/test/functoria/e2e/errors/in_functor_too_many.ml
@@ -1,0 +1,5 @@
+open Functoria
+open E2e
+
+let device = main "Unikernel.Make" (job @-> job @-> job @-> job)
+let () = register "my-app" [ device $ noop $ noop $ noop ]

--- a/test/functoria/e2e/errors/unikernel.ml
+++ b/test/functoria/e2e/errors/unikernel.ml
@@ -1,0 +1,3 @@
+module Make (_ : sig end) (_ : sig end) = struct
+  let start _ _ = ()
+end

--- a/test/functoria/e2e/lib/e2e.ml
+++ b/test/functoria/e2e/lib/e2e.ml
@@ -32,8 +32,9 @@ module C = struct
   let version = "1.0~test"
   let packages = [ package "functoria"; package "e2e" ]
   let keys = Key.[ v vote; v warn_error ]
-  let connect _ _ _ = "()"
+  let connect _ _ _ = code ~pos:__POS__ "()"
   let main i = Fpath.(basename @@ rem_ext @@ Info.main i)
+  let config i = Fpath.(basename @@ rem_ext @@ Info.config_file i)
 
   let dune i =
     let dune =
@@ -41,11 +42,11 @@ module C = struct
         {|
 (executable
   (name      %s)
-  (modules   (:standard \ config))
+  (modules   (:standard \ %s))
   (promote   (until-clean))
   (libraries cmdliner fmt functoria-runtime))
 |}
-        (main i)
+        (main i) (config i)
     in
     [ dune ]
 

--- a/test/functoria/gen-1/main.ml.expected
+++ b/test/functoria/gen-1/main.ml.expected
@@ -7,22 +7,27 @@ let run x = x
 module App_make__3 = App.Make(Key_gen)
 
 let sys__1 = lazy (
+# 24 "lib/functoria/argv.ml"
   return Sys.argv
-  )
+);;
+# 13 "test/main.ml"
 
 let key_gen__2 = lazy (
   let __sys__1 = Lazy.force sys__1 in
   __sys__1 >>= fun _sys__1 ->
+# 51 "lib/functoria/job.ml"
   return Functoria_runtime.(with_argv (runtime_args ()) "foo" _sys__1)
-  )
+);;
+# 21 "test/main.ml"
 
 let app_make__3 = lazy (
   let __key_gen__2 = Lazy.force key_gen__2 in
   __key_gen__2 >>= fun _key_gen__2 ->
   App_make__3.start _key_gen__2
-  )
+);;
+# 28 "test/main.ml"
 
 let () =
-  let t =
-  Lazy.force app_make__3
-  in run t
+  let t = Lazy.force app_make__3 in
+  run t
+;;

--- a/test/functoria/gen-2/main.ml.expected
+++ b/test/functoria/gen-2/main.ml.expected
@@ -7,18 +7,23 @@ let run x = x
 module App_make__4 = App.Make(Key_gen)(Unit)
 
 let sys__1 = lazy (
+# 24 "lib/functoria/argv.ml"
   return Sys.argv
-  )
+);;
+# 13 "test/main.ml"
 
 let key_gen__2 = lazy (
   let __sys__1 = Lazy.force sys__1 in
   __sys__1 >>= fun _sys__1 ->
+# 51 "lib/functoria/job.ml"
   return Functoria_runtime.(with_argv (runtime_args ()) "foo" _sys__1)
-  )
+);;
+# 21 "test/main.ml"
 
 let unit__3 = lazy (
   return ()
-  )
+);;
+# 26 "test/main.ml"
 
 let app_make__4 = lazy (
   let __key_gen__2 = Lazy.force key_gen__2 in
@@ -26,11 +31,12 @@ let app_make__4 = lazy (
   __key_gen__2 >>= fun _key_gen__2 ->
   __unit__3 >>= fun _unit__3 ->
   App_make__4.start _key_gen__2 _unit__3
-  )
+);;
+# 35 "test/main.ml"
 
 let () =
-  let t =
-  Lazy.force key_gen__2 >>= fun _ ->
-    Lazy.force unit__3 >>= fun _ ->
-    Lazy.force app_make__4
-  in run t
+  let t = Lazy.force key_gen__2 >>= fun _ ->
+  Lazy.force unit__3 >>= fun _ ->
+  Lazy.force app_make__4 in
+  run t
+;;

--- a/test/mirage/action/test.ml
+++ b/test/mirage/action/test.ml
@@ -15,7 +15,7 @@ let print_banner s =
 
 let info context =
   Info.v ~packages:[] ~keys:[] ~runtime_args:[] ~build_cmd:"mirage build"
-    ~context ~src:`None "NAME"
+    ~context ~src:`None ~project_name:"test" "NAME"
 
 let test target =
   print_banner target;

--- a/test/mirage/info_gen/main.ml.expected
+++ b/test/mirage/info_gen/main.ml.expected
@@ -7,22 +7,27 @@ let run x = x
 module App_make__3 = App.Make(Key_gen)
 
 let bootvar__1 = lazy (
+# 8 "lib/mirage/impl/mirage_impl_argv.ml"
   Bootvar.argv ()
-  )
+);;
+# 13 "mirage/main.ml"
 
 let key_gen__2 = lazy (
   let __bootvar__1 = Lazy.force bootvar__1 in
   __bootvar__1 >>= fun _bootvar__1 ->
+# 51 "lib/functoria/job.ml"
   return Mirage_runtime.(with_argv (runtime_args ()) "foo" _bootvar__1)
-  )
+);;
+# 21 "mirage/main.ml"
 
 let app_make__3 = lazy (
   let __key_gen__2 = Lazy.force key_gen__2 in
   __key_gen__2 >>= fun _key_gen__2 ->
   App_make__3.start _key_gen__2
-  )
+);;
+# 28 "mirage/main.ml"
 
 let () =
-  let t =
-  Lazy.force app_make__3
-  in run t
+  let t = Lazy.force app_make__3 in
+  run t
+;;

--- a/test/mirage/info_gen/test.ml
+++ b/test/mirage/info_gen/test.ml
@@ -4,7 +4,9 @@ let test () =
   let context = Key.add_to_context Key.target `Unix Context.empty in
   let sigs = job @-> job in
   let job = main "App.Make" sigs $ keys default_argv in
-  Functoria_test.run ~keys:[ Key.v Key.target ] context job
+  Functoria_test.run ~project_name:"mirage"
+    ~keys:[ Key.v Key.target ]
+    context job
 
 let () =
   match Functoria.Action.run (test ()) with

--- a/test/mirage/random-unix/main.ml.expected
+++ b/test/mirage/random-unix/main.ml.expected
@@ -4,81 +4,78 @@ let (>>=) x f = f x
 let return x = x
 let run x = x
 
-module Mirage_crypto_rng_mirage_make__3 =
-  Mirage_crypto_rng_mirage.Make(Unix_os.Time)(Mclock)
+module Mirage_crypto_rng_mirage_make__3 = Mirage_crypto_rng_mirage.Make(Unix_os.Time)(Mclock)
 
 module Ethernet_make__5 = Ethernet.Make(Netif)
 
 module Arp_make__6 = Arp.Make(Ethernet_make__5)(Unix_os.Time)
 
-module Static_ipv4_make__7 =
-  Static_ipv4.Make(Mirage_crypto_rng_mirage_make__3)(Mclock)
-  (Ethernet_make__5)(Arp_make__6)
+module Static_ipv4_make__7 = Static_ipv4.Make(Mirage_crypto_rng_mirage_make__3)(Mclock)(Ethernet_make__5)(Arp_make__6)
 
-module Ipv6_make__8 = Ipv6.Make(Netif)(Ethernet_make__5)
-  (Mirage_crypto_rng_mirage_make__3)(Unix_os.Time)(Mclock)
+module Ipv6_make__8 = Ipv6.Make(Netif)(Ethernet_make__5)(Mirage_crypto_rng_mirage_make__3)(Unix_os.Time)(Mclock)
 
-module Tcpip_stack_direct_ipv4v6__9 =
-  Tcpip_stack_direct.IPV4V6(Static_ipv4_make__7)(Ipv6_make__8)
+module Tcpip_stack_direct_ipv4v6__9 = Tcpip_stack_direct.IPV4V6(Static_ipv4_make__7)(Ipv6_make__8)
 
 module Icmpv4_make__10 = Icmpv4.Make(Static_ipv4_make__7)
 
-module Udp_make__11 = Udp.Make(Tcpip_stack_direct_ipv4v6__9)
-  (Mirage_crypto_rng_mirage_make__3)
+module Udp_make__11 = Udp.Make(Tcpip_stack_direct_ipv4v6__9)(Mirage_crypto_rng_mirage_make__3)
 
-module Tcp_flow_make__12 = Tcp.Flow.Make(Tcpip_stack_direct_ipv4v6__9)
-  (Unix_os.Time)(Mclock)(Mirage_crypto_rng_mirage_make__3)
+module Tcp_flow_make__12 = Tcp.Flow.Make(Tcpip_stack_direct_ipv4v6__9)(Unix_os.Time)(Mclock)(Mirage_crypto_rng_mirage_make__3)
 
-module Tcpip_stack_direct_makev4v6__13 =
-  Tcpip_stack_direct.MakeV4V6(Unix_os.Time)(Mirage_crypto_rng_mirage_make__3)
-  (Netif)(Ethernet_make__5)(Arp_make__6)(Tcpip_stack_direct_ipv4v6__9)
-  (Icmpv4_make__10)(Udp_make__11)(Tcp_flow_make__12)
+module Tcpip_stack_direct_makev4v6__13 = Tcpip_stack_direct.MakeV4V6(Unix_os.Time)(Mirage_crypto_rng_mirage_make__3)(Netif)(Ethernet_make__5)(Arp_make__6)(Tcpip_stack_direct_ipv4v6__9)(Icmpv4_make__10)(Udp_make__11)(Tcp_flow_make__12)
 
-module Conduit_mirage_tcp__14 =
-  Conduit_mirage.TCP(Tcpip_stack_direct_makev4v6__13)
+module Conduit_mirage_tcp__14 = Conduit_mirage.TCP(Tcpip_stack_direct_makev4v6__13)
 
 module Conduit_mirage_tls__15 = Conduit_mirage.TLS(Conduit_mirage_tcp__14)
 
-module App_make__16 = App.Make(Conduit_mirage_tls__15)
-  (Mirage_crypto_rng_mirage_make__3)
+module App_make__16 = App.Make(Conduit_mirage_tls__15)(Mirage_crypto_rng_mirage_make__3)
 
 let unix_os_time__1 = lazy (
   return ()
-  )
+);;
+# 36 "mirage/main.ml"
 
 let mclock__2 = lazy (
   return ()
-  )
+);;
+# 41 "mirage/main.ml"
 
 let mirage_crypto_rng_mirage_make__3 = lazy (
   let __unix_os_time__1 = Lazy.force unix_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
   __unix_os_time__1 >>= fun _unix_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
+# 18 "lib/mirage/impl/mirage_impl_random.ml"
   Mirage_crypto_rng_mirage_make__3.initialize (module Mirage_crypto_rng.Fortuna)
-  )
+);;
+# 51 "mirage/main.ml"
 
 let netif__4 = lazy (
+# 31 "lib/mirage/impl/mirage_impl_network.ml"
   Netif.connect (Key_gen.interface ())
-  )
+);;
+# 57 "mirage/main.ml"
 
 let ethernet_make__5 = lazy (
   let __netif__4 = Lazy.force netif__4 in
   __netif__4 >>= fun _netif__4 ->
+# 13 "lib/mirage/impl/mirage_impl_ethernet.ml"
   Ethernet_make__5.connect _netif__4
-  )
+);;
+# 65 "mirage/main.ml"
 
 let arp_make__6 = lazy (
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
   let __unix_os_time__1 = Lazy.force unix_os_time__1 in
   __ethernet_make__5 >>= fun _ethernet_make__5 ->
   __unix_os_time__1 >>= fun _unix_os_time__1 ->
+# 16 "lib/mirage/impl/mirage_impl_arpv4.ml"
   Arp_make__6.connect _ethernet_make__5
-  )
+);;
+# 75 "mirage/main.ml"
 
 let static_ipv4_make__7 = lazy (
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   let __mclock__2 = Lazy.force mclock__2 in
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
   let __arp_make__6 = Lazy.force arp_make__6 in
@@ -86,16 +83,17 @@ let static_ipv4_make__7 = lazy (
   __mclock__2 >>= fun _mclock__2 ->
   __ethernet_make__5 >>= fun _ethernet_make__5 ->
   __arp_make__6 >>= fun _arp_make__6 ->
+# 42 "lib/mirage/impl/mirage_impl_ip.ml"
   Static_ipv4_make__7.connect ~cidr:(Key_gen.ipv4 ())
                            ?gateway:(Key_gen.ipv4_gateway ())
                            _ethernet_make__5 _arp_make__6
-  )
+);;
+# 91 "mirage/main.ml"
 
 let ipv6_make__8 = lazy (
   let __netif__4 = Lazy.force netif__4 in
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   let __unix_os_time__1 = Lazy.force unix_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
   __netif__4 >>= fun _netif__4 ->
@@ -103,61 +101,65 @@ let ipv6_make__8 = lazy (
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
   __unix_os_time__1 >>= fun _unix_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
+# 103 "lib/mirage/impl/mirage_impl_ip.ml"
   Ipv6_make__8.connect ~handle_ra:(Key_gen.accept_router_advertisements ())
                     ?cidr:(Key_gen.ipv6 ())
                     ?gateway:(Key_gen.ipv6_gateway ()) _netif__4
                     _ethernet_make__5
-  )
+);;
+# 110 "mirage/main.ml"
 
 let tcpip_stack_direct_ipv4v6__9 = lazy (
   let __static_ipv4_make__7 = Lazy.force static_ipv4_make__7 in
   let __ipv6_make__8 = Lazy.force ipv6_make__8 in
   __static_ipv4_make__7 >>= fun _static_ipv4_make__7 ->
   __ipv6_make__8 >>= fun _ipv6_make__8 ->
+# 133 "lib/mirage/impl/mirage_impl_ip.ml"
   Tcpip_stack_direct_ipv4v6__9.connect ~ipv4_only:(Key_gen.ipv4_only ())
                                     ~ipv6_only:(Key_gen.ipv6_only ())
                                     _static_ipv4_make__7 _ipv6_make__8
-  )
+);;
+# 122 "mirage/main.ml"
 
 let icmpv4_make__10 = lazy (
   let __static_ipv4_make__7 = Lazy.force static_ipv4_make__7 in
   __static_ipv4_make__7 >>= fun _static_ipv4_make__7 ->
+# 14 "lib/mirage/impl/mirage_impl_icmp.ml"
   Icmpv4_make__10.connect _static_ipv4_make__7
-  )
+);;
+# 130 "mirage/main.ml"
 
 let udp_make__11 = lazy (
-  let __tcpip_stack_direct_ipv4v6__9 =
-                                      Lazy.force tcpip_stack_direct_ipv4v6__9 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __tcpip_stack_direct_ipv4v6__9 = Lazy.force tcpip_stack_direct_ipv4v6__9 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   __tcpip_stack_direct_ipv4v6__9 >>= fun _tcpip_stack_direct_ipv4v6__9 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
+# 18 "lib/mirage/impl/mirage_impl_udp.ml"
   Udp_make__11.connect _tcpip_stack_direct_ipv4v6__9
-  )
+);;
+# 140 "mirage/main.ml"
 
 let tcp_flow_make__12 = lazy (
-  let __tcpip_stack_direct_ipv4v6__9 =
-                                      Lazy.force tcpip_stack_direct_ipv4v6__9 in
+  let __tcpip_stack_direct_ipv4v6__9 = Lazy.force tcpip_stack_direct_ipv4v6__9 in
   let __unix_os_time__1 = Lazy.force unix_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   __tcpip_stack_direct_ipv4v6__9 >>= fun _tcpip_stack_direct_ipv4v6__9 ->
   __unix_os_time__1 >>= fun _unix_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
+# 21 "lib/mirage/impl/mirage_impl_tcp.ml"
   Tcp_flow_make__12.connect _tcpip_stack_direct_ipv4v6__9
-  )
+);;
+# 154 "mirage/main.ml"
 
 let tcpip_stack_direct_makev4v6__13 = lazy (
   let __unix_os_time__1 = Lazy.force unix_os_time__1 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   let __netif__4 = Lazy.force netif__4 in
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
   let __arp_make__6 = Lazy.force arp_make__6 in
-  let __tcpip_stack_direct_ipv4v6__9 =
-                                      Lazy.force tcpip_stack_direct_ipv4v6__9 in
+  let __tcpip_stack_direct_ipv4v6__9 = Lazy.force tcpip_stack_direct_ipv4v6__9 in
   let __icmpv4_make__10 = Lazy.force icmpv4_make__10 in
   let __udp_make__11 = Lazy.force udp_make__11 in
   let __tcp_flow_make__12 = Lazy.force tcp_flow_make__12 in
@@ -170,55 +172,65 @@ let tcpip_stack_direct_makev4v6__13 = lazy (
   __icmpv4_make__10 >>= fun _icmpv4_make__10 ->
   __udp_make__11 >>= fun _udp_make__11 ->
   __tcp_flow_make__12 >>= fun _tcp_flow_make__12 ->
+# 34 "lib/mirage/impl/mirage_impl_stack.ml"
   Tcpip_stack_direct_makev4v6__13.connect _netif__4 _ethernet_make__5 _arp_make__6 _tcpip_stack_direct_ipv4v6__9 _icmpv4_make__10 _udp_make__11 _tcp_flow_make__12
-  )
+);;
+# 178 "mirage/main.ml"
 
 let conduit_mirage_tcp__14 = lazy (
-  let __tcpip_stack_direct_makev4v6__13 =
-                                         Lazy.force tcpip_stack_direct_makev4v6__13 in
+  let __tcpip_stack_direct_makev4v6__13 = Lazy.force tcpip_stack_direct_makev4v6__13 in
   __tcpip_stack_direct_makev4v6__13 >>= fun _tcpip_stack_direct_makev4v6__13 ->
+# 14 "lib/mirage/impl/mirage_impl_conduit.ml"
   Lwt.return _tcpip_stack_direct_makev4v6__13
 
-  )
+);;
+# 187 "mirage/main.ml"
 
 let conduit_mirage_tls__15 = lazy (
   let __conduit_mirage_tcp__14 = Lazy.force conduit_mirage_tcp__14 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   __conduit_mirage_tcp__14 >>= fun _conduit_mirage_tcp__14 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
+# 23 "lib/mirage/impl/mirage_impl_conduit.ml"
   Lwt.return _conduit_mirage_tcp__14
 
-  )
+);;
+# 198 "mirage/main.ml"
 
 let app_make__16 = lazy (
   let __conduit_mirage_tls__15 = Lazy.force conduit_mirage_tls__15 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   __conduit_mirage_tls__15 >>= fun _conduit_mirage_tls__15 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
   App_make__16.start _conduit_mirage_tls__15 _mirage_crypto_rng_mirage_make__3
-  )
+);;
+# 207 "mirage/main.ml"
 
 let sys__17 = lazy (
+# 24 "lib/functoria/argv.ml"
   return Sys.argv
-  )
+);;
+# 213 "mirage/main.ml"
 
 let key_gen__18 = lazy (
   let __sys__17 = Lazy.force sys__17 in
   __sys__17 >>= fun _sys__17 ->
+# 51 "lib/functoria/job.ml"
   return Functoria_runtime.(with_argv (runtime_args ()) "foo" _sys__17)
-  )
+);;
+# 221 "mirage/main.ml"
 
 let functoria_runtime__19 = lazy (
   let __app_make__16 = Lazy.force app_make__16 in
   let __key_gen__18 = Lazy.force key_gen__18 in
   __app_make__16 >>= fun _app_make__16 ->
   __key_gen__18 >>= fun _key_gen__18 ->
+# 27 "test/mirage/random-unix/test.ml"
   return ()
-  )
+);;
+# 231 "mirage/main.ml"
 
 let () =
-  let t =
-  Lazy.force functoria_runtime__19
-  in run t
+  let t = Lazy.force functoria_runtime__19 in
+  run t
+;;

--- a/test/mirage/random-unix/test.ml
+++ b/test/mirage/random-unix/test.ml
@@ -24,13 +24,13 @@ let test () =
   in
 
   let job =
-    let connect _ _ _ = "return ()" in
+    let connect _ _ _ = code ~pos:__POS__ "return ()" in
     Functoria.impl
       ~runtime_args:Runtime_arg.[ v opt; v opt_all; v flag; v required ]
       ~extra_deps:[ dep job; dep init ]
       "Functoria_runtime" ~connect Functoria.job
   in
-  Functoria_test.run context job
+  Functoria_test.run ~project_name:"mirage" context job
 
 let () =
   match Functoria.Action.run (test ()) with

--- a/test/mirage/random-xen/main.ml.expected
+++ b/test/mirage/random-xen/main.ml.expected
@@ -4,81 +4,78 @@ let (>>=) x f = f x
 let return x = x
 let run x = x
 
-module Mirage_crypto_rng_mirage_make__3 =
-  Mirage_crypto_rng_mirage.Make(Xen_os.Time)(Mclock)
+module Mirage_crypto_rng_mirage_make__3 = Mirage_crypto_rng_mirage.Make(Xen_os.Time)(Mclock)
 
 module Ethernet_make__5 = Ethernet.Make(Netif)
 
 module Arp_make__6 = Arp.Make(Ethernet_make__5)(Xen_os.Time)
 
-module Static_ipv4_make__7 =
-  Static_ipv4.Make(Mirage_crypto_rng_mirage_make__3)(Mclock)
-  (Ethernet_make__5)(Arp_make__6)
+module Static_ipv4_make__7 = Static_ipv4.Make(Mirage_crypto_rng_mirage_make__3)(Mclock)(Ethernet_make__5)(Arp_make__6)
 
-module Ipv6_make__8 = Ipv6.Make(Netif)(Ethernet_make__5)
-  (Mirage_crypto_rng_mirage_make__3)(Xen_os.Time)(Mclock)
+module Ipv6_make__8 = Ipv6.Make(Netif)(Ethernet_make__5)(Mirage_crypto_rng_mirage_make__3)(Xen_os.Time)(Mclock)
 
-module Tcpip_stack_direct_ipv4v6__9 =
-  Tcpip_stack_direct.IPV4V6(Static_ipv4_make__7)(Ipv6_make__8)
+module Tcpip_stack_direct_ipv4v6__9 = Tcpip_stack_direct.IPV4V6(Static_ipv4_make__7)(Ipv6_make__8)
 
 module Icmpv4_make__10 = Icmpv4.Make(Static_ipv4_make__7)
 
-module Udp_make__11 = Udp.Make(Tcpip_stack_direct_ipv4v6__9)
-  (Mirage_crypto_rng_mirage_make__3)
+module Udp_make__11 = Udp.Make(Tcpip_stack_direct_ipv4v6__9)(Mirage_crypto_rng_mirage_make__3)
 
-module Tcp_flow_make__12 = Tcp.Flow.Make(Tcpip_stack_direct_ipv4v6__9)
-  (Xen_os.Time)(Mclock)(Mirage_crypto_rng_mirage_make__3)
+module Tcp_flow_make__12 = Tcp.Flow.Make(Tcpip_stack_direct_ipv4v6__9)(Xen_os.Time)(Mclock)(Mirage_crypto_rng_mirage_make__3)
 
-module Tcpip_stack_direct_makev4v6__13 =
-  Tcpip_stack_direct.MakeV4V6(Xen_os.Time)(Mirage_crypto_rng_mirage_make__3)
-  (Netif)(Ethernet_make__5)(Arp_make__6)(Tcpip_stack_direct_ipv4v6__9)
-  (Icmpv4_make__10)(Udp_make__11)(Tcp_flow_make__12)
+module Tcpip_stack_direct_makev4v6__13 = Tcpip_stack_direct.MakeV4V6(Xen_os.Time)(Mirage_crypto_rng_mirage_make__3)(Netif)(Ethernet_make__5)(Arp_make__6)(Tcpip_stack_direct_ipv4v6__9)(Icmpv4_make__10)(Udp_make__11)(Tcp_flow_make__12)
 
-module Conduit_mirage_tcp__14 =
-  Conduit_mirage.TCP(Tcpip_stack_direct_makev4v6__13)
+module Conduit_mirage_tcp__14 = Conduit_mirage.TCP(Tcpip_stack_direct_makev4v6__13)
 
 module Conduit_mirage_tls__15 = Conduit_mirage.TLS(Conduit_mirage_tcp__14)
 
-module App_make__16 = App.Make(Conduit_mirage_tls__15)
-  (Mirage_crypto_rng_mirage_make__3)
+module App_make__16 = App.Make(Conduit_mirage_tls__15)(Mirage_crypto_rng_mirage_make__3)
 
 let xen_os_time__1 = lazy (
   return ()
-  )
+);;
+# 36 "mirage/main.ml"
 
 let mclock__2 = lazy (
   return ()
-  )
+);;
+# 41 "mirage/main.ml"
 
 let mirage_crypto_rng_mirage_make__3 = lazy (
   let __xen_os_time__1 = Lazy.force xen_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
   __xen_os_time__1 >>= fun _xen_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
+# 18 "lib/mirage/impl/mirage_impl_random.ml"
   Mirage_crypto_rng_mirage_make__3.initialize (module Mirage_crypto_rng.Fortuna)
-  )
+);;
+# 51 "mirage/main.ml"
 
 let netif__4 = lazy (
+# 31 "lib/mirage/impl/mirage_impl_network.ml"
   Netif.connect (Key_gen.interface ())
-  )
+);;
+# 57 "mirage/main.ml"
 
 let ethernet_make__5 = lazy (
   let __netif__4 = Lazy.force netif__4 in
   __netif__4 >>= fun _netif__4 ->
+# 13 "lib/mirage/impl/mirage_impl_ethernet.ml"
   Ethernet_make__5.connect _netif__4
-  )
+);;
+# 65 "mirage/main.ml"
 
 let arp_make__6 = lazy (
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
   let __xen_os_time__1 = Lazy.force xen_os_time__1 in
   __ethernet_make__5 >>= fun _ethernet_make__5 ->
   __xen_os_time__1 >>= fun _xen_os_time__1 ->
+# 16 "lib/mirage/impl/mirage_impl_arpv4.ml"
   Arp_make__6.connect _ethernet_make__5
-  )
+);;
+# 75 "mirage/main.ml"
 
 let static_ipv4_make__7 = lazy (
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   let __mclock__2 = Lazy.force mclock__2 in
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
   let __arp_make__6 = Lazy.force arp_make__6 in
@@ -86,16 +83,17 @@ let static_ipv4_make__7 = lazy (
   __mclock__2 >>= fun _mclock__2 ->
   __ethernet_make__5 >>= fun _ethernet_make__5 ->
   __arp_make__6 >>= fun _arp_make__6 ->
+# 42 "lib/mirage/impl/mirage_impl_ip.ml"
   Static_ipv4_make__7.connect ~cidr:(Key_gen.ipv4 ())
                            ?gateway:(Key_gen.ipv4_gateway ())
                            _ethernet_make__5 _arp_make__6
-  )
+);;
+# 91 "mirage/main.ml"
 
 let ipv6_make__8 = lazy (
   let __netif__4 = Lazy.force netif__4 in
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   let __xen_os_time__1 = Lazy.force xen_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
   __netif__4 >>= fun _netif__4 ->
@@ -103,61 +101,65 @@ let ipv6_make__8 = lazy (
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
   __xen_os_time__1 >>= fun _xen_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
+# 103 "lib/mirage/impl/mirage_impl_ip.ml"
   Ipv6_make__8.connect ~handle_ra:(Key_gen.accept_router_advertisements ())
                     ?cidr:(Key_gen.ipv6 ())
                     ?gateway:(Key_gen.ipv6_gateway ()) _netif__4
                     _ethernet_make__5
-  )
+);;
+# 110 "mirage/main.ml"
 
 let tcpip_stack_direct_ipv4v6__9 = lazy (
   let __static_ipv4_make__7 = Lazy.force static_ipv4_make__7 in
   let __ipv6_make__8 = Lazy.force ipv6_make__8 in
   __static_ipv4_make__7 >>= fun _static_ipv4_make__7 ->
   __ipv6_make__8 >>= fun _ipv6_make__8 ->
+# 133 "lib/mirage/impl/mirage_impl_ip.ml"
   Tcpip_stack_direct_ipv4v6__9.connect ~ipv4_only:(Key_gen.ipv4_only ())
                                     ~ipv6_only:(Key_gen.ipv6_only ())
                                     _static_ipv4_make__7 _ipv6_make__8
-  )
+);;
+# 122 "mirage/main.ml"
 
 let icmpv4_make__10 = lazy (
   let __static_ipv4_make__7 = Lazy.force static_ipv4_make__7 in
   __static_ipv4_make__7 >>= fun _static_ipv4_make__7 ->
+# 14 "lib/mirage/impl/mirage_impl_icmp.ml"
   Icmpv4_make__10.connect _static_ipv4_make__7
-  )
+);;
+# 130 "mirage/main.ml"
 
 let udp_make__11 = lazy (
-  let __tcpip_stack_direct_ipv4v6__9 =
-                                      Lazy.force tcpip_stack_direct_ipv4v6__9 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __tcpip_stack_direct_ipv4v6__9 = Lazy.force tcpip_stack_direct_ipv4v6__9 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   __tcpip_stack_direct_ipv4v6__9 >>= fun _tcpip_stack_direct_ipv4v6__9 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
+# 18 "lib/mirage/impl/mirage_impl_udp.ml"
   Udp_make__11.connect _tcpip_stack_direct_ipv4v6__9
-  )
+);;
+# 140 "mirage/main.ml"
 
 let tcp_flow_make__12 = lazy (
-  let __tcpip_stack_direct_ipv4v6__9 =
-                                      Lazy.force tcpip_stack_direct_ipv4v6__9 in
+  let __tcpip_stack_direct_ipv4v6__9 = Lazy.force tcpip_stack_direct_ipv4v6__9 in
   let __xen_os_time__1 = Lazy.force xen_os_time__1 in
   let __mclock__2 = Lazy.force mclock__2 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   __tcpip_stack_direct_ipv4v6__9 >>= fun _tcpip_stack_direct_ipv4v6__9 ->
   __xen_os_time__1 >>= fun _xen_os_time__1 ->
   __mclock__2 >>= fun _mclock__2 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
+# 21 "lib/mirage/impl/mirage_impl_tcp.ml"
   Tcp_flow_make__12.connect _tcpip_stack_direct_ipv4v6__9
-  )
+);;
+# 154 "mirage/main.ml"
 
 let tcpip_stack_direct_makev4v6__13 = lazy (
   let __xen_os_time__1 = Lazy.force xen_os_time__1 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   let __netif__4 = Lazy.force netif__4 in
   let __ethernet_make__5 = Lazy.force ethernet_make__5 in
   let __arp_make__6 = Lazy.force arp_make__6 in
-  let __tcpip_stack_direct_ipv4v6__9 =
-                                      Lazy.force tcpip_stack_direct_ipv4v6__9 in
+  let __tcpip_stack_direct_ipv4v6__9 = Lazy.force tcpip_stack_direct_ipv4v6__9 in
   let __icmpv4_make__10 = Lazy.force icmpv4_make__10 in
   let __udp_make__11 = Lazy.force udp_make__11 in
   let __tcp_flow_make__12 = Lazy.force tcp_flow_make__12 in
@@ -170,37 +172,41 @@ let tcpip_stack_direct_makev4v6__13 = lazy (
   __icmpv4_make__10 >>= fun _icmpv4_make__10 ->
   __udp_make__11 >>= fun _udp_make__11 ->
   __tcp_flow_make__12 >>= fun _tcp_flow_make__12 ->
+# 34 "lib/mirage/impl/mirage_impl_stack.ml"
   Tcpip_stack_direct_makev4v6__13.connect _netif__4 _ethernet_make__5 _arp_make__6 _tcpip_stack_direct_ipv4v6__9 _icmpv4_make__10 _udp_make__11 _tcp_flow_make__12
-  )
+);;
+# 178 "mirage/main.ml"
 
 let conduit_mirage_tcp__14 = lazy (
-  let __tcpip_stack_direct_makev4v6__13 =
-                                         Lazy.force tcpip_stack_direct_makev4v6__13 in
+  let __tcpip_stack_direct_makev4v6__13 = Lazy.force tcpip_stack_direct_makev4v6__13 in
   __tcpip_stack_direct_makev4v6__13 >>= fun _tcpip_stack_direct_makev4v6__13 ->
+# 14 "lib/mirage/impl/mirage_impl_conduit.ml"
   Lwt.return _tcpip_stack_direct_makev4v6__13
 
-  )
+);;
+# 187 "mirage/main.ml"
 
 let conduit_mirage_tls__15 = lazy (
   let __conduit_mirage_tcp__14 = Lazy.force conduit_mirage_tcp__14 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   __conduit_mirage_tcp__14 >>= fun _conduit_mirage_tcp__14 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
+# 23 "lib/mirage/impl/mirage_impl_conduit.ml"
   Lwt.return _conduit_mirage_tcp__14
 
-  )
+);;
+# 198 "mirage/main.ml"
 
 let app_make__16 = lazy (
   let __conduit_mirage_tls__15 = Lazy.force conduit_mirage_tls__15 in
-  let __mirage_crypto_rng_mirage_make__3 =
-                                          Lazy.force mirage_crypto_rng_mirage_make__3 in
+  let __mirage_crypto_rng_mirage_make__3 = Lazy.force mirage_crypto_rng_mirage_make__3 in
   __conduit_mirage_tls__15 >>= fun _conduit_mirage_tls__15 ->
   __mirage_crypto_rng_mirage_make__3 >>= fun _mirage_crypto_rng_mirage_make__3 ->
   App_make__16.start _conduit_mirage_tls__15 _mirage_crypto_rng_mirage_make__3
-  )
+);;
+# 207 "mirage/main.ml"
 
 let () =
-  let t =
-  Lazy.force app_make__16
-  in run t
+  let t = Lazy.force app_make__16 in
+  run t
+;;

--- a/test/mirage/random-xen/test.ml
+++ b/test/mirage/random-xen/test.ml
@@ -17,7 +17,7 @@ let test () =
   let job =
     main "App.Make" sigs $ conduit_direct ~tls:true stackv4v6 $ default_random
   in
-  Functoria_test.run ~keys context job
+  Functoria_test.run ~keys ~project_name:"mirage" context job
 
 let () =
   match Functoria.Action.run (test ()) with


### PR DESCRIPTION
This is kept optional for the `main` function at the moment, not to break every unikernel out there. We can make this mandatory if needed in the future.

Extracted from #1493 

To be tested with https://github.com/mirage/mirage-skeleton/pull/385

It would be nice to test what happens when users get the wrong number of functor parameters- where it breaks and whether the location of the error message is correct. i.e. check that we haven't actually made things worse in the main case (even if it is now much better when the device code got their connect function wrong -- but this is not supposed to happen when users use the existing devices!)