### PR TITLE
Consolidate mirage bootvar

### DIFF
--- a/lib/devices/argv.ml
+++ b/lib/devices/argv.ml
@@ -2,24 +2,22 @@ open Functoria.DSL
 
 let ty = Functoria.argv
 
-let argv_unix =
-  let packages = [ package ~min:"0.1.0" ~max:"0.2.0" "mirage-bootvar-unix" ] in
-  let connect _ _ _ = code ~pos:__POS__ "Bootvar.argv ()" in
-  impl ~packages ~connect "Bootvar" ty
-
-let argv_solo5 =
-  let packages = [ package ~min:"0.6.0" ~max:"0.7.0" "mirage-bootvar-solo5" ] in
-  let connect _ _ _ = code ~pos:__POS__ "Bootvar.argv ()" in
-  impl ~packages ~connect "Bootvar" ty
-
 let no_argv =
   let connect _ _ _ = code ~pos:__POS__ "return [|\"\"|]" in
   impl ~connect "Mirage_runtime" ty
 
-let argv_xen =
-  let packages = [ package ~min:"0.8.0" ~max:"0.9.0" "mirage-bootvar-xen" ] in
-  let connect _ _ _ = code ~pos:__POS__ "Bootvar.argv ()" in
-  impl ~packages ~connect "Bootvar" ty
+let impl sublib =
+  let packages =
+    [
+      package ~min:"1.0.0" ~max:"2.0.0" ~sublibs:[ ""; sublib ] "mirage-bootvar";
+    ]
+  in
+  let connect _ _ _ = code ~pos:__POS__ "return (Mirage_bootvar.argv ())" in
+  impl ~packages ~connect "Mirage_bootvar" ty
+
+let argv_unix = impl "unix"
+let argv_solo5 = impl "solo5"
+let argv_xen = impl "xen"
 
 let default_argv =
   match_impl

