### PR TITLE
bump min ocaml-solo5 to avoid fast memory usage error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,8 @@
       ...
     ```
 
+- bump minimal ocaml-solo5 version bound to 0.8.2 to avoid fast memory usage
+  error (#1507, @palainp)
 - FEATURE: install `mirage` in the local duniverse. This allows `config.ml`
   and `unikernel.ml` to be built simultaneously so that tools like merlin can
   work on both seamlessly. This is a follow-up of #1475 (#1515, @samoht)

--- a/lib/devices/target.ml
+++ b/lib/devices/target.ml
@@ -215,7 +215,7 @@ module Solo5 = struct
 
   let build_packages =
     [
-      Functoria.package ~min:"0.8.1" ~max:"0.9.0" ~scope:`Switch ~build:true
+      Functoria.package ~min:"0.8.2" ~max:"0.9.0" ~scope:`Switch ~build:true
         "ocaml-solo5";
       Functoria.package ~min:"0.7.5" ~max:"0.9.0" ~scope:`Switch ~build:true
         "solo5";

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -29,7 +29,7 @@ Query opam file
     "mirage-logs" { ?monorepo & >= "2.0.0" & < "3.0.0" }
     "mirage-runtime" { ?monorepo & >= "4.4.0" & < "4.5.0" }
     "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
-    "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
+    "ocaml-solo5" { build & >= "0.8.2" & < "0.9.0" }
     "opam-monorepo" { build & >= "0.3.2" }
     "solo5" { build & >= "0.7.5" & < "0.9.0" }
   ]
@@ -59,7 +59,7 @@ Query packages
   "mirage-logs" { ?monorepo & >= "2.0.0" & < "3.0.0" }
   "mirage-runtime" { ?monorepo & >= "4.4.0" & < "4.5.0" }
   "mirage-solo5" { ?monorepo & >= "0.9.0" & < "0.10.0" }
-  "ocaml-solo5" { build & >= "0.8.1" & < "0.9.0" }
+  "ocaml-solo5" { build & >= "0.8.2" & < "0.9.0" }
   "opam-monorepo" { build & >= "0.3.2" }
   "solo5" { build & >= "0.7.5" & < "0.9.0" }
 


### PR DESCRIPTION
Dear devs, this PR is needed to avoid the unwanted selection of `ocaml-solo5` where an issue about fast memory usage value was present (https://github.com/mirage/ocaml-solo5/releases/tag/v0.8.2).
Best.