### PR TITLE
improve runtime argument error messages

### DIFF
--- a/lib_runtime/functoria/functoria_runtime.ml
+++ b/lib_runtime/functoria/functoria_runtime.ml
@@ -16,7 +16,6 @@
 
 let runtime_args_r = ref []
 let runtime_args () = !runtime_args_r
-let initialized = ref false
 
 module Arg = struct
   type 'a t = { arg : 'a Cmdliner.Term.t; mutable value : 'a option }
@@ -26,14 +25,9 @@ module Arg = struct
   let get t =
     match t.value with
     | None ->
-        if !initialized then
-          invalid_arg
-            "Not sure how you got here, please report an issue at the issue \
-             tracker with your unikernel source."
-        else
-          invalid_arg
-            "Called too early. Please delay this call to after the start \
-             function of the unikernel."
+        invalid_arg
+          "Called too early. Please delay this call to after the start \
+           function of the unikernel."
     | Some v -> v
 
   let term (type a) (t : a t) =
@@ -44,6 +38,8 @@ module Arg = struct
     let pp ppf v = Format.pp_print_string ppf (to_string v) in
     Cmdliner.Arg.conv (of_string, pp)
 end
+
+let initialized = ref false
 
 let register t =
   if !initialized then


### PR DESCRIPTION
there are two kinds of errors: we call `get` too early, or `register` too late. Separate them to avoid clunky errors (see https://github.com/mirage/mirage/issues/1572#issuecomment-2396279621)