### PR TITLE
Re-introduce deps which can be useful to track dependencies which need to be built but not used to apply a functor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### Unreleased
+
+- BREAKING re-introduce `?deps` argument into `Mirage.main` function to be
+  able to track how to compile some artifacts for an unikernel without emitting
+  modules/functors used by these artifacts (#1555, @dinosaure)
+
 ### v4.6.0 (2024-06-26)
 
 - BREAKING adapt to happy-eyeballs and dns-client devices where dependencies

--- a/lib/functoria/DSL.ml
+++ b/lib/functoria/DSL.ml
@@ -48,9 +48,10 @@ let impl ?packages ?packages_v ?install ?install_v ?keys ?runtime_args
   @@ Device.v ?packages ?packages_v ?install ?install_v ?keys ?runtime_args
        ?extra_deps ?connect ?dune ?configure ?files module_name module_type
 
-let main ?pos ?packages ?packages_v ?runtime_args module_name ty =
+let main ?pos ?packages ?packages_v ?runtime_args ?deps module_name ty =
   let connect _ = Device.start ?pos in
-  impl ?packages ?packages_v ?runtime_args ~connect module_name ty
+  impl ?packages ?packages_v ?runtime_args ?extra_deps:deps ~connect module_name
+    ty
 
 let runtime_arg ~pos ?packages str =
   Runtime_arg.v (Runtime_arg.create ~pos ?packages str)

--- a/lib/functoria/DSL.mli
+++ b/lib/functoria/DSL.mli
@@ -151,6 +151,7 @@ val main :
   ?packages:package list ->
   ?packages_v:package list value ->
   ?runtime_args:Runtime_arg.t list ->
+  ?deps:abstract_impl list ->
   string ->
   'a typ ->
   'a impl


### PR DESCRIPTION
This PR reintroduce the `deps` argument into the `main` to be able to track a dependency which needs to be built by `dune` but we don't want to generate a module/functor from it. It's actually used by `pasteur` to track some JS files generated by `js_of_ocaml` and packed with `docteur` (to make a disk image).