### PR TITLE
fix generated opam file - the build rule is now `make "-Csubdir" "build"

### DIFF
--- a/lib/functoria/info.ml
+++ b/lib/functoria/info.ml
@@ -126,7 +126,7 @@ let pp verbose ppf ({ name; keys; context; output; _ } as t) =
 let t =
   let i =
     v ~config_file:(Fpath.v "config.ml") ~packages:[] ~keys:[] ~runtime_args:[]
-      ~build_cmd:"dummy" ~context:Context.empty ~src:`None "dummy"
-      ~project_name:"dummy"
+      ~build_cmd:(fun _ -> "dummy")
+      ~context:Context.empty ~src:`None "dummy" ~project_name:"dummy"
   in
   Type.v i

--- a/lib/functoria/info.mli
+++ b/lib/functoria/info.mli
@@ -75,7 +75,7 @@ val v :
   ?configure_cmd:string ->
   ?pre_build_cmd:(Fpath.t option -> string) ->
   ?lock_location:(Fpath.t option -> string -> string) ->
-  build_cmd:string ->
+  build_cmd:(Fpath.t option -> string) ->
   src:[ `Auto | `None | `Some of string ] ->
   project_name:string ->
   string ->

--- a/lib/functoria/opam.mli
+++ b/lib/functoria/opam.mli
@@ -22,7 +22,7 @@ val v :
   ?configure:string ->
   ?pre_build:(Fpath.t option -> string) ->
   ?lock_location:(Fpath.t option -> string -> string) ->
-  ?build:string ->
+  ?build:(Fpath.t option -> string) ->
   ?install:Install.t ->
   ?extra_repo:(string * string) list ->
   ?depends:Package.t list ->

--- a/test/mirage/action/test.ml
+++ b/test/mirage/action/test.ml
@@ -14,7 +14,8 @@ let print_banner s =
   print_newline ()
 
 let info context =
-  Info.v ~packages:[] ~keys:[] ~runtime_args:[] ~build_cmd:"mirage build"
+  Info.v ~packages:[] ~keys:[] ~runtime_args:[]
+    ~build_cmd:(fun _ -> "make build")
     ~context ~src:`None ~project_name:"test" "NAME"
 
 let test target =

--- a/test/mirage/action/test.ml
+++ b/test/mirage/action/test.ml
@@ -15,7 +15,10 @@ let print_banner s =
 
 let info context =
   Info.v ~packages:[] ~keys:[] ~runtime_args:[]
-    ~build_cmd:(fun _ -> "make build")
+    ~build_cmd:(fun sub ->
+      Fmt.str "make%a build"
+        Fmt.(option ~none:(any "") (any " " ++ Fpath.pp))
+        sub)
     ~context ~src:`None ~project_name:"test" "NAME"
 
 let test target =

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -14,7 +14,7 @@ Query opam file
   fetched.
   """
   
-  build: ["sh" "-exc" "mirage build"]
+  build: [make "build"]
   
   install: [
     [ "cp" "dist/noop.hvt" "%{bin}%/noop.hvt" ]

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -18,7 +18,7 @@ Query opam file
   fetched.
   """
   
-  build: ["sh" "-exc" "mirage build"]
+  build: [make "build"]
   
   install: [
     [ "cp" "dist/noop" "%{bin}%/noop" ]


### PR DESCRIPTION
Previously, `sh -exc 'cd subdir && mirage build'` was used in the generated opam file as build command. Since #1404 got merged and released, the mirage build subcommand does no longer exist.

In the opam file, now "make build" is used instead.