### PR TITLE
On a `Term error from Cmdliner, print a Hint about how to pass a space

### DIFF
--- a/lib_runtime/functoria/functoria_runtime.ml
+++ b/lib_runtime/functoria/functoria_runtime.ml
@@ -72,6 +72,9 @@ let with_argv keys s argv =
     | Ok (`Ok _) ->
         initialized := true;
         ()
-    | Error (`Parse | `Term) -> exit argument_error
+    | Error `Parse -> exit argument_error
+    | Error `Term ->
+      print_endline ("Hint: A space needs to be escaped twice: \027[1m--hello='\"Hello, world!\"'\027[m");
+      exit argument_error
     | Error `Exn -> exit Cmd.Exit.internal_error
     | Ok `Help | Ok `Version -> exit help_version

--- a/lib_runtime/functoria/functoria_runtime.ml
+++ b/lib_runtime/functoria/functoria_runtime.ml
@@ -74,7 +74,12 @@ let with_argv keys s argv =
         ()
     | Error `Parse -> exit argument_error
     | Error `Term ->
-      print_endline ("Hint: A space needs to be escaped twice: \027[1m--hello='\"Hello, world!\"'\027[m");
-      exit argument_error
+        print_endline
+          "Hint: To pass a space, it needs to be escaped twice: \
+           \027[1m--hello='Hello,\\ world!'\027[m";
+        print_endline
+          "      Another possibility is: \027[1m--hello='\"Hello, \
+           world!\"'\027[m";
+        exit argument_error
     | Error `Exn -> exit Cmd.Exit.internal_error
     | Ok `Help | Ok `Version -> exit help_version


### PR DESCRIPTION
See #1248 @samoht @patricoferris @pitag-ha

Of course, happy to improve the text. But since this is a pretty common issue, I'm happy to have such a hint.

![console-hint](https://github.com/mirage/mirage/assets/228456/6d078b20-498c-4b9c-9926-b38e6003684e)
