### PR TITLE
Update test with new warning

### DIFF
--- a/test/mirage/random/run-opam-git.t
+++ b/test/mirage/random/run-opam-git.t
@@ -24,6 +24,7 @@ Make an empty commit and rename it to main. Otherwise we don't have any branches
 Configure the project for Unix:
 
   $ mirage configure -t unix
+  mirage: [WARNING] Skipping version check, since our_version is not watermarked
 
 Check the source url of the generated opam package
 
@@ -37,6 +38,7 @@ Now, let's use a remote with ssh transport:
 Configure the project again for Unix:
 
   $ mirage configure -t unix
+  mirage: [WARNING] Skipping version check, since our_version is not watermarked
 
 Check the source url of the generated opam package
 


### PR DESCRIPTION
The test was added in #1564 while #1566 was merged first adding a new warning. This updates the expected output of the test from #1564 with the warning and main should no longer error.