### PR TITLE
OCaml runtime arguments are now in cmdliner-stdlib

### DIFF
--- a/lib/devices/runtime_arg.ml
+++ b/lib/devices/runtime_arg.ml
@@ -31,18 +31,6 @@ let runtime_network_key ~pos fmt =
     ("Mirage_runtime_network." ^^ fmt)
 
 let delay = runtime_arg ~pos:__POS__ "delay"
-let backtrace = runtime_arg ~pos:__POS__ "backtrace"
-let randomize_hashtables = runtime_arg ~pos:__POS__ "randomize_hashtables"
-let allocation_policy = runtime_arg ~pos:__POS__ "allocation_policy"
-let minor_heap_size = runtime_arg ~pos:__POS__ "minor_heap_size"
-let major_heap_increment = runtime_arg ~pos:__POS__ "major_heap_increment"
-let space_overhead = runtime_arg ~pos:__POS__ "space_overhead"
-let max_space_overhead = runtime_arg ~pos:__POS__ "max_space_overhead"
-let gc_verbosity = runtime_arg ~pos:__POS__ "gc_verbosity"
-let gc_window_size = runtime_arg ~pos:__POS__ "gc_window_size"
-let custom_major_ratio = runtime_arg ~pos:__POS__ "custom_major_ratio"
-let custom_minor_ratio = runtime_arg ~pos:__POS__ "custom_minor_ratio"
-let custom_minor_max_size = runtime_arg ~pos:__POS__ "custom_minor_max_size"
 
 let pp_group ppf = function
   | None | Some "" -> ()

--- a/lib/devices/runtime_arg.mli
+++ b/lib/devices/runtime_arg.mli
@@ -28,37 +28,6 @@ val create :
 val v : 'a arg -> Functoria.Runtime_arg.t
 (** [v k] is the [k] with its type hidden. *)
 
