### PR TITLE
update ocamlformat to 0.26.2

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.26.1
+version = 0.26.2
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true


### PR DESCRIPTION
there's no change, but this will remove the need from changing it in a bunch of PRs.