### PR TITLE
mirage-runtime: provide sleeper storage

### DIFF
--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -250,6 +250,16 @@ let at_exit f = add f exit_hooks
 let at_leave_iter f = add f leave_iter_hooks
 let at_enter_iter f = add f enter_iter_hooks
 
+type sleep = { time : int64; mutable canceled : bool; thread : unit Lwt.u }
+
+let new_sleepers = ref []
+let add_new_sleeper s = new_sleepers := s :: !new_sleepers
+
+let get_new_sleepers () =
+  let sl = !new_sleepers in
+  new_sleepers := [];
+  sl
+
 let with_argv =
   Functoria_runtime.with_argv
     ~sections:

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -131,6 +131,19 @@ val run_leave_iter_hooks : unit -> unit
 (** [run_leave_iter_hooks ()] call the sequence of hooks registered with
     {!at_leave_iter} in sequence. *)
 
+(** {2 Sleepers} *)
+
+(** This is mainly for for developers implementing new targets. *)
+
+type sleep = { time : int64; mutable canceled : bool; thread : unit Lwt.u }
+
+val add_new_sleeper : sleep -> unit
+(** [add_new_sleeper sleep] adds [sleep] to the list of new sleepers. *)
+
+val get_new_sleepers : unit -> sleep list
+(** [get_new_sleepers ()] retrieves all new sleepers. Afterwards the list of new
+    sleepers will be empty. *)
+
 (** {2 Exit Codes} *)
 
 val argument_error : int


### PR DESCRIPTION
The purpose of this storage is to be able to move the `Time.sleep_ns` functionality to a different place than mirage-solo5/mirage-xen. Since this is a very different change than other things in #1521, I'd appreciate this to be reviewed separately.

As mentioned, this is a prerequisite to solve #1513 and has been carved out of #1521.