--- a/lib/functoria/package.ml
+++ b/lib/functoria/package.ml
@@ -86,7 +86,8 @@ let v ?(scope = `Monorepo) ?(build = false) ?sublibs ?libs ?min ?max ?pin
   let libs =
     match (sublibs, libs) with
     | None, None -> [ name ]
-    | Some xs, None -> List.map (fun x -> name ^ "." ^ x) xs
+    | Some xs, None ->
+        List.map (fun x -> if x = "" then name else name ^ "." ^ x) xs
     | None, Some a -> a
     | Some _, Some _ ->
         Fmt.invalid_arg

--- a/lib/functoria/package.mli
+++ b/lib/functoria/package.mli
@@ -41,11 +41,12 @@ val v :
 (** [v ~scope ~build ~sublibs ~libs ~min ~max ~pin opam] is a [package]. [Build]
     indicates a build-time dependency only, defaults to [false]. The library
     name is by default the same as [opam], you can specify [~sublibs] to add
-    additional sublibraries (e.g. [~sublibs:["mirage"] "foo"] will result in the
-    library names [["foo"; "foo.mirage"]]. In case the library name is disjoint
-    (or empty), use [~libs]. Specifying both [~libs] and [~sublibs] leads to an
-    invalid argument. Version constraints are given as [min] (inclusive) and
-    [max] (exclusive). If [pin] is provided, a
+    sublibraries (e.g. [~sublibs:["mirage"] "foo"] will result in the library
+    name [["foo.mirage"]], and [~sublibs:[""; "mirage"] "foo"] will result in
+    the library names [["foo";"foo.mirage"]] ). In case the library name is
+    disjoint (or empty), use [~libs]. Specifying both [~libs] and [~sublibs]
+    leads to an invalid argument. Version constraints are given as [min]
+    (inclusive) and [max] (exclusive). If [pin] is provided, a
     {{:https://opam.ocaml.org/doc/Manual.html#opamfield-pin-depends}
       pin-depends} is generated, [pin_version] is ["dev"] by default. [~scope]
     specifies the installation location of the package. *)

--- a/test/mirage/describe/run.t
+++ b/test/mirage/describe/run.t
@@ -70,9 +70,9 @@ Describe before configure (no eval)
                 53 [label="gc__53\nGc\n", shape="box"];
                 54 [label="hashtbl__54\nHashtbl\n", shape="box"];
                 55 [label="printexc__55\nPrintexc\n", shape="box"];
-                56 [label="bootvar__56\nBootvar\n", shape="box"];
-                57 [label="bootvar__57\nBootvar\n", shape="box"];
-                58 [label="bootvar__58\nBootvar\n", shape="box"];
+                56 [label="mirage_bootvar__56\nMirage_bootvar\n", shape="box"];
+                57 [label="mirage_bootvar__57\nMirage_bootvar\n", shape="box"];
+                58 [label="mirage_bootvar__58\nMirage_bootvar\n", shape="box"];
                 59 [label="If\ntarget"];
                 60 [label="struct_end__60\nstruct end\n", shape="box"];
                 61 [label="mirage_runtime__61\nMirage_runtime\ntarget", shape="box"];

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -11,8 +11,8 @@ Query unikernel dune
   
   (executable
    (name main)
-   (libraries duration lwt mirage-bootvar-unix mirage-clock-unix mirage-logs
-     mirage-runtime mirage-unix)
+   (libraries duration lwt mirage-bootvar mirage-bootvar.unix
+     mirage-clock-unix mirage-logs mirage-runtime mirage-unix)
    (link_flags (-thread))
    (modules (:standard \ config))
    (flags :standard -w -70)
@@ -111,8 +111,8 @@ Query unikernel dune (hvt)
    (enabled_if (= %{context_name} "solo5"))
    (name main)
    (modes (native exe))
-   (libraries duration lwt mirage-bootvar-solo5 mirage-clock-solo5 mirage-logs
-     mirage-runtime mirage-solo5)
+   (libraries duration lwt mirage-bootvar mirage-bootvar.solo5
+     mirage-clock-solo5 mirage-logs mirage-runtime mirage-solo5)
    (link_flags :standard -w -70 -cclib "-z solo5-abi=hvt")
    (modules (:standard \ config manifest))
    (foreign_stubs (language c) (names manifest))

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -24,7 +24,7 @@ Query opam file
     "duration" { ?monorepo & < "1.0.0" }
     "lwt" { ?monorepo }
     "mirage" { build & >= "4.5.0" & < "4.6.0" }
-    "mirage-bootvar-solo5" { ?monorepo & >= "0.6.0" & < "0.7.0" }
+    "mirage-bootvar" { ?monorepo & >= "1.0.0" & < "2.0.0" }
     "mirage-clock-solo5" { ?monorepo & >= "4.2.0" & < "5.0.0" }
     "mirage-logs" { ?monorepo & >= "2.0.0" & < "3.0.0" }
     "mirage-runtime" { ?monorepo & >= "4.5.0" & < "4.6.0" }
@@ -54,7 +54,7 @@ Query packages
   "duration" { ?monorepo & < "1.0.0" }
   "lwt" { ?monorepo }
   "mirage" { build & >= "4.5.0" & < "4.6.0" }
-  "mirage-bootvar-solo5" { ?monorepo & >= "0.6.0" & < "0.7.0" }
+  "mirage-bootvar" { ?monorepo & >= "1.0.0" & < "2.0.0" }
   "mirage-clock-solo5" { ?monorepo & >= "4.2.0" & < "5.0.0" }
   "mirage-logs" { ?monorepo & >= "2.0.0" & < "3.0.0" }
   "mirage-runtime" { ?monorepo & >= "4.5.0" & < "4.6.0" }
@@ -258,8 +258,8 @@ Query unikernel dune
    (enabled_if (= %{context_name} "solo5"))
    (name main)
    (modes (native exe))
-   (libraries duration lwt mirage-bootvar-solo5 mirage-clock-solo5 mirage-logs
-     mirage-runtime mirage-solo5)
+   (libraries duration lwt mirage-bootvar mirage-bootvar.solo5
+     mirage-clock-solo5 mirage-logs mirage-runtime mirage-solo5)
    (link_flags :standard -w -70 -cclib "-z solo5-abi=hvt")
    (modules (:standard \ config manifest))
    (foreign_stubs (language c) (names manifest))

--- a/test/mirage/query/run-noop.t
+++ b/test/mirage/query/run-noop.t
@@ -11,8 +11,8 @@ Query unikernel dune
   
   (executable
    (name main)
-   (libraries duration lwt mirage-bootvar-unix mirage-clock-unix mirage-logs
-     mirage-runtime mirage-unix)
+   (libraries duration lwt mirage-bootvar mirage-bootvar.unix
+     mirage-clock-unix mirage-logs mirage-runtime mirage-unix)
    (link_flags (-thread))
    (modules (:standard \ config))
    (flags :standard -w -70)
@@ -111,8 +111,8 @@ Query unikernel dune (hvt)
    (enabled_if (= %{context_name} "solo5"))
    (name main)
    (modes (native exe))
-   (libraries duration lwt mirage-bootvar-solo5 mirage-clock-solo5 mirage-logs
-     mirage-runtime mirage-solo5)
+   (libraries duration lwt mirage-bootvar mirage-bootvar.solo5
+     mirage-clock-solo5 mirage-logs mirage-runtime mirage-solo5)
    (link_flags :standard -w -70 -cclib "-z solo5-abi=hvt")
    (modules (:standard \ config manifest))
    (foreign_stubs (language c) (names manifest))

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -28,7 +28,7 @@ Query opam file
     "duration" { ?monorepo & < "1.0.0" }
     "lwt" { ?monorepo }
     "mirage" { build & >= "4.5.0" & < "4.6.0" }
-    "mirage-bootvar-unix" { ?monorepo & >= "0.1.0" & < "0.2.0" }
+    "mirage-bootvar" { ?monorepo & >= "1.0.0" & < "2.0.0" }
     "mirage-clock-unix" { ?monorepo & >= "3.0.0" & < "5.0.0" }
     "mirage-logs" { ?monorepo & >= "2.0.0" & < "3.0.0" }
     "mirage-runtime" { ?monorepo & >= "4.5.0" & < "4.6.0" }
@@ -56,7 +56,7 @@ Query packages
   "duration" { ?monorepo & < "1.0.0" }
   "lwt" { ?monorepo }
   "mirage" { build & >= "4.5.0" & < "4.6.0" }
-  "mirage-bootvar-unix" { ?monorepo & >= "0.1.0" & < "0.2.0" }
+  "mirage-bootvar" { ?monorepo & >= "1.0.0" & < "2.0.0" }
   "mirage-clock-unix" { ?monorepo & >= "3.0.0" & < "5.0.0" }
   "mirage-logs" { ?monorepo & >= "2.0.0" & < "3.0.0" }
   "mirage-runtime" { ?monorepo & >= "4.5.0" & < "4.6.0" }
@@ -262,8 +262,8 @@ Query unikernel dune
   
   (executable
    (name main)
-   (libraries duration lwt mirage-bootvar-unix mirage-clock-unix mirage-logs
-     mirage-runtime mirage-unix)
+   (libraries duration lwt mirage-bootvar mirage-bootvar.unix
+     mirage-clock-unix mirage-logs mirage-runtime mirage-unix)
    (link_flags (-thread))
    (modules (:standard \ config))
    (flags :standard -w -70)

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -102,17 +102,17 @@ Configure the project for Unix:
   
   module App_make__12 = App.Make(Mirage_crypto_rng_mirage_make__11)
   
-  let bootvar__1 = lazy (
-  # 7 "lib/devices/argv.ml"
-    Bootvar.argv ()
+  let mirage_bootvar__1 = lazy (
+  # 15 "lib/devices/argv.ml"
+    return (Mirage_bootvar.argv ())
   );;
   # 87 "mirage/main.ml"
   
   let struct_end__2 = lazy (
-    let __bootvar__1 = Lazy.force bootvar__1 in
-    __bootvar__1 >>= fun _bootvar__1 ->
+    let __mirage_bootvar__1 = Lazy.force mirage_bootvar__1 in
+    __mirage_bootvar__1 >>= fun _mirage_bootvar__1 ->
   # 47 "lib/functoria/job.ml"
-    return Mirage_runtime.(with_argv (runtime_args ()) "random" _bootvar__1)
+    return Mirage_runtime.(with_argv (runtime_args ()) "random" _mirage_bootvar__1)
   );;
   # 95 "mirage/main.ml"
   
@@ -354,17 +354,17 @@ Configure the project for Xen:
   
   module App_make__12 = App.Make(Mirage_crypto_rng_mirage_make__11)
   
-  let bootvar__1 = lazy (
-  # 21 "lib/devices/argv.ml"
-    Bootvar.argv ()
+  let mirage_bootvar__1 = lazy (
+  # 15 "lib/devices/argv.ml"
+    return (Mirage_bootvar.argv ())
   );;
   # 87 "mirage/main.ml"
   
   let struct_end__2 = lazy (
-    let __bootvar__1 = Lazy.force bootvar__1 in
-    __bootvar__1 >>= fun _bootvar__1 ->
+    let __mirage_bootvar__1 = Lazy.force mirage_bootvar__1 in
+    __mirage_bootvar__1 >>= fun _mirage_bootvar__1 ->
   # 47 "lib/functoria/job.ml"
-    return Mirage_runtime.(with_argv (runtime_args ()) "random" _bootvar__1)
+    return Mirage_runtime.(with_argv (runtime_args ()) "random" _mirage_bootvar__1)
   );;
   # 95 "mirage/main.ml"
   


### PR DESCRIPTION
I found an even simpler example than "mirage-time" in respect to "how to use dune variants": boot parameters.

We used to have mirage-bootvar-xen, mirage-bootvar-unix, mirage-bootvar-solo5, and the parse-argv opam packages that were all involved.

Now, I created (retaining history) the single repository https://github.com/mirage/mirage-bootvar. This uses dune variants, the default is the unix implementation.

What is interesting about bootvar is that no one bothered to functorize it ;) Also, it shows how a unikernel could still decide to use "no_argv", bypassing any dune variant restrictions (I'm not sure whether this is desirable, but it is possible -- this also sheds some light that we could use configure-time keys to select some other implementation).

Anyways, this is much simpler than #1529 and you may enjoy looking into it.

EDIT: CI fails since the mirage-bootvar is not released, I'm happy to do that if no one objects about the approach taken.