### PR TITLE
add parens around the return value of register/register_arg

### DIFF
--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -102,6 +102,8 @@ val help_version : int
 (** [help_version] is the exit code used when help/version is used: 63. *)
 
 val register_arg : 'a Cmdliner.Term.t -> (unit -> 'a)
+(* the return value is (unit -> 'a), let's keep the parens although they're
+   superfluous. *)
 [@@ocamlformat "disable"]
 (** [register_arg term] registers term to be evaluated at boot time. An example
     is: [let hello = register_arg <myterm>] (at the toplevel of the unikernel),
@@ -114,5 +116,7 @@ val with_argv : unit Cmdliner.Term.t list -> string -> string array -> unit
 val runtime_args : unit -> unit Cmdliner.Term.t list
 
 val register : 'a Cmdliner.Term.t -> (unit -> 'a)
+(* the return value is (unit -> 'a), let's keep the parens although they're
+   superfluous. *)
 [@@ocamlformat "disable"]
 [@@ocaml.deprecated "Use Mirage_runtime.register_arg instead."]

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -101,7 +101,8 @@ val argument_error : int
 val help_version : int
 (** [help_version] is the exit code used when help/version is used: 63. *)
 
-val register_arg : 'a Cmdliner.Term.t -> unit -> 'a
+val register_arg : 'a Cmdliner.Term.t -> (unit -> 'a)
+[@@ocamlformat "disable"]
 (** [register_arg term] registers term to be evaluated at boot time. An example
     is: [let hello = register_arg <myterm>] (at the toplevel of the unikernel),
     and in the unikernel code
@@ -112,5 +113,6 @@ val register_arg : 'a Cmdliner.Term.t -> unit -> 'a
 val with_argv : unit Cmdliner.Term.t list -> string -> string array -> unit
 val runtime_args : unit -> unit Cmdliner.Term.t list
 
-val register : 'a Cmdliner.Term.t -> unit -> 'a
+val register : 'a Cmdliner.Term.t -> (unit -> 'a)
+[@@ocamlformat "disable"]
 [@@ocaml.deprecated "Use Mirage_runtime.register_arg instead."]


### PR DESCRIPTION
and disable ocamlformat here locally

cc @reynir 