### PR TITLE
opam src url: path includes leading slash

### DIFF
--- a/lib/functoria/opam.ml
+++ b/lib/functoria/opam.ml
@@ -61,6 +61,7 @@ module Endpoint = struct
         Astring.String.cut ~sep:":" (String.sub str consumed (len - consumed))
       with
       | Some ("", path) ->
+          let path = "/" ^ path in
           let local =
             List.map
               (function `Atom x -> x | `String x -> Fmt.str "%S" x)
@@ -113,7 +114,7 @@ let guess_src () =
         | Ok
             { Endpoint.scheme = `Scheme scheme; port = None; path; hostname; _ }
           ->
-            Fmt.str "%s://%s/%s" scheme hostname path
+            Fmt.str "%s://%s%s" scheme hostname path
         | Ok
             {
               Endpoint.scheme = `Scheme scheme;
@@ -122,11 +123,11 @@ let guess_src () =
               hostname;
               _;
             } ->
-            Fmt.str "%s://%s:%d/%s" scheme hostname port path
+            Fmt.str "%s://%s:%d%s" scheme hostname port path
         | Ok { Endpoint.port = None; path; hostname; _ } ->
-            Fmt.str "git+https://%s/%s" hostname path
+            Fmt.str "git+https://%s%s" hostname path
         | Ok { Endpoint.port = Some port; path; hostname; _ } ->
-            Fmt.str "git+https://%s:%d/%s" hostname port path
+            Fmt.str "git+https://%s:%d%s" hostname port path
         | _ -> "git+https://invalid/endpoint"
       in
       (subdir, Some (Fmt.str "%s#%s" public branch))

--- a/test/mirage/random/run-opam-git.t
+++ b/test/mirage/random/run-opam-git.t
@@ -1,0 +1,44 @@
+Initialize a git repository:
+
+  $ git init --quiet
+
+And set a user name for future commits:
+
+  $ git config user.email "noreply@mirage.io"
+  $ git config user.name "Camelus Dromedarius"
+
+And set its "origin" remote to something:
+
+  $ git remote add origin https://github.com/notifications/invalid-repo.git
+  $ git remote show -n
+  origin
+  $ git branch
+
+Make an empty commit and rename it to main. Otherwise we don't have any branches.
+
+  $ git commit --quiet --allow-empty -m 'Hello Mirage World'
+  $ git branch -m main
+  $ git branch
+  * main
+
+Configure the project for Unix:
+
+  $ mirage configure -t unix
+
+Check the source url of the generated opam package
+
+  $ cat mirage/random-unix.opam | grep "^url"
+  url { src: "git+https://github.com/notifications/invalid-repo.git#main" }
+
+Now, let's use a remote with ssh transport:
+
+  $ git remote set-url origin git@github.com:notifications/invalid-repo.git
+
+Configure the project again for Unix:
+
+  $ mirage configure -t unix
+
+Check the source url of the generated opam package
+
+  $ cat mirage/random-unix.opam | grep "^url"
+  url { src: "git+https://github.com/notifications/invalid-repo.git#main" }


### PR DESCRIPTION
It seems `ssh://` urls are relative when they otherwise look absolute, see e.g. https://github.com/ocaml/opam/issues/3382. I guess an absolute path is `ssh://user@host//absolute/path` i.e. a double leading slash.

Closes #1563.

Draft PR while I look into how we can test this.