### PR TITLE
Use copy# for config.ml

### DIFF
--- a/lib/functoria/dune.ml
+++ b/lib/functoria/dune.ml
@@ -80,7 +80,9 @@ let config_rule ~config_ml_file ~packages =
     if name = "config" then []
     else
       [
-        stanzaf "(rule (copy %s config%s))" (Fpath.to_string config_ml_file) ext;
+        stanzaf "(rule (copy# %s config%s))"
+          (Fpath.to_string config_ml_file)
+          ext;
       ]
   in
   let contents =

--- a/test/functoria/e2e/errors.t
+++ b/test/functoria/e2e/errors.t
@@ -4,7 +4,7 @@ of a device's connect function:
   $ ./test.exe configure -f errors/in_device.ml
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   $ dune build
-  File "errors/config.ml", line 6, characters 2-26:
+  File "errors/in_device.ml", line 6, characters 2-26:
   Error: Unbound value Unikernel_make__4.start'
   Hint: Did you mean start?
   [1]


### PR DESCRIPTION
This gives better error messages when using a config.ml whose name is *not* config.ml, e.g. errors/in_device.ml.