### PR TITLE
add the options to specify "host" (and "socket") for the host system network stack

### DIFF
--- a/lib/devices/key.ml
+++ b/lib/devices/key.ml
@@ -133,8 +133,12 @@ let dhcp ?group () =
   let doc = Fmt.str "Enable dhcp for %a." pp_group group in
   configure_key ~doc ?group ~default:false Arg.bool "dhcp"
 
-let net ?group () : [ `Socket | `Direct ] option Key.key =
-  let enum = [ ("socket", `Socket); ("direct", `Direct) ] in
+let net ?group () : [ `Host | `OCaml ] option Key.key =
+  let enum =
+    [
+      ("host", `Host); ("socket", `Host); ("direct", `OCaml); ("ocaml", `OCaml);
+    ]
+  in
   let conv = Cmdliner.Arg.enum enum in
   let doc =
     Fmt.str "Use %s group for %a."

--- a/lib/devices/key.mli
+++ b/lib/devices/key.mli
@@ -68,5 +68,5 @@ val block : ?group:string -> unit -> [ `XenstoreId | `BlockFile | `Ramdisk ] key
 val dhcp : ?group:string -> unit -> bool key
 (** Enable dhcp. Is either [true] or [false]. *)
 
-val net : ?group:string -> unit -> [ `Direct | `Socket ] option key
-(** The type of stack. Is either ["direct"] or ["socket"]. *)
+val net : ?group:string -> unit -> [ `OCaml | `Host ] option key
+(** The type of stack. Is either ["ocaml"] or ["host"]. *)

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -111,7 +111,7 @@ let generic_stackv4v6 ?group ?ipv6_config ?ipv4_config
   let choose target net dhcp =
     match (target, net, dhcp) with
     | `Qubes, _, _ -> `Qubes
-    | _, Some `Socket, _ -> `Socket
+    | _, Some `Host, _ -> `Socket
     | _, _, true -> `Dhcp
     | (`Unix | `MacOSX), None, false -> `Socket
     | _, _, _ -> `Static

--- a/lib/devices/stack.mli
+++ b/lib/devices/stack.mli
@@ -34,7 +34,7 @@ val generic_stackv4v6 :
   ?ipv6_config:Ip.ipv6_config ->
   ?ipv4_config:Ip.ipv4_config ->
   ?dhcp_key:bool value ->
-  ?net_key:[ `Direct | `Socket ] option value ->
+  ?net_key:[ `OCaml | `Host ] option value ->
   ?tcp:Tcp.tcpv4v6 impl ->
   Network.network impl ->
   stackv4v6 impl

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -604,7 +604,7 @@ val generic_stackv4v6 :
   ?ipv6_config:ipv6_config ->
   ?ipv4_config:ipv4_config ->
   ?dhcp_key:bool value ->
-  ?net_key:[ `Direct | `Socket ] option value ->
+  ?net_key:[ `OCaml | `Host ] option value ->
   ?tcp:tcpv4v6 impl ->
   network impl ->
   stackv4v6 impl


### PR DESCRIPTION
the native ocaml stack can be used by passing "OCaml" or "direct".

over time, the confusion of "direct" has escalated. it is kept for backwards compatibility

//cc @pitag-ha