### PR TITLE
Upgrade the tool to use tcpip.8.1.0 and mirage-qubes.0.10.0

### DIFF
--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -85,7 +85,7 @@ type ipv6_config = {
 (** Types for IP manual configuration. *)
 
 let ipv4_qubes_conf =
-  let packages = [ package ~min:"0.9.0" ~max:"0.10.0" "mirage-qubes-ipv4" ] in
+  let packages = [ package ~min:"0.10.0" ~max:"0.11.0" "mirage-qubes-ipv4" ] in
   let connect _ modname = function
     | [ db; _random; _mclock; etif; arp ] ->
         code ~pos:__POS__ "%s.connect@[@ %s@ %s@ %s@]" modname db etif arp

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -85,7 +85,7 @@ type ipv6_config = {
 (** Types for IP manual configuration. *)
 
 let ipv4_qubes_conf =
-  let packages = [ package ~min:"0.10.0" ~max:"0.11.0" "mirage-qubes-ipv4" ] in
+  let packages = [ package ~min:"0.9.0" ~max:"0.11.0" "mirage-qubes-ipv4" ] in
   let connect _ modname = function
     | [ db; _random; _mclock; etif; arp ] ->
         code ~pos:__POS__ "%s.connect@[@ %s@ %s@ %s@]" modname db etif arp

--- a/lib/devices/qubesdb.ml
+++ b/lib/devices/qubesdb.ml
@@ -5,7 +5,7 @@ open Misc
 type qubesdb = QUBES_DB
 
 let qubesdb = typ QUBES_DB
-let pkg = package ~min:"0.9.0" ~max:"0.10.0" "mirage-qubes"
+let pkg = package ~min:"0.10.0" ~max:"0.11.0" "mirage-qubes"
 
 let default_qubesdb =
   let packages = [ pkg ] in

--- a/lib/devices/qubesdb.ml
+++ b/lib/devices/qubesdb.ml
@@ -5,7 +5,7 @@ open Misc
 type qubesdb = QUBES_DB
 
 let qubesdb = typ QUBES_DB
-let pkg = package ~min:"0.10.0" ~max:"0.11.0" "mirage-qubes"
+let pkg = package ~min:"0.9.0" ~max:"0.11.0" "mirage-qubes"
 
 let default_qubesdb =
   let packages = [ pkg ] in

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -164,7 +164,7 @@ let socket_stackv4v6 = Stack.socket_stackv4v6
 let tcpv4v6_of_stackv4v6 v =
   let impl =
     let packages =
-      [ package "tcpip" ~sublibs:[ "stack-direct" ] ~min:"7.1.0" ]
+      [ package "tcpip" ~sublibs:[ "stack-direct" ] ~min:"8.1.0" ]
     in
     let connect _ modname = function
       | [ stackv4v6 ] ->

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -164,7 +164,7 @@ let socket_stackv4v6 = Stack.socket_stackv4v6
 let tcpv4v6_of_stackv4v6 v =
   let impl =
     let packages =
-      [ package "tcpip" ~sublibs:[ "stack-direct" ] ~min:"8.1.0" ]
+      [ package "tcpip" ~sublibs:[ "stack-direct" ] ~min:"7.1.0" ~max:"9.0.0" ]
     in
     let connect _ modname = function
       | [ stackv4v6 ] ->


### PR DESCRIPTION
/cc @hannesm, I'm not sure that it's enough for your recent change about tcpip. At least, this change is required for `qubes-miragevpn`.