### PR TITLE
provide Mirage_runtime.register_arg, deprecate Mirage_runtime.register

### DIFF
--- a/lib/functoria/runtime_arg.ml
+++ b/lib/functoria/runtime_arg.ml
@@ -63,7 +63,7 @@ let ocaml_name k = String.lowercase_ascii (Name.ocamlify k)
 let pp_pos ppf (file, line) = Fmt.pf ppf "# %d %S@." line file
 
 let serialize ~runtime_modname fmt (Any k) =
-  Format.fprintf fmt "let %s__key = %s.register @@@@\n%a  @[<v2>%s@]\n;;\n"
+  Format.fprintf fmt "let %s__key = %s.register_arg @@@@\n%a  @[<v2>%s@]\n;;\n"
     (ocaml_name k.name) runtime_modname pp_pos k.pos k.code
 
 let call fmt (Any k) = Fmt.pf fmt "(%s__key ())" (ocaml_name k.name)

--- a/lib_runtime/functoria/functoria_runtime.ml
+++ b/lib_runtime/functoria/functoria_runtime.ml
@@ -41,7 +41,7 @@ end
 
 let initialized = ref false
 
-let register t =
+let register_arg t =
   if !initialized then
     invalid_arg
       "register called to late. Please call register before the start function \
@@ -50,6 +50,7 @@ let register t =
   runtime_args_r := Arg.term u :: !runtime_args_r;
   fun () -> Arg.get u
 
+let register = register_arg
 let help_version = 63
 let argument_error = 64
 

--- a/lib_runtime/functoria/functoria_runtime.mli
+++ b/lib_runtime/functoria/functoria_runtime.mli
@@ -37,14 +37,16 @@ end
 
 val register : 'a Cmdliner.Term.t -> unit -> 'a
 [@@ocaml.deprecated "Use register_arg instead."]
