### PR TITLE
Provide Mirage.ethif as an alias for Mirage.etif

### DIFF
--- a/lib/devices/ethernet.ml
+++ b/lib/devices/ethernet.ml
@@ -6,7 +6,7 @@ type ethernet = ETHERNET
 
 let ethernet = typ ETHERNET
 
-let etif_conf =
+let ethif_conf =
   let packages = [ package ~min:"3.0.0" ~max:"4.0.0" "ethernet" ] in
   let connect _ m = function
     | [ eth ] -> code ~pos:__POS__ "%s.connect %s" m eth
@@ -14,4 +14,4 @@ let etif_conf =
   in
   impl ~packages ~connect "Ethernet.Make" (network @-> ethernet)
 
-let etif network = etif_conf $ network
+let ethif network = ethif_conf $ network

--- a/lib/devices/ethernet.mli
+++ b/lib/devices/ethernet.mli
@@ -3,4 +3,4 @@ open Functoria
 type ethernet
 
 val ethernet : ethernet typ
-val etif : Network.network impl -> ethernet impl
+val ethif : Network.network impl -> ethernet impl

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -65,7 +65,7 @@ let static_ipv4v6_stack ?group ?ipv6_config ?ipv4_config ?(arp = arp ?time:None)
     ?tcp tap =
   let ipv4_only = Runtime_arg.ipv4_only ?group ()
   and ipv6_only = Runtime_arg.ipv6_only ?group () in
-  let e = etif tap in
+  let e = ethif tap in
   let a = arp e in
   let i4 = create_ipv4 ?group ?config:ipv4_config ~no_init:ipv6_only e a in
   let i6 = create_ipv6 ?group ?config:ipv6_config ~no_init:ipv4_only tap e in
@@ -75,7 +75,7 @@ let generic_ipv4v6_stack p ?group ?ipv6_config ?ipv4_config
     ?(arp = arp ?time:None) ?tcp tap =
   let ipv4_only = Runtime_arg.ipv4_only ?group ()
   and ipv6_only = Runtime_arg.ipv6_only ?group () in
-  let e = etif tap in
+  let e = ethif tap in
   let a = arp e in
   let i4 =
     match_impl p

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -99,7 +99,8 @@ let default_network = Network.default_network
 type ethernet = Ethernet.ethernet
 
 let ethernet = Ethernet.ethernet
-let etif = Ethernet.etif
+let etif = Ethernet.ethif
+let ethif = Ethernet.ethif
 
 type arpv4 = Arp.arpv4
 

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -458,6 +458,11 @@ val ethernet : ethernet typ
 (** Implementations of the [Ethernet.S] signature. *)
 
 val etif : network impl -> ethernet impl
+[@@ocaml.deprecated "Deprecated. Use [ethif] instead."]
+(** [etif net] is the ethernet layer on [net]. *)
+
+val ethif : network impl -> ethernet impl
+(** [ethif net] is the ethernet layer on [net]. *)
 
 (** {2 ARP configuration} *)
 

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -124,14 +124,14 @@ Configure the project for Unix:
   
   let printexc__3 = lazy (
     let _mirage_runtime_backtrace = (mirage_runtime_backtrace__key ()) in
-  # 397 "lib/mirage.ml"
+  # 398 "lib/mirage.ml"
     return (Printexc.record_backtrace _mirage_runtime_backtrace)
   );;
   # 109 "mirage/main.ml"
   
   let hashtbl__4 = lazy (
     let _mirage_runtime_randomize_hashtables = (mirage_runtime_randomize_hashtables__key ()) in
-  # 406 "lib/mirage.ml"
+  # 407 "lib/mirage.ml"
     return (if _mirage_runtime_randomize_hashtables then Hashtbl.randomize ())
   );;
   # 116 "mirage/main.ml"
@@ -147,7 +147,7 @@ Configure the project for Unix:
     let _mirage_runtime_custom_major_ratio = (mirage_runtime_custom_major_ratio__key ()) in
     let _mirage_runtime_custom_minor_ratio = (mirage_runtime_custom_minor_ratio__key ()) in
     let _mirage_runtime_custom_minor_max_size = (mirage_runtime_custom_minor_max_size__key ()) in
-  # 458 "lib/mirage.ml"
+  # 459 "lib/mirage.ml"
     return (
   let open Gc in
     let ctrl = get () in
@@ -167,7 +167,7 @@ Configure the project for Unix:
   
   let mirage_runtime__6 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 302 "lib/mirage.ml"
+  # 303 "lib/mirage.ml"
     Unix_os.Time.sleep_ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 152 "mirage/main.ml"
@@ -232,7 +232,7 @@ Configure the project for Unix:
     __mirage_runtime__6 >>= fun _mirage_runtime__6 ->
     __mirage_logs_make__8 >>= fun _mirage_logs_make__8 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 385 "lib/mirage.ml"
+  # 386 "lib/mirage.ml"
     return ()
   );;
   # 217 "mirage/main.ml"
@@ -382,14 +382,14 @@ Configure the project for Xen:
   
   let printexc__3 = lazy (
     let _mirage_runtime_backtrace = (mirage_runtime_backtrace__key ()) in
-  # 397 "lib/mirage.ml"
+  # 398 "lib/mirage.ml"
     return (Printexc.record_backtrace _mirage_runtime_backtrace)
   );;
   # 109 "mirage/main.ml"
   
   let hashtbl__4 = lazy (
     let _mirage_runtime_randomize_hashtables = (mirage_runtime_randomize_hashtables__key ()) in
-  # 406 "lib/mirage.ml"
+  # 407 "lib/mirage.ml"
     return (if _mirage_runtime_randomize_hashtables then Hashtbl.randomize ())
   );;
   # 116 "mirage/main.ml"
@@ -405,7 +405,7 @@ Configure the project for Xen:
     let _mirage_runtime_custom_major_ratio = (mirage_runtime_custom_major_ratio__key ()) in
     let _mirage_runtime_custom_minor_ratio = (mirage_runtime_custom_minor_ratio__key ()) in
     let _mirage_runtime_custom_minor_max_size = (mirage_runtime_custom_minor_max_size__key ()) in
-  # 458 "lib/mirage.ml"
+  # 459 "lib/mirage.ml"
     return (
   let open Gc in
     let ctrl = get () in
@@ -425,7 +425,7 @@ Configure the project for Xen:
   
   let mirage_runtime__6 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 302 "lib/mirage.ml"
+  # 303 "lib/mirage.ml"
     Xen_os.Time.sleep_ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 152 "mirage/main.ml"
@@ -490,7 +490,7 @@ Configure the project for Xen:
     __mirage_runtime__6 >>= fun _mirage_runtime__6 ->
     __mirage_logs_make__8 >>= fun _mirage_logs_make__8 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 385 "lib/mirage.ml"
+  # 386 "lib/mirage.ml"
     return ()
   );;
   # 217 "mirage/main.ml"


### PR DESCRIPTION
To be used with https://github.com/mirage/mirage-skeleton/pull/396

Mark Mirage.etif as deprecated