### PR TITLE
job with no arguments, check a bit more thoroughly

### DIFF
--- a/test/mirage/job-no-device-arg/config.ml
+++ b/test/mirage/job-no-device-arg/config.ml
@@ -1,0 +1,5 @@
+open Mirage
+
+let runtime_args = [ runtime_arg ~pos:__POS__ "Unikernel.hello" ]
+let main = main ~runtime_args ~pos:__POS__ "App" job
+let () = register ~src:`None "noop" [ main ]

--- a/test/mirage/job-no-device-arg/configure.t
+++ b/test/mirage/job-no-device-arg/configure.t
@@ -1,0 +1,4 @@
+  $ export MIRAGE_DEFAULT_TARGET=unix
+
+Configure
+  $ ./config.exe configure

--- a/test/mirage/job-no-device-arg/dune
+++ b/test/mirage/job-no-device-arg/dune
@@ -1,0 +1,7 @@
+(executable
+ (name config)
+ (libraries mirage))
+
+(cram
+ (package mirage)
+ (deps config.exe))


### PR DESCRIPTION
This adds a test case (initially failing) where a device with some runtime arguments should not fail the `configure` stage.

The reasoning is: we really need to check that execution is delayed (i.e. it is not `let start = ...`, but more `let start _ = ...`).

Previously, we only checked for `args` -- which are the functor applications. Now, we also check for extra_deps - which are passed as arguments - and furthermore we check whether runtime_args is empty. And only in this case, where all of the three things are empty, and in addition we're not at the `noop` job, we raise an error.

Addresses @samoht comment on https://github.com/mirage/mirage/pull/1529#discussion_r1604834773