-(** [register t] registers the Cmdliner term [k] as a runtime key and return a
-    callback [f] that evaluates to [t]s' value passed on the command-line.
+(** [register t] registers the Cmdliner term [k] as a runtime argument and
+    return a callback [f] that evaluates to [t]s' value passed on the
+    command-line.
 
     [f] will raise [Invalid_argument] if called before cmdliner's evaluation. *)
 
 val register_arg : 'a Cmdliner.Term.t -> unit -> 'a
-(** [register_arg t] registers the Cmdliner term [k] as a runtime key and return
-    a callback [f] that evaluates to [t]s' value passed on the command-line.
+(** [register_arg t] registers the Cmdliner term [k] as a runtime argument and
+    return a callback [f] that evaluates to [t]s' value passed on the
+    command-line.
 
     [f] will raise [Invalid_argument] if called before cmdliner's evaluation. *)
 
@@ -54,12 +56,12 @@ val with_argv :
   string ->
   string array ->
   unit
-(** [with_argv ?sections keys name argv] evaluates the [keys] {{!Key.term}
-    terms} on the command-line [argv]. [name] is the executable name. [sections]
-    is a list of sections to include in the man page - useful for enforcing a
-    specific order of sections. On evaluation error the application calls
-    [exit(3)] with status [64]. If [`Help] or [`Version] were evaluated,
-    [exit(3)] is called with status [63]. *)
+(** [with_argv ?sections arguments name argv] evaluates the [arguments]
+    {{!Key.term} terms} on the command-line [argv]. [name] is the executable
+    name. [sections] is a list of sections to include in the man page - useful
+    for enforcing a specific order of sections. On evaluation error the
+    application calls [exit(3)] with status [64]. If [`Help] or [`Version] were
+    evaluated, [exit(3)] is called with status [63]. *)
 
 val runtime_args : unit -> unit Cmdliner.Term.t list
 

--- a/lib_runtime/functoria/functoria_runtime.mli
+++ b/lib_runtime/functoria/functoria_runtime.mli
@@ -36,8 +36,15 @@ module Arg : sig
 end
 
 val register : 'a Cmdliner.Term.t -> unit -> 'a
+[@@ocaml.deprecated "Use register_arg instead."]
 (** [register t] registers the Cmdliner term [k] as a runtime key and return a
     callback [f] that evaluates to [t]s' value passed on the command-line.
+
+    [f] will raise [Invalid_argument] if called before cmdliner's evaluation. *)
+
+val register_arg : 'a Cmdliner.Term.t -> unit -> 'a
+(** [register_arg t] registers the Cmdliner term [k] as a runtime key and return
+    a callback [f] that evaluates to [t]s' value passed on the command-line.
 
     [f] will raise [Invalid_argument] if called before cmdliner's evaluation. *)
 

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -257,5 +257,6 @@ let with_argv =
 
 let runtime_args = Functoria_runtime.runtime_args
 let register = Functoria_runtime.register
+let register_arg = Functoria_runtime.register
 let argument_error = Functoria_runtime.argument_error
 let help_version = Functoria_runtime.help_version

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -256,7 +256,7 @@ let with_argv =
       [ Manpage.s_arguments; Manpage.s_options; s_net; s_log; s_disk; s_ocaml ]
 
 let runtime_args = Functoria_runtime.runtime_args
-let register = Functoria_runtime.register
-let register_arg = Functoria_runtime.register
+let register = Functoria_runtime.register_arg
+let register_arg = Functoria_runtime.register_arg
 let argument_error = Functoria_runtime.argument_error
 let help_version = Functoria_runtime.help_version

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -143,4 +143,8 @@ val help_version : int
 
 val with_argv : unit Cmdliner.Term.t list -> string -> string array -> unit
 val runtime_args : unit -> unit Cmdliner.Term.t list
+
 val register : 'a Cmdliner.Term.t -> unit -> 'a
+[@@ocaml.deprecated "Use Mirage_runtime.register_arg instead."]
+
+val register_arg : 'a Cmdliner.Term.t -> unit -> 'a

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -27,72 +27,72 @@ Configure the project for Unix:
   let run t = Unix_os.Main.run t ; exit
   0
   
-  let mirage_runtime_delay__key = Mirage_runtime.register @@
+  let mirage_runtime_delay__key = Mirage_runtime.register_arg @@
   # 33 "lib/devices/runtime_arg.ml"
     Mirage_runtime.delay
   ;;
   
-  let mirage_runtime_backtrace__key = Mirage_runtime.register @@
+  let mirage_runtime_backtrace__key = Mirage_runtime.register_arg @@
   # 34 "lib/devices/runtime_arg.ml"
     Mirage_runtime.backtrace
   ;;
   
-  let mirage_runtime_randomize_hashtables__key = Mirage_runtime.register @@
+  let mirage_runtime_randomize_hashtables__key = Mirage_runtime.register_arg @@
   # 35 "lib/devices/runtime_arg.ml"
     Mirage_runtime.randomize_hashtables
   ;;
   
-  let mirage_runtime_allocation_policy__key = Mirage_runtime.register @@
+  let mirage_runtime_allocation_policy__key = Mirage_runtime.register_arg @@
   # 36 "lib/devices/runtime_arg.ml"
     Mirage_runtime.allocation_policy
   ;;
   
-  let mirage_runtime_minor_heap_size__key = Mirage_runtime.register @@
+  let mirage_runtime_minor_heap_size__key = Mirage_runtime.register_arg @@
   # 37 "lib/devices/runtime_arg.ml"
     Mirage_runtime.minor_heap_size
   ;;
   
-  let mirage_runtime_major_heap_increment__key = Mirage_runtime.register @@
+  let mirage_runtime_major_heap_increment__key = Mirage_runtime.register_arg @@
   # 38 "lib/devices/runtime_arg.ml"
     Mirage_runtime.major_heap_increment
   ;;
   
-  let mirage_runtime_space_overhead__key = Mirage_runtime.register @@
+  let mirage_runtime_space_overhead__key = Mirage_runtime.register_arg @@
   # 39 "lib/devices/runtime_arg.ml"
     Mirage_runtime.space_overhead
   ;;
   
-  let mirage_runtime_max_space_overhead__key = Mirage_runtime.register @@
+  let mirage_runtime_max_space_overhead__key = Mirage_runtime.register_arg @@
   # 40 "lib/devices/runtime_arg.ml"
     Mirage_runtime.max_space_overhead
   ;;
   
-  let mirage_runtime_gc_verbosity__key = Mirage_runtime.register @@
+  let mirage_runtime_gc_verbosity__key = Mirage_runtime.register_arg @@
   # 41 "lib/devices/runtime_arg.ml"
     Mirage_runtime.gc_verbosity
   ;;
   
-  let mirage_runtime_gc_window_size__key = Mirage_runtime.register @@
+  let mirage_runtime_gc_window_size__key = Mirage_runtime.register_arg @@
   # 42 "lib/devices/runtime_arg.ml"
     Mirage_runtime.gc_window_size
   ;;
   
-  let mirage_runtime_custom_major_ratio__key = Mirage_runtime.register @@
+  let mirage_runtime_custom_major_ratio__key = Mirage_runtime.register_arg @@
   # 43 "lib/devices/runtime_arg.ml"
     Mirage_runtime.custom_major_ratio
   ;;
   
-  let mirage_runtime_custom_minor_ratio__key = Mirage_runtime.register @@
+  let mirage_runtime_custom_minor_ratio__key = Mirage_runtime.register_arg @@
   # 44 "lib/devices/runtime_arg.ml"
     Mirage_runtime.custom_minor_ratio
   ;;
   
-  let mirage_runtime_custom_minor_max_size__key = Mirage_runtime.register @@
+  let mirage_runtime_custom_minor_max_size__key = Mirage_runtime.register_arg @@
   # 45 "lib/devices/runtime_arg.ml"
     Mirage_runtime.custom_minor_max_size
   ;;
   
-  let mirage_runtime_logs__key = Mirage_runtime.register @@
+  let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
   # 143 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;
@@ -286,72 +286,72 @@ Configure the project for Xen:
   let run t = Xen_os.Main.run t ; exit
   0
   
-  let mirage_runtime_delay__key = Mirage_runtime.register @@
+  let mirage_runtime_delay__key = Mirage_runtime.register_arg @@
   # 33 "lib/devices/runtime_arg.ml"
     Mirage_runtime.delay
   ;;
   
-  let mirage_runtime_backtrace__key = Mirage_runtime.register @@
+  let mirage_runtime_backtrace__key = Mirage_runtime.register_arg @@
   # 34 "lib/devices/runtime_arg.ml"
     Mirage_runtime.backtrace
   ;;
   
-  let mirage_runtime_randomize_hashtables__key = Mirage_runtime.register @@
+  let mirage_runtime_randomize_hashtables__key = Mirage_runtime.register_arg @@
   # 35 "lib/devices/runtime_arg.ml"
     Mirage_runtime.randomize_hashtables
   ;;
   
-  let mirage_runtime_allocation_policy__key = Mirage_runtime.register @@
+  let mirage_runtime_allocation_policy__key = Mirage_runtime.register_arg @@
   # 36 "lib/devices/runtime_arg.ml"
     Mirage_runtime.allocation_policy
   ;;
   
-  let mirage_runtime_minor_heap_size__key = Mirage_runtime.register @@
+  let mirage_runtime_minor_heap_size__key = Mirage_runtime.register_arg @@
   # 37 "lib/devices/runtime_arg.ml"
     Mirage_runtime.minor_heap_size
   ;;
   
-  let mirage_runtime_major_heap_increment__key = Mirage_runtime.register @@
+  let mirage_runtime_major_heap_increment__key = Mirage_runtime.register_arg @@
   # 38 "lib/devices/runtime_arg.ml"
     Mirage_runtime.major_heap_increment
   ;;
   
-  let mirage_runtime_space_overhead__key = Mirage_runtime.register @@
+  let mirage_runtime_space_overhead__key = Mirage_runtime.register_arg @@
   # 39 "lib/devices/runtime_arg.ml"
     Mirage_runtime.space_overhead
   ;;
   
-  let mirage_runtime_max_space_overhead__key = Mirage_runtime.register @@
+  let mirage_runtime_max_space_overhead__key = Mirage_runtime.register_arg @@
   # 40 "lib/devices/runtime_arg.ml"
     Mirage_runtime.max_space_overhead
   ;;
   
-  let mirage_runtime_gc_verbosity__key = Mirage_runtime.register @@
+  let mirage_runtime_gc_verbosity__key = Mirage_runtime.register_arg @@
   # 41 "lib/devices/runtime_arg.ml"
     Mirage_runtime.gc_verbosity
   ;;
   
-  let mirage_runtime_gc_window_size__key = Mirage_runtime.register @@
+  let mirage_runtime_gc_window_size__key = Mirage_runtime.register_arg @@
   # 42 "lib/devices/runtime_arg.ml"
     Mirage_runtime.gc_window_size
   ;;
   
-  let mirage_runtime_custom_major_ratio__key = Mirage_runtime.register @@
+  let mirage_runtime_custom_major_ratio__key = Mirage_runtime.register_arg @@
   # 43 "lib/devices/runtime_arg.ml"
     Mirage_runtime.custom_major_ratio
   ;;
   
-  let mirage_runtime_custom_minor_ratio__key = Mirage_runtime.register @@
+  let mirage_runtime_custom_minor_ratio__key = Mirage_runtime.register_arg @@
   # 44 "lib/devices/runtime_arg.ml"
     Mirage_runtime.custom_minor_ratio
   ;;
   
-  let mirage_runtime_custom_minor_max_size__key = Mirage_runtime.register @@
+  let mirage_runtime_custom_minor_max_size__key = Mirage_runtime.register_arg @@
   # 45 "lib/devices/runtime_arg.ml"
     Mirage_runtime.custom_minor_max_size
   ;;
   
-  let mirage_runtime_logs__key = Mirage_runtime.register @@
+  let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
   # 143 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;


### PR DESCRIPTION
The name `Mirage_runtime.register` is slightly too generic in my opinion.