### PR TITLE
Add a call to Printexc.record_backtrace

### DIFF
--- a/lib_runtime/functoria/functoria_runtime.ml
+++ b/lib_runtime/functoria/functoria_runtime.ml
@@ -25,6 +25,8 @@ module Arg = struct
   let get t =
     match t.value with
     | None ->
+        (* When used incorrectly this may raise before we otherwise turn on back traces *)
+        Printexc.record_backtrace true;
         invalid_arg
           "Called too early. Please delay this call to after the start \
            function of the unikernel."

--- a/lib_runtime/functoria/functoria_runtime.ml
+++ b/lib_runtime/functoria/functoria_runtime.ml
@@ -25,8 +25,6 @@ module Arg = struct
   let get t =
     match t.value with
     | None ->
-        (* When used incorrectly this may raise before we otherwise turn on back traces *)
-        Printexc.record_backtrace true;
         invalid_arg
           "Called too early. Please delay this call to after the start \
            function of the unikernel."

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -24,6 +24,12 @@ let s_ocaml = "OCAML RUNTIME OPTIONS"
 
 type log_threshold = [ `All | `Src of string ] * Logs.level option
 
+(* We provisionally record backtraces until the [backtrace] runtime argument
+   further below is evaluated. This ensures we get proper backtraces if someone
+   calls [register_arg _ ()] too early before command line arguments are
+   evaluated. *)
+let () = Printexc.record_backtrace true
+
 let set_level ~default l =
   let srcs = Logs.Src.list () in
   let default =


### PR DESCRIPTION
Runtime argument getters may be called before `Printexc.record_backtrace` is called - therefore we call it just before raising in order to get a nice backtrace.

For context see https://github.com/mirage/mirage-skeleton/pull/405#discussion_r1797009524