### PR TITLE
functoria: Quote Runtime_arg.call

### DIFF
--- a/lib/functoria/runtime_arg.ml
+++ b/lib/functoria/runtime_arg.ml
@@ -66,5 +66,5 @@ let serialize ~runtime_modname fmt (Any k) =
   Format.fprintf fmt "let %s__key = %s.register @@@@\n%a  @[<v2>%s@]\n;;\n"
     (ocaml_name k.name) runtime_modname pp_pos k.pos k.code
 
-let call fmt (Any k) = Fmt.pf fmt "%s__key ()" (ocaml_name k.name)
+let call fmt (Any k) = Fmt.pf fmt "(%s__key ())" (ocaml_name k.name)
 let var_name (Any k) = ocaml_name k.name

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -117,30 +117,30 @@ Configure the project for Unix:
   # 95 "mirage/main.ml"
   
   let printexc__3 = lazy (
-    let _backtrace = backtrace__key () in
+    let _backtrace = (backtrace__key ()) in
   # 397 "lib/mirage.ml"
     return (Printexc.record_backtrace _backtrace)
   );;
   # 102 "mirage/main.ml"
   
   let hashtbl__4 = lazy (
-    let _randomize_hashtables = randomize_hashtables__key () in
+    let _randomize_hashtables = (randomize_hashtables__key ()) in
   # 406 "lib/mirage.ml"
     return (if _randomize_hashtables then Hashtbl.randomize ())
   );;
   # 109 "mirage/main.ml"
   
   let gc__5 = lazy (
-    let _allocation_policy = allocation_policy__key () in
-    let _minor_heap_size = minor_heap_size__key () in
-    let _major_heap_increment = major_heap_increment__key () in
-    let _space_overhead = space_overhead__key () in
-    let _max_space_overhead = max_space_overhead__key () in
-    let _gc_verbosity = gc_verbosity__key () in
-    let _gc_window_size = gc_window_size__key () in
-    let _custom_major_ratio = custom_major_ratio__key () in
-    let _custom_minor_ratio = custom_minor_ratio__key () in
-    let _custom_minor_max_size = custom_minor_max_size__key () in
+    let _allocation_policy = (allocation_policy__key ()) in
+    let _minor_heap_size = (minor_heap_size__key ()) in
+    let _major_heap_increment = (major_heap_increment__key ()) in
+    let _space_overhead = (space_overhead__key ()) in
+    let _max_space_overhead = (max_space_overhead__key ()) in
+    let _gc_verbosity = (gc_verbosity__key ()) in
+    let _gc_window_size = (gc_window_size__key ()) in
+    let _custom_major_ratio = (custom_major_ratio__key ()) in
+    let _custom_minor_ratio = (custom_minor_ratio__key ()) in
+    let _custom_minor_max_size = (custom_minor_max_size__key ()) in
   # 458 "lib/mirage.ml"
     return (
   let open Gc in
@@ -160,7 +160,7 @@ Configure the project for Unix:
   # 138 "mirage/main.ml"
   
   let mirage_runtime__6 = lazy (
-    let _delay = delay__key () in
+    let _delay = (delay__key ()) in
   # 302 "lib/mirage.ml"
     Unix_os.Time.sleep_ns (Duration.of_sec _delay)
   );;
@@ -174,7 +174,7 @@ Configure the project for Unix:
   let mirage_logs_make__8 = lazy (
     let __pclock__7 = Lazy.force pclock__7 in
     __pclock__7 >>= fun _pclock__7 ->
-    let _logs = logs__key () in
+    let _logs = (logs__key ()) in
   # 22 "lib/devices/reporter.ml"
     let reporter = Mirage_logs_make__8.create () in
     Mirage_runtime.set_level ~default:(Some Logs.Info) _logs;
@@ -241,6 +241,7 @@ Configure the project for Unix:
     Lazy.force mirage_runtime__13 in
     run t
   ;;
+
   $ mirage clean
 
 
@@ -368,30 +369,30 @@ Configure the project for Xen:
   # 95 "mirage/main.ml"
   
   let printexc__3 = lazy (
-    let _backtrace = backtrace__key () in
+    let _backtrace = (backtrace__key ()) in
   # 397 "lib/mirage.ml"
     return (Printexc.record_backtrace _backtrace)
   );;
   # 102 "mirage/main.ml"
   
   let hashtbl__4 = lazy (
-    let _randomize_hashtables = randomize_hashtables__key () in
+    let _randomize_hashtables = (randomize_hashtables__key ()) in
   # 406 "lib/mirage.ml"
     return (if _randomize_hashtables then Hashtbl.randomize ())
   );;
   # 109 "mirage/main.ml"
   
   let gc__5 = lazy (
-    let _allocation_policy = allocation_policy__key () in
-    let _minor_heap_size = minor_heap_size__key () in
-    let _major_heap_increment = major_heap_increment__key () in
-    let _space_overhead = space_overhead__key () in
-    let _max_space_overhead = max_space_overhead__key () in
-    let _gc_verbosity = gc_verbosity__key () in
-    let _gc_window_size = gc_window_size__key () in
-    let _custom_major_ratio = custom_major_ratio__key () in
-    let _custom_minor_ratio = custom_minor_ratio__key () in
-    let _custom_minor_max_size = custom_minor_max_size__key () in
+    let _allocation_policy = (allocation_policy__key ()) in
+    let _minor_heap_size = (minor_heap_size__key ()) in
+    let _major_heap_increment = (major_heap_increment__key ()) in
+    let _space_overhead = (space_overhead__key ()) in
+    let _max_space_overhead = (max_space_overhead__key ()) in
+    let _gc_verbosity = (gc_verbosity__key ()) in
+    let _gc_window_size = (gc_window_size__key ()) in
+    let _custom_major_ratio = (custom_major_ratio__key ()) in
+    let _custom_minor_ratio = (custom_minor_ratio__key ()) in
+    let _custom_minor_max_size = (custom_minor_max_size__key ()) in
   # 458 "lib/mirage.ml"
     return (
   let open Gc in
@@ -411,7 +412,7 @@ Configure the project for Xen:
   # 138 "mirage/main.ml"
   
   let mirage_runtime__6 = lazy (
-    let _delay = delay__key () in
+    let _delay = (delay__key ()) in
   # 302 "lib/mirage.ml"
     Xen_os.Time.sleep_ns (Duration.of_sec _delay)
   );;
@@ -425,7 +426,7 @@ Configure the project for Xen:
   let mirage_logs_make__8 = lazy (
     let __pclock__7 = Lazy.force pclock__7 in
     __pclock__7 >>= fun _pclock__7 ->
-    let _logs = logs__key () in
+    let _logs = (logs__key ()) in
   # 22 "lib/devices/reporter.ml"
     let reporter = Mirage_logs_make__8.create () in
     Mirage_runtime.set_level ~default:(Some Logs.Info) _logs;
@@ -492,4 +493,5 @@ Configure the project for Xen:
     Lazy.force mirage_runtime__13 in
     run t
   ;;
+
   $ mirage clean


### PR DESCRIPTION
Fixes codes that use an arg call as an argument to a function:

    code ~pos:__POS__ "f ~arg:%a"
      Runtime_arg.call my_arg