-(** {2 OCaml Arguments}
-
-    The OCaml runtime is usually configurable via the [OCAMLRUNPARAM]
-    environment variable. We provide boot parameters covering these options. *)
-
-val backtrace : bool runtime_arg
-(** [--backtrace]: Output a backtrace if an uncaught exception terminated the
-    unikernel. *)
-
-val randomize_hashtables : bool runtime_arg
-(** [--randomize-hashtables]: Randomize all hash tables. *)
-
-(** {3 GC control}
-
-    The OCaml garbage collector can be configured, as described in detail in
-    {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html#TYPEcontrol} GC
-      control}.
-
-    The following arguments allow boot time configuration. *)
-
-val allocation_policy : [ `Next_fit | `First_fit | `Best_fit ] runtime_arg
-val minor_heap_size : int option runtime_arg
-val major_heap_increment : int option runtime_arg
-val space_overhead : int option runtime_arg
-val max_space_overhead : int option runtime_arg
-val gc_verbosity : int option runtime_arg
-val gc_window_size : int option runtime_arg
-val custom_major_ratio : int option runtime_arg
-val custom_minor_ratio : int option runtime_arg
-val custom_minor_max_size : int option runtime_arg
-
 (** {3 Network Arguments} *)
 
 val interface : ?group:string -> ?docs:string -> string -> string runtime_arg

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -404,7 +404,7 @@ let runtime_args argv =
     ~runtime_modname:"Mirage_runtime" argv
 
 let ocaml_runtime =
-  let packages = [ package ~min:"1.0.0" ~max:"2.0.0" "cmdliner-stdlib" ] in
+  let packages = [ package ~min:"1.0.1" ~max:"2.0.0" "cmdliner-stdlib" ] in
   let runtime_args =
     [
       Runtime_arg.v

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -16,6 +16,9 @@
 
 open Cmdliner
 
+let register = Functoria_runtime.register_arg
+let register_arg = Functoria_runtime.register_arg
+
 (* The order of the argument sections in the manpage can be enforced in the call to [with_argv] *)
 let s_net = "NETWORK OPTIONS"
 let s_log = "LOG AND MONITORING OPTIONS"
@@ -71,125 +74,181 @@ module Conv = struct
     (Arg.enum enum, Arg.doc_alts_enum enum)
 end
 
-let backtrace =
-  let doc =
-    "Trigger the printing of a stack backtrace when an uncaught exception \
-     aborts the unikernel."
-  in
-  let doc = Arg.info ~docs:s_ocaml ~docv:"BOOL" ~doc [ "backtrace" ] in
-  Arg.(value & opt bool true doc)
+module OCaml = struct
+  let backtrace =
+    let doc =
+      "Trigger the printing of a stack backtrace when an uncaught exception \
+       aborts the unikernel."
+    in
+    let doc = Arg.info ~docs:s_ocaml ~docv:"BOOL" ~doc [ "backtrace" ] in
+    register_arg Arg.(value & opt bool true doc)
 
-let randomize_hashtables =
-  let doc = "Turn on randomization of all hash tables by default." in
-  let doc =
-    Arg.info ~docs:s_ocaml ~docv:"BOOL" ~doc [ "randomize-hashtables" ]
-  in
-  Arg.(value & opt bool true doc)
+  let randomize_hashtables =
+    let doc = "Turn on randomization of all hash tables by default." in
+    let doc =
+      Arg.info ~docs:s_ocaml ~docv:"BOOL" ~doc [ "randomize-hashtables" ]
+    in
+    register_arg Arg.(value & opt bool true doc)
 
-let allocation_policy =
-  let doc =
-    Printf.sprintf
-      "The policy used for allocating in the OCaml heap. Possible values are: \
-       %s. Best-fit is only supported since OCaml 4.10."
-      Conv.allocation_policy_doc_alts
-  in
-  let doc =
-    Arg.info ~docs:s_ocaml ~docv:"ALLOCATION" ~doc [ "allocation-policy" ]
-  in
-  Arg.(value & opt Conv.allocation_policy `Best_fit doc)
+  let allocation_policy =
+    let doc =
+      Printf.sprintf
+        "The policy used for allocating in the OCaml heap. Possible values \
+         are: %s. Best-fit is only supported since OCaml 4.10."
+        Conv.allocation_policy_doc_alts
+    in
+    let doc =
+      Arg.info ~docs:s_ocaml ~docv:"ALLOCATION" ~doc [ "allocation-policy" ]
+    in
+    register_arg Arg.(value & opt Conv.allocation_policy `Best_fit doc)
 
-let minor_heap_size =
-  let doc = "The size of the minor heap (in words). Default: 256k." in
-  let doc =
-    Arg.info ~docs:s_ocaml ~docv:"MINOR SIZE" ~doc [ "minor-heap-size" ]
-  in
-  Arg.(value & opt (some int) None doc)
+  let minor_heap_size =
+    let doc = "The size of the minor heap (in words). Default: 256k." in
+    let doc =
+      Arg.info ~docs:s_ocaml ~docv:"MINOR SIZE" ~doc [ "minor-heap-size" ]
+    in
+    register_arg Arg.(value & opt (some int) None doc)
 
-let major_heap_increment =
-  let doc =
-    "The size increment for the major heap (in words). If less than or equal \
-     1000, it is a percentage of the current heap size. If more than 1000, it \
-     is a fixed number of words. Default: 15."
-  in
-  let doc =
-    Arg.info ~docs:s_ocaml ~docv:"MAJOR INCREMENT" ~doc
-      [ "major-heap-increment" ]
-  in
-  Arg.(value & opt (some int) None doc)
+  let major_heap_increment =
+    let doc =
+      "The size increment for the major heap (in words). If less than or equal \
+       1000, it is a percentage of the current heap size. If more than 1000, \
+       it is a fixed number of words. Default: 15."
+    in
+    let doc =
+      Arg.info ~docs:s_ocaml ~docv:"MAJOR INCREMENT" ~doc
+        [ "major-heap-increment" ]
+    in
+    register_arg Arg.(value & opt (some int) None doc)
 
-let space_overhead =
-  let doc =
-    "The percentage of live data of wasted memory, due to GC does not \
-     immediately collect unreachable blocks. The major GC speed is computed \
-     from this parameter, it will work more if smaller. Default: 80."
-  in
-  let doc =
-    Arg.info ~docs:s_ocaml ~docv:"SPACE OVERHEAD" ~doc [ "space-overhead" ]
-  in
-  Arg.(value & opt (some int) None doc)
+  let space_overhead =
+    let doc =
+      "The percentage of live data of wasted memory, due to GC does not \
+       immediately collect unreachable blocks. The major GC speed is computed \
+       from this parameter, it will work more if smaller. Default: 80."
+    in
+    let doc =
+      Arg.info ~docs:s_ocaml ~docv:"SPACE OVERHEAD" ~doc [ "space-overhead" ]
+    in
+    register_arg Arg.(value & opt (some int) None doc)
 
-let max_space_overhead =
-  let doc =
-    "Heap compaction is triggered when the estimated amount of wasted memory \
-     exceeds this (percentage of live data). If above 1000000, compaction is \
-     never triggered. Default: 500."
-  in
-  let doc =
-    Arg.info ~docs:s_ocaml ~docv:"MAX SPACE OVERHEAD" ~doc
-      [ "max-space-overhead" ]
-  in
-  Arg.(value & opt (some int) None doc)
+  let max_space_overhead =
+    let doc =
+      "Heap compaction is triggered when the estimated amount of wasted memory \
+       exceeds this (percentage of live data). If above 1000000, compaction is \
+       never triggered. Default: 500."
+    in
+    let doc =
+      Arg.info ~docs:s_ocaml ~docv:"MAX SPACE OVERHEAD" ~doc
+        [ "max-space-overhead" ]
+    in
+    register_arg Arg.(value & opt (some int) None doc)
 
-let gc_verbosity =
-  let doc =
-    "GC messages on standard error output. Sum of flags. Check GC module \
-     documentation for details."
-  in
-  let doc = Arg.info ~docs:s_ocaml ~docv:"VERBOSITY" ~doc [ "gc-verbosity" ] in
-  Arg.(value & opt (some int) None doc)
+  let gc_verbosity =
+    let doc =
+      "GC messages on standard error output. Sum of flags. Check GC module \
+       documentation for details."
+    in
+    let doc =
+      Arg.info ~docs:s_ocaml ~docv:"VERBOSITY" ~doc [ "gc-verbosity" ]
+    in
+    register_arg Arg.(value & opt (some int) None doc)
 
-let gc_window_size =
-  let doc =
-    "The size of the window used by the major GC for smoothing out variations \
-     in its workload. Between 1 adn 50, default: 1."
-  in
-  let doc =
-    Arg.info ~docs:s_ocaml ~docv:"WINDOW SIZE" ~doc [ "gc-window-size" ]
-  in
-  Arg.(value & opt (some int) None doc)
+  let gc_window_size =
+    let doc =
+      "The size of the window used by the major GC for smoothing out \
+       variations in its workload. Between 1 adn 50, default: 1."
+    in
+    let doc =
+      Arg.info ~docs:s_ocaml ~docv:"WINDOW SIZE" ~doc [ "gc-window-size" ]
+    in
+    register_arg Arg.(value & opt (some int) None doc)
 
-let custom_major_ratio =
-  let doc =
-    "Target ratio of floating garbage to major heap size for out-of-heap \
-     memory held by custom values. Default: 44."
-  in
-  let doc =
-    Arg.info ~docs:s_ocaml ~docv:"CUSTOM MAJOR RATIO" ~doc
-      [ "custom-major-ratio" ]
-  in
-  Arg.(value & opt (some int) None doc)
+  let custom_major_ratio =
+    let doc =
+      "Target ratio of floating garbage to major heap size for out-of-heap \
+       memory held by custom values. Default: 44."
+    in
+    let doc =
+      Arg.info ~docs:s_ocaml ~docv:"CUSTOM MAJOR RATIO" ~doc
+        [ "custom-major-ratio" ]
+    in
+    register_arg Arg.(value & opt (some int) None doc)
 
-let custom_minor_ratio =
-  let doc =
-    "Bound on floating garbage for out-of-heap memory held by custom values in \
-     the minor heap. Default: 100."
-  in
-  let doc =
-    Arg.info ~docs:s_ocaml ~docv:"CUSTOM MINOR RATIO" ~doc
-      [ "custom-minor-ratio" ]
-  in
-  Arg.(value & opt (some int) None doc)
+  let custom_minor_ratio =
+    let doc =
+      "Bound on floating garbage for out-of-heap memory held by custom values \
+       in the minor heap. Default: 100."
+    in
+    let doc =
+      Arg.info ~docs:s_ocaml ~docv:"CUSTOM MINOR RATIO" ~doc
+        [ "custom-minor-ratio" ]
+    in
+    register_arg Arg.(value & opt (some int) None doc)
 
-let custom_minor_max_size =
-  let doc =
-    "Maximum amount of out-of-heap memory for each custom value allocated in \
-     the minor heap. Default: 8192 bytes."
-  in
-  let doc =
-    Arg.info ~docs:s_ocaml ~docv:"CUSTOM MINOR MAX SIZE" ~doc
-      [ "custom-minor-max-size" ]
-  in
-  Arg.(value & opt (some int) None doc)
+  let custom_minor_max_size =
+    let doc =
+      "Maximum amount of out-of-heap memory for each custom value allocated in \
+       the minor heap. Default: 8192 bytes."
+    in
+    let doc =
+      Arg.info ~docs:s_ocaml ~docv:"CUSTOM MINOR MAX SIZE" ~doc
+        [ "custom-minor-max-size" ]
+    in
+    register_arg Arg.(value & opt (some int) None doc)
+
+  let set_gc allocation_policy minor_heap_size major_heap_increment
+      space_overhead max_overhead verbose window_size custom_major_ratio
+      custom_minor_ratio custom_minor_max_size =
+    let ctrl = Gc.get () in
+    let allocation_policy =
+      match allocation_policy with
+      | `Next_fit -> 0
+      | `First_fit -> 1
+      | `Best_fit -> 2
+    and minor_heap_size =
+      Option.value ~default:ctrl.minor_heap_size minor_heap_size
+    and major_heap_increment =
+      Option.value ~default:ctrl.major_heap_increment major_heap_increment
+    and space_overhead =
+      Option.value ~default:ctrl.space_overhead space_overhead
+    and max_overhead = Option.value ~default:ctrl.max_overhead max_overhead
+    and verbose = Option.value ~default:ctrl.verbose verbose
+    and window_size = Option.value ~default:ctrl.window_size window_size
+    and custom_major_ratio =
+      Option.value ~default:ctrl.custom_major_ratio custom_major_ratio
+    and custom_minor_ratio =
+      Option.value ~default:ctrl.custom_minor_ratio custom_minor_ratio
+    and custom_minor_max_size =
+      Option.value ~default:ctrl.custom_minor_max_size custom_minor_max_size
+    in
+    Gc.set
+      {
+        ctrl with
+        allocation_policy;
+        minor_heap_size;
+        major_heap_increment;
+        space_overhead;
+        max_overhead;
+        verbose;
+        window_size;
+        custom_major_ratio;
+        custom_minor_ratio;
+        custom_minor_max_size;
+      }
+
+  let connect () =
+    let set_backtrace doit = Printexc.record_backtrace doit
+    and set_randomize_hashtables doit = if doit then Hashtbl.randomize () in
+    set_backtrace (backtrace ());
+    set_randomize_hashtables (randomize_hashtables ());
+    set_gc (allocation_policy ()) (minor_heap_size ()) (major_heap_increment ())
+      (space_overhead ()) (max_space_overhead ()) (gc_verbosity ())
+      (gc_window_size ()) (custom_major_ratio ()) (custom_minor_ratio ())
+      (custom_minor_max_size ())
+end
+
+let configure_ocaml_runtime () = OCaml.connect ()
 
 let logs =
   let docs = s_log in
@@ -256,7 +315,5 @@ let with_argv =
       [ Manpage.s_arguments; Manpage.s_options; s_net; s_log; s_disk; s_ocaml ]
 
 let runtime_args = Functoria_runtime.runtime_args
-let register = Functoria_runtime.register_arg
-let register_arg = Functoria_runtime.register_arg
 let argument_error = Functoria_runtime.argument_error
 let help_version = Functoria_runtime.help_version

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -55,37 +55,6 @@ val s_log : string
 val s_ocaml : string
 (** [s_ocaml] is used for OCaml runtime keys. *)
 
-(** {2 OCaml runtime keys}
-
-    The OCaml runtime is usually configurable via the [OCAMLRUNPARAM]
-    environment variable. We provide boot parameters covering these options. *)
-
-val backtrace : bool Term.t
-(** [--backtrace]: Output a backtrace if an uncaught exception terminated the
-    unikernel. *)
-
-val randomize_hashtables : bool Term.t
-(** [--randomize-hashtables]: Randomize all hash tables. *)
-
-(** {3 GC control}
-
-    The OCaml garbage collector can be configured, as described in detail in
-    {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html#TYPEcontrol} GC
-      control}.
-
-    The following Term.ts allow boot time configuration. *)
-
-val allocation_policy : [ `Next_fit | `First_fit | `Best_fit ] Term.t
-val minor_heap_size : int option Term.t
-val major_heap_increment : int option Term.t
-val space_overhead : int option Term.t
-val max_space_overhead : int option Term.t
-val gc_verbosity : int option Term.t
-val gc_window_size : int option Term.t
-val custom_major_ratio : int option Term.t
-val custom_minor_ratio : int option Term.t
-val custom_minor_max_size : int option Term.t
-
 (** {3 Blocks} *)
 
 val disk : string Term.t
@@ -139,6 +108,16 @@ val argument_error : int
 val help_version : int
 (** [help_version] is the exit code used when help/version is used: 63. *)
 
+val configure_ocaml_runtime : unit -> unit
+(** [configure_ocaml_runtime ()] uses boot arguments to configure the OCaml
+    runtime (GC settings, backtrace, hashtable randomization). *)
+
+val register_arg : 'a Cmdliner.Term.t -> unit -> 'a
+(** [register_arg term] registers term to be evaluated at boot time. An example
+    is: [let hello = register_arg <myterm>] (at the toplevel of the unikernel),
+    and in the unikernel code
+    [Logs.info (fun m -> m "hello argument is: %s" (hello ()))]. *)
+
 (** / *)
 
 val with_argv : unit Cmdliner.Term.t list -> string -> string array -> unit
@@ -146,5 +125,3 @@ val runtime_args : unit -> unit Cmdliner.Term.t list
 
 val register : 'a Cmdliner.Term.t -> unit -> 'a
 [@@ocaml.deprecated "Use Mirage_runtime.register_arg instead."]
-
-val register_arg : 'a Cmdliner.Term.t -> unit -> 'a

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -48,9 +48,6 @@ val s_disk : string
 val s_log : string
 (** [s_log] is used for logging and monitoring options. *)
 
-val s_ocaml : string
-(** [s_ocaml] is used for OCaml runtime keys. *)
-
 (** {3 Blocks} *)
 
 val disk : string Term.t

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -36,10 +36,6 @@ val logs : log_threshold list Term.t
 module Conv : sig
   val log_threshold : log_threshold Cmdliner.Arg.conv
   (** [log_threshold] converts log reporter threshold. *)
-
-  val allocation_policy :
-    [ `Next_fit | `First_fit | `Best_fit ] Cmdliner.Arg.conv
-  (** [allocation_policy] converts allocation policy. *)
 end
 
 (** {2 Manpage sections} *)
@@ -107,10 +103,6 @@ val argument_error : int
 
 val help_version : int
 (** [help_version] is the exit code used when help/version is used: 63. *)
-
-val configure_ocaml_runtime : unit -> unit
-(** [configure_ocaml_runtime ()] uses boot arguments to configure the OCaml
-    runtime (GC settings, backtrace, hashtable randomization). *)
 
 val register_arg : 'a Cmdliner.Term.t -> unit -> 'a
 (** [register_arg term] registers term to be evaluated at boot time. An example

--- a/test/mirage/describe/run.t
+++ b/test/mirage/describe/run.t
@@ -67,7 +67,7 @@ Describe before configure (no eval)
                 50 [label="pclock__50\nPclock\n", shape="box"];
                 51 [label="mirage_logs_make__51\nMirage_logs.Make\n", shape="box"];
                 52 [label="mirage_runtime__52\nMirage_runtime\n", shape="box"];
-                53 [label="mirage_runtime__53\nMirage_runtime\n", shape="box"];
+                53 [label="cmdliner_stdlib__53\nCmdliner_stdlib\n", shape="box"];
                 54 [label="mirage_bootvar__54\nMirage_bootvar\n", shape="box"];
                 55 [label="mirage_bootvar__55\nMirage_bootvar\n", shape="box"];
                 56 [label="mirage_bootvar__56\nMirage_bootvar\n", shape="box"];

--- a/test/mirage/describe/run.t
+++ b/test/mirage/describe/run.t
@@ -67,15 +67,13 @@ Describe before configure (no eval)
                 50 [label="pclock__50\nPclock\n", shape="box"];
                 51 [label="mirage_logs_make__51\nMirage_logs.Make\n", shape="box"];
                 52 [label="mirage_runtime__52\nMirage_runtime\n", shape="box"];
-                53 [label="gc__53\nGc\n", shape="box"];
-                54 [label="hashtbl__54\nHashtbl\n", shape="box"];
-                55 [label="printexc__55\nPrintexc\n", shape="box"];
+                53 [label="mirage_runtime__53\nMirage_runtime\n", shape="box"];
+                54 [label="mirage_bootvar__54\nMirage_bootvar\n", shape="box"];
+                55 [label="mirage_bootvar__55\nMirage_bootvar\n", shape="box"];
                 56 [label="mirage_bootvar__56\nMirage_bootvar\n", shape="box"];
-                57 [label="mirage_bootvar__57\nMirage_bootvar\n", shape="box"];
-                58 [label="mirage_bootvar__58\nMirage_bootvar\n", shape="box"];
-                59 [label="If\ntarget"];
-                60 [label="struct_end__60\nstruct end\n", shape="box"];
-                61 [label="mirage_runtime__61\nMirage_runtime\ntarget", shape="box"];
+                57 [label="If\ntarget"];
+                58 [label="struct_end__58\nstruct end\n", shape="box"];
+                59 [label="mirage_runtime__59\nMirage_runtime\ntarget", shape="box"];
                 
                 3 -> 2 [style="dashed"];
                 3 -> 1 [style="dashed"];
@@ -171,22 +169,20 @@ Describe before configure (no eval)
                 48 -> 47 [style="bold", style="dotted", headport="n"];
                 49 -> 48 [];
                 51 -> 50 [];
-                59 -> 56 [style="dotted", headport="n"];
-                59 -> 56 [style="dotted", headport="n"];
-                59 -> 57 [style="dotted", headport="n"];
-                59 -> 57 [style="dotted", headport="n"];
-                59 -> 57 [style="dotted", headport="n"];
-                59 -> 57 [style="dotted", headport="n"];
-                59 -> 57 [style="dotted", headport="n"];
-                59 -> 58 [style="bold", style="dotted", headport="n"];
-                60 -> 59 [style="dashed"];
-                61 -> 60 [style="dashed"];
-                61 -> 55 [style="dashed"];
-                61 -> 54 [style="dashed"];
-                61 -> 53 [style="dashed"];
-                61 -> 52 [style="dashed"];
-                61 -> 51 [style="dashed"];
-                61 -> 49 [style="dashed"];
+                57 -> 54 [style="dotted", headport="n"];
+                57 -> 54 [style="dotted", headport="n"];
+                57 -> 55 [style="dotted", headport="n"];
+                57 -> 55 [style="dotted", headport="n"];
+                57 -> 55 [style="dotted", headport="n"];
+                57 -> 55 [style="dotted", headport="n"];
+                57 -> 55 [style="dotted", headport="n"];
+                57 -> 56 [style="bold", style="dotted", headport="n"];
+                58 -> 57 [style="dashed"];
+                59 -> 58 [style="dashed"];
+                59 -> 53 [style="dashed"];
+                59 -> 52 [style="dashed"];
+                59 -> 51 [style="dashed"];
+                59 -> 49 [style="dashed"];
                 }
 
 Describe after configure

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -11,7 +11,7 @@ Query unikernel dune
   
   (executable
    (name main)
-   (libraries duration lwt mirage-bootvar mirage-bootvar.unix
+   (libraries cmdliner-stdlib duration lwt mirage-bootvar mirage-bootvar.unix
      mirage-clock-unix mirage-logs mirage-runtime mirage-unix)
    (link_flags (-thread))
    (modules (:standard \ config))
@@ -111,7 +111,7 @@ Query unikernel dune (hvt)
    (enabled_if (= %{context_name} "solo5"))
    (name main)
    (modes (native exe))
-   (libraries duration lwt mirage-bootvar mirage-bootvar.solo5
+   (libraries cmdliner-stdlib duration lwt mirage-bootvar mirage-bootvar.solo5
      mirage-clock-solo5 mirage-logs mirage-runtime mirage-solo5)
    (link_flags :standard -w -70 -cclib "-z solo5-abi=hvt")
    (modules (:standard \ config manifest))

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -21,7 +21,7 @@ Query opam file
   ]
   
   depends: [
-    "cmdliner-stdlib" { ?monorepo & >= "1.0.0" & < "2.0.0" }
+    "cmdliner-stdlib" { ?monorepo & >= "1.0.1" & < "2.0.0" }
     "duration" { ?monorepo & < "1.0.0" }
     "lwt" { ?monorepo }
     "mirage" { build & >= "4.8.0" & < "4.9.0" }
@@ -52,7 +52,7 @@ Query opam file
 
 Query packages
   $ ./config.exe query --target hvt packages
-  "cmdliner-stdlib" { ?monorepo & >= "1.0.0" & < "2.0.0" }
+  "cmdliner-stdlib" { ?monorepo & >= "1.0.1" & < "2.0.0" }
   "duration" { ?monorepo & < "1.0.0" }
   "lwt" { ?monorepo }
   "mirage" { build & >= "4.8.0" & < "4.9.0" }

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -21,6 +21,7 @@ Query opam file
   ]
   
   depends: [
+    "cmdliner-stdlib" { ?monorepo & >= "1.0.0" & < "2.0.0" }
     "duration" { ?monorepo & < "1.0.0" }
     "lwt" { ?monorepo }
     "mirage" { build & >= "4.8.0" & < "4.9.0" }
@@ -51,6 +52,7 @@ Query opam file
 
 Query packages
   $ ./config.exe query --target hvt packages
+  "cmdliner-stdlib" { ?monorepo & >= "1.0.0" & < "2.0.0" }
   "duration" { ?monorepo & < "1.0.0" }
   "lwt" { ?monorepo }
   "mirage" { build & >= "4.8.0" & < "4.9.0" }
@@ -258,7 +260,7 @@ Query unikernel dune
    (enabled_if (= %{context_name} "solo5"))
    (name main)
    (modes (native exe))
-   (libraries duration lwt mirage-bootvar mirage-bootvar.solo5
+   (libraries cmdliner-stdlib duration lwt mirage-bootvar mirage-bootvar.solo5
      mirage-clock-solo5 mirage-logs mirage-runtime mirage-solo5)
    (link_flags :standard -w -70 -cclib "-z solo5-abi=hvt")
    (modules (:standard \ config manifest))

--- a/test/mirage/query/run-noop.t
+++ b/test/mirage/query/run-noop.t
@@ -11,7 +11,7 @@ Query unikernel dune
   
   (executable
    (name main)
-   (libraries duration lwt mirage-bootvar mirage-bootvar.unix
+   (libraries cmdliner-stdlib duration lwt mirage-bootvar mirage-bootvar.unix
      mirage-clock-unix mirage-logs mirage-runtime mirage-unix)
    (link_flags (-thread))
    (modules (:standard \ config))
@@ -111,7 +111,7 @@ Query unikernel dune (hvt)
    (enabled_if (= %{context_name} "solo5"))
    (name main)
    (modes (native exe))
-   (libraries duration lwt mirage-bootvar mirage-bootvar.solo5
+   (libraries cmdliner-stdlib duration lwt mirage-bootvar mirage-bootvar.solo5
      mirage-clock-solo5 mirage-logs mirage-runtime mirage-solo5)
    (link_flags :standard -w -70 -cclib "-z solo5-abi=hvt")
    (modules (:standard \ config manifest))

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -25,6 +25,7 @@ Query opam file
   ]
   
   depends: [
+    "cmdliner-stdlib" { ?monorepo & >= "1.0.0" & < "2.0.0" }
     "duration" { ?monorepo & < "1.0.0" }
     "lwt" { ?monorepo }
     "mirage" { build & >= "4.8.0" & < "4.9.0" }
@@ -53,6 +54,7 @@ Query opam file
 
 Query packages
   $ ./config.exe query packages
+  "cmdliner-stdlib" { ?monorepo & >= "1.0.0" & < "2.0.0" }
   "duration" { ?monorepo & < "1.0.0" }
   "lwt" { ?monorepo }
   "mirage" { build & >= "4.8.0" & < "4.9.0" }
@@ -262,7 +264,7 @@ Query unikernel dune
   
   (executable
    (name main)
-   (libraries duration lwt mirage-bootvar mirage-bootvar.unix
+   (libraries cmdliner-stdlib duration lwt mirage-bootvar mirage-bootvar.unix
      mirage-clock-unix mirage-logs mirage-runtime mirage-unix)
    (link_flags (-thread))
    (modules (:standard \ config))

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -25,7 +25,7 @@ Query opam file
   ]
   
   depends: [
-    "cmdliner-stdlib" { ?monorepo & >= "1.0.0" & < "2.0.0" }
+    "cmdliner-stdlib" { ?monorepo & >= "1.0.1" & < "2.0.0" }
     "duration" { ?monorepo & < "1.0.0" }
     "lwt" { ?monorepo }
     "mirage" { build & >= "4.8.0" & < "4.9.0" }
@@ -54,7 +54,7 @@ Query opam file
 
 Query packages
   $ ./config.exe query packages
-  "cmdliner-stdlib" { ?monorepo & >= "1.0.0" & < "2.0.0" }
+  "cmdliner-stdlib" { ?monorepo & >= "1.0.1" & < "2.0.0" }
   "duration" { ?monorepo & < "1.0.0" }
   "lwt" { ?monorepo }
   "mirage" { build & >= "4.8.0" & < "4.9.0" }

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -32,88 +32,28 @@ Configure the project for Unix:
     Mirage_runtime.delay
   ;;
   
-  let mirage_runtime_backtrace__key = Mirage_runtime.register_arg @@
-  # 34 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.backtrace
-  ;;
-  
-  let mirage_runtime_randomize_hashtables__key = Mirage_runtime.register_arg @@
-  # 35 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.randomize_hashtables
-  ;;
-  
-  let mirage_runtime_allocation_policy__key = Mirage_runtime.register_arg @@
-  # 36 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.allocation_policy
-  ;;
-  
-  let mirage_runtime_minor_heap_size__key = Mirage_runtime.register_arg @@
-  # 37 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.minor_heap_size
-  ;;
-  
-  let mirage_runtime_major_heap_increment__key = Mirage_runtime.register_arg @@
-  # 38 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.major_heap_increment
-  ;;
-  
-  let mirage_runtime_space_overhead__key = Mirage_runtime.register_arg @@
-  # 39 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.space_overhead
-  ;;
-  
-  let mirage_runtime_max_space_overhead__key = Mirage_runtime.register_arg @@
-  # 40 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.max_space_overhead
-  ;;
-  
-  let mirage_runtime_gc_verbosity__key = Mirage_runtime.register_arg @@
-  # 41 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.gc_verbosity
-  ;;
-  
-  let mirage_runtime_gc_window_size__key = Mirage_runtime.register_arg @@
-  # 42 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.gc_window_size
-  ;;
-  
-  let mirage_runtime_custom_major_ratio__key = Mirage_runtime.register_arg @@
-  # 43 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.custom_major_ratio
-  ;;
-  
-  let mirage_runtime_custom_minor_ratio__key = Mirage_runtime.register_arg @@
-  # 44 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.custom_minor_ratio
-  ;;
-  
-  let mirage_runtime_custom_minor_max_size__key = Mirage_runtime.register_arg @@
-  # 45 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.custom_minor_max_size
-  ;;
-  
   let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
-  # 208 "lib/devices/runtime_arg.ml"
+  # 196 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;
   
-  # 78 "mirage/main.ml"
+  # 18 "mirage/main.ml"
   
-  module Mirage_logs_make__8 = Mirage_logs.Make(Pclock)
+  module Mirage_logs_make__6 = Mirage_logs.Make(Pclock)
   
-  # 82 "mirage/main.ml"
+  # 22 "mirage/main.ml"
   
-  module Mirage_crypto_rng_mirage_make__11 = Mirage_crypto_rng_mirage.Make(Unix_os.Time)(Mclock)
+  module Mirage_crypto_rng_mirage_make__9 = Mirage_crypto_rng_mirage.Make(Unix_os.Time)(Mclock)
   
-  # 86 "mirage/main.ml"
+  # 26 "mirage/main.ml"
   
-  module App_make__12 = App.Make(Mirage_crypto_rng_mirage_make__11)
+  module App_make__10 = App.Make(Mirage_crypto_rng_mirage_make__9)
   
   let mirage_bootvar__1 = lazy (
   # 15 "lib/devices/argv.ml"
     return (Mirage_bootvar.argv ())
   );;
-  # 94 "mirage/main.ml"
+  # 34 "mirage/main.ml"
   
   let struct_end__2 = lazy (
     let __mirage_bootvar__1 = Lazy.force mirage_bootvar__1 in
@@ -121,131 +61,88 @@ Configure the project for Unix:
   # 47 "lib/functoria/job.ml"
     return Mirage_runtime.(with_argv (runtime_args ()) "random" _mirage_bootvar__1)
   );;
-  # 102 "mirage/main.ml"
+  # 42 "mirage/main.ml"
   
-  let printexc__3 = lazy (
-    let _mirage_runtime_backtrace = (mirage_runtime_backtrace__key ()) in
-  # 404 "lib/mirage.ml"
-    return (Printexc.record_backtrace _mirage_runtime_backtrace)
+  let mirage_runtime__3 = lazy (
+  # 408 "lib/mirage.ml"
+    return (Mirage_runtime.configure_ocaml_runtime ())
   );;
-  # 109 "mirage/main.ml"
+  # 48 "mirage/main.ml"
   
-  let hashtbl__4 = lazy (
-    let _mirage_runtime_randomize_hashtables = (mirage_runtime_randomize_hashtables__key ()) in
-  # 413 "lib/mirage.ml"
-    return (if _mirage_runtime_randomize_hashtables then Hashtbl.randomize ())
-  );;
-  # 116 "mirage/main.ml"
-  
-  let gc__5 = lazy (
-    let _mirage_runtime_allocation_policy = (mirage_runtime_allocation_policy__key ()) in
-    let _mirage_runtime_minor_heap_size = (mirage_runtime_minor_heap_size__key ()) in
-    let _mirage_runtime_major_heap_increment = (mirage_runtime_major_heap_increment__key ()) in
-    let _mirage_runtime_space_overhead = (mirage_runtime_space_overhead__key ()) in
-    let _mirage_runtime_max_space_overhead = (mirage_runtime_max_space_overhead__key ()) in
-    let _mirage_runtime_gc_verbosity = (mirage_runtime_gc_verbosity__key ()) in
-    let _mirage_runtime_gc_window_size = (mirage_runtime_gc_window_size__key ()) in
-    let _mirage_runtime_custom_major_ratio = (mirage_runtime_custom_major_ratio__key ()) in
-    let _mirage_runtime_custom_minor_ratio = (mirage_runtime_custom_minor_ratio__key ()) in
-    let _mirage_runtime_custom_minor_max_size = (mirage_runtime_custom_minor_max_size__key ()) in
-  # 465 "lib/mirage.ml"
-    return (
-  let open Gc in
-    let ctrl = get () in
-    set ({ ctrl with allocation_policy = (match _mirage_runtime_allocation_policy with `Next_fit -> 0 | `First_fit -> 1 | `Best_fit -> 2);
-    minor_heap_size = (match _mirage_runtime_minor_heap_size with None -> ctrl.minor_heap_size | Some x -> x);
-    major_heap_increment = (match _mirage_runtime_major_heap_increment with None -> ctrl.major_heap_increment | Some x -> x);
-    space_overhead = (match _mirage_runtime_space_overhead with None -> ctrl.space_overhead | Some x -> x);
-    max_overhead = (match _mirage_runtime_max_space_overhead with None -> ctrl.max_overhead | Some x -> x);
-    verbose = (match _mirage_runtime_gc_verbosity with None -> ctrl.verbose | Some x -> x);
-    window_size = (match _mirage_runtime_gc_window_size with None -> ctrl.window_size | Some x -> x);
-    custom_major_ratio = (match _mirage_runtime_custom_major_ratio with None -> ctrl.custom_major_ratio | Some x -> x);
-    custom_minor_ratio = (match _mirage_runtime_custom_minor_ratio with None -> ctrl.custom_minor_ratio | Some x -> x);
-    custom_minor_max_size = (match _mirage_runtime_custom_minor_max_size with None -> ctrl.custom_minor_max_size | Some x -> x) })
-  )
-  );;
-  # 145 "mirage/main.ml"
-  
-  let mirage_runtime__6 = lazy (
+  let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
   # 309 "lib/mirage.ml"
     Unix_os.Time.sleep_ns (Duration.of_sec _mirage_runtime_delay)
   );;
-  # 152 "mirage/main.ml"
+  # 55 "mirage/main.ml"
   
-  let pclock__7 = lazy (
+  let pclock__5 = lazy (
     return ()
   );;
-  # 157 "mirage/main.ml"
+  # 60 "mirage/main.ml"
   
-  let mirage_logs_make__8 = lazy (
-    let __pclock__7 = Lazy.force pclock__7 in
-    __pclock__7 >>= fun _pclock__7 ->
+  let mirage_logs_make__6 = lazy (
+    let __pclock__5 = Lazy.force pclock__5 in
+    __pclock__5 >>= fun _pclock__5 ->
     let _mirage_runtime_logs = (mirage_runtime_logs__key ()) in
   # 22 "lib/devices/reporter.ml"
-    let reporter = Mirage_logs_make__8.create () in
+    let reporter = Mirage_logs_make__6.create () in
     Mirage_runtime.set_level ~default:(Some Logs.Info) _mirage_runtime_logs;
     Logs.set_reporter reporter;
     Lwt.return reporter
   );;
-  # 169 "mirage/main.ml"
+  # 72 "mirage/main.ml"
   
-  let unix_os_time__9 = lazy (
+  let unix_os_time__7 = lazy (
     return ()
   );;
-  # 174 "mirage/main.ml"
+  # 77 "mirage/main.ml"
   
-  let mclock__10 = lazy (
+  let mclock__8 = lazy (
     return ()
   );;
-  # 179 "mirage/main.ml"
+  # 82 "mirage/main.ml"
   
-  let mirage_crypto_rng_mirage_make__11 = lazy (
-    let __unix_os_time__9 = Lazy.force unix_os_time__9 in
-    let __mclock__10 = Lazy.force mclock__10 in
-    __unix_os_time__9 >>= fun _unix_os_time__9 ->
-    __mclock__10 >>= fun _mclock__10 ->
+  let mirage_crypto_rng_mirage_make__9 = lazy (
+    let __unix_os_time__7 = Lazy.force unix_os_time__7 in
+    let __mclock__8 = Lazy.force mclock__8 in
+    __unix_os_time__7 >>= fun _unix_os_time__7 ->
+    __mclock__8 >>= fun _mclock__8 ->
   # 15 "lib/devices/random.ml"
-    Mirage_crypto_rng_mirage_make__11.initialize (module Mirage_crypto_rng.Fortuna)
+    Mirage_crypto_rng_mirage_make__9.initialize (module Mirage_crypto_rng.Fortuna)
   );;
-  # 189 "mirage/main.ml"
+  # 92 "mirage/main.ml"
   
-  let app_make__12 = lazy (
-    let __mirage_crypto_rng_mirage_make__11 = Lazy.force mirage_crypto_rng_mirage_make__11 in
-    __mirage_crypto_rng_mirage_make__11 >>= fun _mirage_crypto_rng_mirage_make__11 ->
+  let app_make__10 = lazy (
+    let __mirage_crypto_rng_mirage_make__9 = Lazy.force mirage_crypto_rng_mirage_make__9 in
+    __mirage_crypto_rng_mirage_make__9 >>= fun _mirage_crypto_rng_mirage_make__9 ->
   # 3 "config.ml"
-    (App_make__12.start _mirage_crypto_rng_mirage_make__11 : unit io)
+    (App_make__10.start _mirage_crypto_rng_mirage_make__9 : unit io)
   );;
-  # 197 "mirage/main.ml"
+  # 100 "mirage/main.ml"
   
-  let mirage_runtime__13 = lazy (
+  let mirage_runtime__11 = lazy (
     let __struct_end__2 = Lazy.force struct_end__2 in
-    let __printexc__3 = Lazy.force printexc__3 in
-    let __hashtbl__4 = Lazy.force hashtbl__4 in
-    let __gc__5 = Lazy.force gc__5 in
-    let __mirage_runtime__6 = Lazy.force mirage_runtime__6 in
-    let __mirage_logs_make__8 = Lazy.force mirage_logs_make__8 in
-    let __app_make__12 = Lazy.force app_make__12 in
+    let __mirage_runtime__3 = Lazy.force mirage_runtime__3 in
+    let __mirage_runtime__4 = Lazy.force mirage_runtime__4 in
+    let __mirage_logs_make__6 = Lazy.force mirage_logs_make__6 in
+    let __app_make__10 = Lazy.force app_make__10 in
     __struct_end__2 >>= fun _struct_end__2 ->
-    __printexc__3 >>= fun _printexc__3 ->
-    __hashtbl__4 >>= fun _hashtbl__4 ->
-    __gc__5 >>= fun _gc__5 ->
-    __mirage_runtime__6 >>= fun _mirage_runtime__6 ->
-    __mirage_logs_make__8 >>= fun _mirage_logs_make__8 ->
-    __app_make__12 >>= fun _app_make__12 ->
+    __mirage_runtime__3 >>= fun _mirage_runtime__3 ->
+    __mirage_runtime__4 >>= fun _mirage_runtime__4 ->
+    __mirage_logs_make__6 >>= fun _mirage_logs_make__6 ->
+    __app_make__10 >>= fun _app_make__10 ->
   # 392 "lib/mirage.ml"
     return ()
   );;
-  # 217 "mirage/main.ml"
+  # 116 "mirage/main.ml"
   
   let () =
     let t = Lazy.force struct_end__2 >>= fun _ ->
-    Lazy.force printexc__3 >>= fun _ ->
-    Lazy.force hashtbl__4 >>= fun _ ->
-    Lazy.force gc__5 >>= fun _ ->
-    Lazy.force mirage_runtime__6 >>= fun _ ->
-    Lazy.force mirage_logs_make__8 >>= fun _ ->
-    Lazy.force mirage_runtime__13 in
+    Lazy.force mirage_runtime__3 >>= fun _ ->
+    Lazy.force mirage_runtime__4 >>= fun _ ->
+    Lazy.force mirage_logs_make__6 >>= fun _ ->
+    Lazy.force mirage_runtime__11 in
     run t
   ;;
 
@@ -291,88 +188,28 @@ Configure the project for Xen:
     Mirage_runtime.delay
   ;;
   
-  let mirage_runtime_backtrace__key = Mirage_runtime.register_arg @@
-  # 34 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.backtrace
-  ;;
-  
-  let mirage_runtime_randomize_hashtables__key = Mirage_runtime.register_arg @@
-  # 35 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.randomize_hashtables
-  ;;
-  
-  let mirage_runtime_allocation_policy__key = Mirage_runtime.register_arg @@
-  # 36 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.allocation_policy
-  ;;
-  
-  let mirage_runtime_minor_heap_size__key = Mirage_runtime.register_arg @@
-  # 37 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.minor_heap_size
-  ;;
-  
-  let mirage_runtime_major_heap_increment__key = Mirage_runtime.register_arg @@
-  # 38 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.major_heap_increment
-  ;;
-  
-  let mirage_runtime_space_overhead__key = Mirage_runtime.register_arg @@
-  # 39 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.space_overhead
-  ;;
-  
-  let mirage_runtime_max_space_overhead__key = Mirage_runtime.register_arg @@
-  # 40 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.max_space_overhead
-  ;;
-  
-  let mirage_runtime_gc_verbosity__key = Mirage_runtime.register_arg @@
-  # 41 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.gc_verbosity
-  ;;
-  
-  let mirage_runtime_gc_window_size__key = Mirage_runtime.register_arg @@
-  # 42 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.gc_window_size
-  ;;
-  
-  let mirage_runtime_custom_major_ratio__key = Mirage_runtime.register_arg @@
-  # 43 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.custom_major_ratio
-  ;;
-  
-  let mirage_runtime_custom_minor_ratio__key = Mirage_runtime.register_arg @@
-  # 44 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.custom_minor_ratio
-  ;;
-  
-  let mirage_runtime_custom_minor_max_size__key = Mirage_runtime.register_arg @@
-  # 45 "lib/devices/runtime_arg.ml"
-    Mirage_runtime.custom_minor_max_size
-  ;;
-  
   let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
-  # 208 "lib/devices/runtime_arg.ml"
+  # 196 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;
   
-  # 78 "mirage/main.ml"
+  # 18 "mirage/main.ml"
   
-  module Mirage_logs_make__8 = Mirage_logs.Make(Pclock)
+  module Mirage_logs_make__6 = Mirage_logs.Make(Pclock)
   
-  # 82 "mirage/main.ml"
+  # 22 "mirage/main.ml"
   
-  module Mirage_crypto_rng_mirage_make__11 = Mirage_crypto_rng_mirage.Make(Xen_os.Time)(Mclock)
+  module Mirage_crypto_rng_mirage_make__9 = Mirage_crypto_rng_mirage.Make(Xen_os.Time)(Mclock)
   
-  # 86 "mirage/main.ml"
+  # 26 "mirage/main.ml"
   
-  module App_make__12 = App.Make(Mirage_crypto_rng_mirage_make__11)
+  module App_make__10 = App.Make(Mirage_crypto_rng_mirage_make__9)
   
   let mirage_bootvar__1 = lazy (
   # 15 "lib/devices/argv.ml"
     return (Mirage_bootvar.argv ())
   );;
-  # 94 "mirage/main.ml"
+  # 34 "mirage/main.ml"
   
   let struct_end__2 = lazy (
     let __mirage_bootvar__1 = Lazy.force mirage_bootvar__1 in
@@ -380,131 +217,88 @@ Configure the project for Xen:
   # 47 "lib/functoria/job.ml"
     return Mirage_runtime.(with_argv (runtime_args ()) "random" _mirage_bootvar__1)
   );;
-  # 102 "mirage/main.ml"
+  # 42 "mirage/main.ml"
   
-  let printexc__3 = lazy (
-    let _mirage_runtime_backtrace = (mirage_runtime_backtrace__key ()) in
-  # 404 "lib/mirage.ml"
-    return (Printexc.record_backtrace _mirage_runtime_backtrace)
+  let mirage_runtime__3 = lazy (
+  # 408 "lib/mirage.ml"
+    return (Mirage_runtime.configure_ocaml_runtime ())
   );;
-  # 109 "mirage/main.ml"
+  # 48 "mirage/main.ml"
   
-  let hashtbl__4 = lazy (
-    let _mirage_runtime_randomize_hashtables = (mirage_runtime_randomize_hashtables__key ()) in
-  # 413 "lib/mirage.ml"
-    return (if _mirage_runtime_randomize_hashtables then Hashtbl.randomize ())
-  );;
-  # 116 "mirage/main.ml"
-  
-  let gc__5 = lazy (
-    let _mirage_runtime_allocation_policy = (mirage_runtime_allocation_policy__key ()) in
-    let _mirage_runtime_minor_heap_size = (mirage_runtime_minor_heap_size__key ()) in
-    let _mirage_runtime_major_heap_increment = (mirage_runtime_major_heap_increment__key ()) in
-    let _mirage_runtime_space_overhead = (mirage_runtime_space_overhead__key ()) in
-    let _mirage_runtime_max_space_overhead = (mirage_runtime_max_space_overhead__key ()) in
-    let _mirage_runtime_gc_verbosity = (mirage_runtime_gc_verbosity__key ()) in
-    let _mirage_runtime_gc_window_size = (mirage_runtime_gc_window_size__key ()) in
-    let _mirage_runtime_custom_major_ratio = (mirage_runtime_custom_major_ratio__key ()) in
-    let _mirage_runtime_custom_minor_ratio = (mirage_runtime_custom_minor_ratio__key ()) in
-    let _mirage_runtime_custom_minor_max_size = (mirage_runtime_custom_minor_max_size__key ()) in
-  # 465 "lib/mirage.ml"
-    return (
-  let open Gc in
-    let ctrl = get () in
-    set ({ ctrl with allocation_policy = (match _mirage_runtime_allocation_policy with `Next_fit -> 0 | `First_fit -> 1 | `Best_fit -> 2);
-    minor_heap_size = (match _mirage_runtime_minor_heap_size with None -> ctrl.minor_heap_size | Some x -> x);
-    major_heap_increment = (match _mirage_runtime_major_heap_increment with None -> ctrl.major_heap_increment | Some x -> x);
-    space_overhead = (match _mirage_runtime_space_overhead with None -> ctrl.space_overhead | Some x -> x);
-    max_overhead = (match _mirage_runtime_max_space_overhead with None -> ctrl.max_overhead | Some x -> x);
-    verbose = (match _mirage_runtime_gc_verbosity with None -> ctrl.verbose | Some x -> x);
-    window_size = (match _mirage_runtime_gc_window_size with None -> ctrl.window_size | Some x -> x);
-    custom_major_ratio = (match _mirage_runtime_custom_major_ratio with None -> ctrl.custom_major_ratio | Some x -> x);
-    custom_minor_ratio = (match _mirage_runtime_custom_minor_ratio with None -> ctrl.custom_minor_ratio | Some x -> x);
-    custom_minor_max_size = (match _mirage_runtime_custom_minor_max_size with None -> ctrl.custom_minor_max_size | Some x -> x) })
-  )
-  );;
-  # 145 "mirage/main.ml"
-  
-  let mirage_runtime__6 = lazy (
+  let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
   # 309 "lib/mirage.ml"
     Xen_os.Time.sleep_ns (Duration.of_sec _mirage_runtime_delay)
   );;
-  # 152 "mirage/main.ml"
+  # 55 "mirage/main.ml"
   
-  let pclock__7 = lazy (
+  let pclock__5 = lazy (
     return ()
   );;
-  # 157 "mirage/main.ml"
+  # 60 "mirage/main.ml"
   
-  let mirage_logs_make__8 = lazy (
-    let __pclock__7 = Lazy.force pclock__7 in
-    __pclock__7 >>= fun _pclock__7 ->
+  let mirage_logs_make__6 = lazy (
+    let __pclock__5 = Lazy.force pclock__5 in
+    __pclock__5 >>= fun _pclock__5 ->
     let _mirage_runtime_logs = (mirage_runtime_logs__key ()) in
   # 22 "lib/devices/reporter.ml"
-    let reporter = Mirage_logs_make__8.create () in
+    let reporter = Mirage_logs_make__6.create () in
     Mirage_runtime.set_level ~default:(Some Logs.Info) _mirage_runtime_logs;
     Logs.set_reporter reporter;
     Lwt.return reporter
   );;
-  # 169 "mirage/main.ml"
+  # 72 "mirage/main.ml"
   
-  let xen_os_time__9 = lazy (
+  let xen_os_time__7 = lazy (
     return ()
   );;
-  # 174 "mirage/main.ml"
+  # 77 "mirage/main.ml"
   
-  let mclock__10 = lazy (
+  let mclock__8 = lazy (
     return ()
   );;
-  # 179 "mirage/main.ml"
+  # 82 "mirage/main.ml"
   
-  let mirage_crypto_rng_mirage_make__11 = lazy (
-    let __xen_os_time__9 = Lazy.force xen_os_time__9 in
-    let __mclock__10 = Lazy.force mclock__10 in
-    __xen_os_time__9 >>= fun _xen_os_time__9 ->
-    __mclock__10 >>= fun _mclock__10 ->
+  let mirage_crypto_rng_mirage_make__9 = lazy (
+    let __xen_os_time__7 = Lazy.force xen_os_time__7 in
+    let __mclock__8 = Lazy.force mclock__8 in
+    __xen_os_time__7 >>= fun _xen_os_time__7 ->
+    __mclock__8 >>= fun _mclock__8 ->
   # 15 "lib/devices/random.ml"
-    Mirage_crypto_rng_mirage_make__11.initialize (module Mirage_crypto_rng.Fortuna)
+    Mirage_crypto_rng_mirage_make__9.initialize (module Mirage_crypto_rng.Fortuna)
   );;
-  # 189 "mirage/main.ml"
+  # 92 "mirage/main.ml"
   
-  let app_make__12 = lazy (
-    let __mirage_crypto_rng_mirage_make__11 = Lazy.force mirage_crypto_rng_mirage_make__11 in
-    __mirage_crypto_rng_mirage_make__11 >>= fun _mirage_crypto_rng_mirage_make__11 ->
+  let app_make__10 = lazy (
+    let __mirage_crypto_rng_mirage_make__9 = Lazy.force mirage_crypto_rng_mirage_make__9 in
+    __mirage_crypto_rng_mirage_make__9 >>= fun _mirage_crypto_rng_mirage_make__9 ->
   # 3 "config.ml"
-    (App_make__12.start _mirage_crypto_rng_mirage_make__11 : unit io)
+    (App_make__10.start _mirage_crypto_rng_mirage_make__9 : unit io)
   );;
-  # 197 "mirage/main.ml"
+  # 100 "mirage/main.ml"
   
-  let mirage_runtime__13 = lazy (
+  let mirage_runtime__11 = lazy (
     let __struct_end__2 = Lazy.force struct_end__2 in
-    let __printexc__3 = Lazy.force printexc__3 in
-    let __hashtbl__4 = Lazy.force hashtbl__4 in
-    let __gc__5 = Lazy.force gc__5 in
-    let __mirage_runtime__6 = Lazy.force mirage_runtime__6 in
-    let __mirage_logs_make__8 = Lazy.force mirage_logs_make__8 in
-    let __app_make__12 = Lazy.force app_make__12 in
+    let __mirage_runtime__3 = Lazy.force mirage_runtime__3 in
+    let __mirage_runtime__4 = Lazy.force mirage_runtime__4 in
+    let __mirage_logs_make__6 = Lazy.force mirage_logs_make__6 in
+    let __app_make__10 = Lazy.force app_make__10 in
     __struct_end__2 >>= fun _struct_end__2 ->
-    __printexc__3 >>= fun _printexc__3 ->
-    __hashtbl__4 >>= fun _hashtbl__4 ->
-    __gc__5 >>= fun _gc__5 ->
-    __mirage_runtime__6 >>= fun _mirage_runtime__6 ->
-    __mirage_logs_make__8 >>= fun _mirage_logs_make__8 ->
-    __app_make__12 >>= fun _app_make__12 ->
+    __mirage_runtime__3 >>= fun _mirage_runtime__3 ->
+    __mirage_runtime__4 >>= fun _mirage_runtime__4 ->
+    __mirage_logs_make__6 >>= fun _mirage_logs_make__6 ->
+    __app_make__10 >>= fun _app_make__10 ->
   # 392 "lib/mirage.ml"
     return ()
   );;
-  # 217 "mirage/main.ml"
+  # 116 "mirage/main.ml"
   
   let () =
     let t = Lazy.force struct_end__2 >>= fun _ ->
-    Lazy.force printexc__3 >>= fun _ ->
-    Lazy.force hashtbl__4 >>= fun _ ->
-    Lazy.force gc__5 >>= fun _ ->
-    Lazy.force mirage_runtime__6 >>= fun _ ->
-    Lazy.force mirage_logs_make__8 >>= fun _ ->
-    Lazy.force mirage_runtime__13 in
+    Lazy.force mirage_runtime__3 >>= fun _ ->
+    Lazy.force mirage_runtime__4 >>= fun _ ->
+    Lazy.force mirage_logs_make__6 >>= fun _ ->
+    Lazy.force mirage_runtime__11 in
     run t
   ;;
 

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -37,15 +37,20 @@ Configure the project for Unix:
     Mirage_runtime.logs
   ;;
   
-  # 18 "mirage/main.ml"
+  let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
+  # 411 "lib/mirage.ml"
+    Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
+  ;;
+  
+  # 23 "mirage/main.ml"
   
   module Mirage_logs_make__6 = Mirage_logs.Make(Pclock)
   
-  # 22 "mirage/main.ml"
+  # 27 "mirage/main.ml"
   
   module Mirage_crypto_rng_mirage_make__9 = Mirage_crypto_rng_mirage.Make(Unix_os.Time)(Mclock)
   
-  # 26 "mirage/main.ml"
+  # 31 "mirage/main.ml"
   
   module App_make__10 = App.Make(Mirage_crypto_rng_mirage_make__9)
   
@@ -53,7 +58,7 @@ Configure the project for Unix:
   # 15 "lib/devices/argv.ml"
     return (Mirage_bootvar.argv ())
   );;
-  # 34 "mirage/main.ml"
+  # 39 "mirage/main.ml"
   
   let struct_end__2 = lazy (
     let __mirage_bootvar__1 = Lazy.force mirage_bootvar__1 in
@@ -61,25 +66,25 @@ Configure the project for Unix:
   # 47 "lib/functoria/job.ml"
     return Mirage_runtime.(with_argv (runtime_args ()) "random" _mirage_bootvar__1)
   );;
-  # 42 "mirage/main.ml"
+  # 47 "mirage/main.ml"
   
-  let mirage_runtime__3 = lazy (
-  # 408 "lib/mirage.ml"
-    return (Mirage_runtime.configure_ocaml_runtime ())
+  let cmdliner_stdlib__3 = lazy (
+    let _cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true_ = (cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key ()) in
+    return (_cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true_)
   );;
-  # 48 "mirage/main.ml"
+  # 53 "mirage/main.ml"
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
   # 309 "lib/mirage.ml"
     Unix_os.Time.sleep_ns (Duration.of_sec _mirage_runtime_delay)
   );;
-  # 55 "mirage/main.ml"
+  # 60 "mirage/main.ml"
   
   let pclock__5 = lazy (
     return ()
   );;
-  # 60 "mirage/main.ml"
+  # 65 "mirage/main.ml"
   
   let mirage_logs_make__6 = lazy (
     let __pclock__5 = Lazy.force pclock__5 in
@@ -91,17 +96,17 @@ Configure the project for Unix:
     Logs.set_reporter reporter;
     Lwt.return reporter
   );;
-  # 72 "mirage/main.ml"
+  # 77 "mirage/main.ml"
   
   let unix_os_time__7 = lazy (
     return ()
   );;
-  # 77 "mirage/main.ml"
+  # 82 "mirage/main.ml"
   
   let mclock__8 = lazy (
     return ()
   );;
-  # 82 "mirage/main.ml"
+  # 87 "mirage/main.ml"
   
   let mirage_crypto_rng_mirage_make__9 = lazy (
     let __unix_os_time__7 = Lazy.force unix_os_time__7 in
@@ -111,7 +116,7 @@ Configure the project for Unix:
   # 15 "lib/devices/random.ml"
     Mirage_crypto_rng_mirage_make__9.initialize (module Mirage_crypto_rng.Fortuna)
   );;
-  # 92 "mirage/main.ml"
+  # 97 "mirage/main.ml"
   
   let app_make__10 = lazy (
     let __mirage_crypto_rng_mirage_make__9 = Lazy.force mirage_crypto_rng_mirage_make__9 in
@@ -119,27 +124,27 @@ Configure the project for Unix:
   # 3 "config.ml"
     (App_make__10.start _mirage_crypto_rng_mirage_make__9 : unit io)
   );;
-  # 100 "mirage/main.ml"
+  # 105 "mirage/main.ml"
   
   let mirage_runtime__11 = lazy (
     let __struct_end__2 = Lazy.force struct_end__2 in
-    let __mirage_runtime__3 = Lazy.force mirage_runtime__3 in
+    let __cmdliner_stdlib__3 = Lazy.force cmdliner_stdlib__3 in
     let __mirage_runtime__4 = Lazy.force mirage_runtime__4 in
     let __mirage_logs_make__6 = Lazy.force mirage_logs_make__6 in
     let __app_make__10 = Lazy.force app_make__10 in
     __struct_end__2 >>= fun _struct_end__2 ->
-    __mirage_runtime__3 >>= fun _mirage_runtime__3 ->
+    __cmdliner_stdlib__3 >>= fun _cmdliner_stdlib__3 ->
     __mirage_runtime__4 >>= fun _mirage_runtime__4 ->
     __mirage_logs_make__6 >>= fun _mirage_logs_make__6 ->
     __app_make__10 >>= fun _app_make__10 ->
   # 392 "lib/mirage.ml"
     return ()
   );;
-  # 116 "mirage/main.ml"
+  # 121 "mirage/main.ml"
   
   let () =
     let t = Lazy.force struct_end__2 >>= fun _ ->
-    Lazy.force mirage_runtime__3 >>= fun _ ->
+    Lazy.force cmdliner_stdlib__3 >>= fun _ ->
     Lazy.force mirage_runtime__4 >>= fun _ ->
     Lazy.force mirage_logs_make__6 >>= fun _ ->
     Lazy.force mirage_runtime__11 in
@@ -193,15 +198,20 @@ Configure the project for Xen:
     Mirage_runtime.logs
   ;;
   
-  # 18 "mirage/main.ml"
+  let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
+  # 411 "lib/mirage.ml"
+    Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
+  ;;
+  
+  # 23 "mirage/main.ml"
   
   module Mirage_logs_make__6 = Mirage_logs.Make(Pclock)
   
-  # 22 "mirage/main.ml"
+  # 27 "mirage/main.ml"
   
   module Mirage_crypto_rng_mirage_make__9 = Mirage_crypto_rng_mirage.Make(Xen_os.Time)(Mclock)
   
-  # 26 "mirage/main.ml"
+  # 31 "mirage/main.ml"
   
   module App_make__10 = App.Make(Mirage_crypto_rng_mirage_make__9)
   
@@ -209,7 +219,7 @@ Configure the project for Xen:
   # 15 "lib/devices/argv.ml"
     return (Mirage_bootvar.argv ())
   );;
-  # 34 "mirage/main.ml"
+  # 39 "mirage/main.ml"
   
   let struct_end__2 = lazy (
     let __mirage_bootvar__1 = Lazy.force mirage_bootvar__1 in
@@ -217,25 +227,25 @@ Configure the project for Xen:
   # 47 "lib/functoria/job.ml"
     return Mirage_runtime.(with_argv (runtime_args ()) "random" _mirage_bootvar__1)
   );;
-  # 42 "mirage/main.ml"
+  # 47 "mirage/main.ml"
   
-  let mirage_runtime__3 = lazy (
-  # 408 "lib/mirage.ml"
-    return (Mirage_runtime.configure_ocaml_runtime ())
+  let cmdliner_stdlib__3 = lazy (
+    let _cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true_ = (cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key ()) in
+    return (_cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true_)
   );;
-  # 48 "mirage/main.ml"
+  # 53 "mirage/main.ml"
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
   # 309 "lib/mirage.ml"
     Xen_os.Time.sleep_ns (Duration.of_sec _mirage_runtime_delay)
   );;
-  # 55 "mirage/main.ml"
+  # 60 "mirage/main.ml"
   
   let pclock__5 = lazy (
     return ()
   );;
-  # 60 "mirage/main.ml"
+  # 65 "mirage/main.ml"
   
   let mirage_logs_make__6 = lazy (
     let __pclock__5 = Lazy.force pclock__5 in
@@ -247,17 +257,17 @@ Configure the project for Xen:
     Logs.set_reporter reporter;
     Lwt.return reporter
   );;
-  # 72 "mirage/main.ml"
+  # 77 "mirage/main.ml"
   
   let xen_os_time__7 = lazy (
     return ()
   );;
-  # 77 "mirage/main.ml"
+  # 82 "mirage/main.ml"
   
   let mclock__8 = lazy (
     return ()
   );;
-  # 82 "mirage/main.ml"
+  # 87 "mirage/main.ml"
   
   let mirage_crypto_rng_mirage_make__9 = lazy (
     let __xen_os_time__7 = Lazy.force xen_os_time__7 in
@@ -267,7 +277,7 @@ Configure the project for Xen:
   # 15 "lib/devices/random.ml"
     Mirage_crypto_rng_mirage_make__9.initialize (module Mirage_crypto_rng.Fortuna)
   );;
-  # 92 "mirage/main.ml"
+  # 97 "mirage/main.ml"
   
   let app_make__10 = lazy (
     let __mirage_crypto_rng_mirage_make__9 = Lazy.force mirage_crypto_rng_mirage_make__9 in
@@ -275,27 +285,27 @@ Configure the project for Xen:
   # 3 "config.ml"
     (App_make__10.start _mirage_crypto_rng_mirage_make__9 : unit io)
   );;
-  # 100 "mirage/main.ml"
+  # 105 "mirage/main.ml"
   
   let mirage_runtime__11 = lazy (
     let __struct_end__2 = Lazy.force struct_end__2 in
-    let __mirage_runtime__3 = Lazy.force mirage_runtime__3 in
+    let __cmdliner_stdlib__3 = Lazy.force cmdliner_stdlib__3 in
     let __mirage_runtime__4 = Lazy.force mirage_runtime__4 in
     let __mirage_logs_make__6 = Lazy.force mirage_logs_make__6 in
     let __app_make__10 = Lazy.force app_make__10 in
     __struct_end__2 >>= fun _struct_end__2 ->
-    __mirage_runtime__3 >>= fun _mirage_runtime__3 ->
+    __cmdliner_stdlib__3 >>= fun _cmdliner_stdlib__3 ->
     __mirage_runtime__4 >>= fun _mirage_runtime__4 ->
     __mirage_logs_make__6 >>= fun _mirage_logs_make__6 ->
     __app_make__10 >>= fun _app_make__10 ->
   # 392 "lib/mirage.ml"
     return ()
   );;
-  # 116 "mirage/main.ml"
+  # 121 "mirage/main.ml"
   
   let () =
     let t = Lazy.force struct_end__2 >>= fun _ ->
-    Lazy.force mirage_runtime__3 >>= fun _ ->
+    Lazy.force cmdliner_stdlib__3 >>= fun _ ->
     Lazy.force mirage_runtime__4 >>= fun _ ->
     Lazy.force mirage_logs_make__6 >>= fun _ ->
     Lazy.force mirage_runtime__11 in


### PR DESCRIPTION
A special entry function, `configure_ocaml_runtime`, is defined in Mirage_runtime and run by mirage.ml.

This reduces the code generated in main.ml drastically.