### PR TITLE
separate DNS, happy-eyeballs, SSH, TLS, HTTP arguments into separate man page sections

### DIFF
--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -18,6 +18,11 @@ open Cmdliner
 
 (* The order of the argument sections in the manpage can be enforced in the call to [with_argv] *)
 let s_net = "NETWORK OPTIONS"
+let s_dns = "DNS OPTIONS"
+let s_he = "HAPPY EYEBALLS OPTIONS"
+let s_ssh = "SSH OPTIONS"
+let s_tls = "TLS OPTIONS"
+let s_http = "HTTP OPTIONS"
 let s_log = "LOG AND MONITORING OPTIONS"
 let s_disk = "DISK OPTIONS"
 let s_ocaml = "OCAML RUNTIME OPTIONS"
@@ -136,7 +141,19 @@ let at_enter_iter f = add f enter_iter_hooks
 let with_argv =
   Functoria_runtime.with_argv
     ~sections:
-      [ Manpage.s_arguments; Manpage.s_options; s_net; s_log; s_disk; s_ocaml ]
+      [
+        Manpage.s_arguments;
+        Manpage.s_options;
+        s_http;
+        s_ssh;
+        s_tls;
+        s_he;
+        s_dns;
+        s_net;
+        s_log;
+        s_disk;
+        s_ocaml;
+      ]
 
 let runtime_args = Functoria_runtime.runtime_args
 let register = Functoria_runtime.register_arg

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -48,6 +48,21 @@ val s_disk : string
 val s_log : string
 (** [s_log] is used for logging and monitoring options. *)
 
+val s_he : string
+(** [s_he] is used for happy eyeballs options. *)
+
+val s_dns : string
+(** [s_dns] is used for DNS options. *)
+
+val s_ssh : string
+(** [s_ssh] is used for SSH options. *)
+
+val s_tls : string
+(** [s_tls] is used for TLS options. *)
+
+val s_http : string
+(** [s_http] is used for HTTP options. *)
+
 (** {3 Blocks} *)
 
 val disk : string Term.t

--- a/lib_runtime/mirage_runtime_network.ml
+++ b/lib_runtime/mirage_runtime_network.ml
@@ -82,83 +82,83 @@ let resolver ?group ?(docs = Mirage_runtime.s_net) ?default () =
     Arg.(some (list string))
     "resolver"
 
-let dns_servers ?group ?(docs = Mirage_runtime.s_net) default =
+let dns_servers ?group ?(docs = Mirage_runtime.s_dns) default =
   let doc = str "DNS servers (default to anycast.censurfridns.dk)" in
   runtime_arg ~doc ~docv:"DNS-SERVER" ~docs ?group ~default
     Arg.(some (list string))
     "dns_servers"
 
-let dns_timeout ?group ?(docs = Mirage_runtime.s_net) default =
+let dns_timeout ?group ?(docs = Mirage_runtime.s_dns) default =
   let doc = str "DNS timeout (in nanoseconds)" in
   runtime_arg ~doc ~docv:"DNS-TIMEOUT" ~docs ?group ~default
     Arg.(some int64)
     "dns_timeout"
 
-let dns_cache_size ?group ?(docs = Mirage_runtime.s_net) default =
+let dns_cache_size ?group ?(docs = Mirage_runtime.s_dns) default =
   let doc = str "DNS cache size" in
   runtime_arg ~doc ~docv:"DNS-CACHE-SIZE" ~docs ?group ~default
     Arg.(some int)
     "dns_cache_size"
 
-let he_aaaa_timeout ?group ?(docs = Mirage_runtime.s_net) default =
+let he_aaaa_timeout ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "AAAA timeout (in nanoseconds)" in
   runtime_arg ~doc ~docv:"AAAA-TIMEOUT" ~docs ?group ~default
     Arg.(some int64)
     "he_aaaa_timeout"
 
-let he_connect_delay ?group ?(docs = Mirage_runtime.s_net) default =
+let he_connect_delay ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "Delay (in nanoseconds) for connection establishment" in
   runtime_arg ~doc ~docv:"CONNECT-DELAY" ~docs ?group ~default
     Arg.(some int64)
     "he_connect_delay"
 
-let he_connect_timeout ?group ?(docs = Mirage_runtime.s_net) default =
+let he_connect_timeout ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "Connection establishment timeout (in nanoseconds)" in
   runtime_arg ~doc ~docv:"CONNECT-TIMEOUT" ~docs ?group ~default
     Arg.(some int64)
     "he_connect_timeout"
 
-let he_resolve_timeout ?group ?(docs = Mirage_runtime.s_net) default =
+let he_resolve_timeout ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "DNS resolution timeout (in nanoseconds)" in
   runtime_arg ~doc ~docv:"RESOLVE-TIMEOUT" ~docs ?group ~default
     Arg.(some int64)
     "he_resolve_timeout"
 
-let he_resolve_retries ?group ?(docs = Mirage_runtime.s_net) default =
+let he_resolve_retries ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "Amount of DNS resolution attempts" in
   runtime_arg ~doc ~docv:"RESOLVE-RETRIES" ~docs ?group ~default
     Arg.(some int)
     "he_resolve_retries"
 
-let he_timer_interval ?group ?(docs = Mirage_runtime.s_net) default =
+let he_timer_interval ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "Interal (in nanoseconds) for execution of the timer" in
   runtime_arg ~doc ~docv:"TIMER-INTERVAL" ~docs ?group ~default
     Arg.(some int64)
     "he_timer_interval"
 
-let ssh_key ?group ?(docs = Mirage_runtime.s_net) default =
+let ssh_key ?group ?(docs = Mirage_runtime.s_ssh) default =
   let doc = str "Private SSH key (rsa:<seed> or ed25519:<b64-key>)." in
   runtime_arg ~doc ~docs ~docv:"KEY" ?group ~default Arg.(some string) "ssh-key"
 
-let ssh_password ?group ?(docs = Mirage_runtime.s_net) default =
+let ssh_password ?group ?(docs = Mirage_runtime.s_ssh) default =
   let doc = str "Private SSH password." in
   runtime_arg ~doc ~docs ~docv:"PASSWORD" ?group ~default
     Arg.(some string)
     "ssh-password"
 
-let ssh_authenticator ?group ?(docs = Mirage_runtime.s_net) default =
+let ssh_authenticator ?group ?(docs = Mirage_runtime.s_ssh) default =
   let doc = str "SSH authenticator." in
   runtime_arg ~doc ~docs ~docv:"SSH-AUTHENTICATOR" ?group ~default
     Arg.(some string)
     "ssh-authenticator"
 
-let tls_authenticator ?group ?(docs = Mirage_runtime.s_net) default =
+let tls_authenticator ?group ?(docs = Mirage_runtime.s_tls) default =
   let doc = str "TLS authenticator." in
   runtime_arg ~doc ~docs ~docv:"TLS-AUTHENTICATOR" ?group ~default
     Arg.(some string)
     "tls-authenticator"
 
-let http_headers ?group ?(docs = Mirage_runtime.s_net) default =
+let http_headers ?group ?(docs = Mirage_runtime.s_http) default =
   let doc = str "HTTP headers." in
   runtime_arg ~doc ~docs ~docv:"HEADERS" ?group ~default
     Arg.(some (list ~sep:',' (pair ~sep:':' string string)))


### PR DESCRIPTION
fixes #1587

<details>
<summary>Manpage before this change</summary>

```
NAME
       caldav

SYNOPSIS
       caldav [OPTION]…

OPTIONS
       --admin-password=STRING
           Password for the administrator.

       --http=PORT
           Listening HTTP port.

       --https=PORT
           Listening HTTPS port.

       --name=STRING, --host=STRING (required)
           Hostname to use.

       --remote=REMOTE (required)
           Location of calendar data. Use suffix #foo to specify branch
           'foo'.

       --tls-proxy
           TLS proxy in front (use https://<hostname> as base url).

       --tofu
           If a user does not exist, create them and give them a new
           calendar.

NETWORK OPTIONS
       --accept-router-advertisements=VAL (absent=true)
           Accept router advertisements for the unikernel.

       --dns_cache_size=DNS-CACHE-SIZE
           DNS cache size

       --dns_servers=DNS-SERVER
           DNS servers (default to anycast.censurfridns.dk)

       --dns_timeout=DNS-TIMEOUT
           DNS timeout (in nanoseconds)

       --he_aaaa_timeout=AAAA-TIMEOUT
           AAAA timeout (in nanoseconds)

       --he_connect_delay=CONNECT-DELAY
           Delay (in nanoseconds) for connection establishment

       --he_connect_timeout=CONNECT-TIMEOUT
           Connection establishment timeout (in nanoseconds)

       --he_resolve_retries=RESOLVE-RETRIES
           Amount of DNS resolution attempts

       --he_resolve_timeout=RESOLVE-TIMEOUT
           DNS resolution timeout (in nanoseconds)

       --he_timer_interval=TIMER-INTERVAL
           Interal (in nanoseconds) for execution of the timer

       --http-headers=HEADERS
           HTTP headers.

       --ipv4=PREFIX (absent=10.0.0.2/24)
           The network of the unikernel specified as an IP address and
           netmask, e.g. 192.168.0.1/16 .

       --ipv4-gateway=IP
           The gateway of the unikernel.

       --ipv4-only=VAL (absent=false)
           Only use IPv4 for the unikernel.

       --ipv6=PREFIX
           The network of the unikernel specified as IPv6 address and prefix
           length.

       --ipv6-gateway=IP
           The gateway of the unikernel.

       --ipv6-only=VAL (absent=false)
           Only use IPv6 for the unikernel.

       --ssh-authenticator=SSH-AUTHENTICATOR
           SSH authenticator.

       --ssh-key=KEY
           Private SSH key (rsa:<seed> or ed25519:<b64-key>).

       --ssh-password=PASSWORD
           Private SSH password.

       --tls-authenticator=TLS-AUTHENTICATOR
           TLS authenticator.

LOG AND MONITORING OPTIONS
       -l LEVEL, --logs=LEVEL
           Be more or less verbose. LEVEL must be of the form
           *:info,foo:debug means that that the log threshold is set to info
           for every log sources but the foo which is set to debug.

OCAML RUNTIME OPTIONS
       --allocation-policy=ALLOCATION (absent=best-fit)
           The policy used for allocating in the OCaml heap. Possible values
           are: one of next-fit, first-fit or best-fit. Best-fit is only
           supported since OCaml 4.10.

       --backtrace=BOOL (absent=true)
           Trigger the printing of a stack backtrace when an uncaught
           exception aborts the unikernel.

       --custom-major-ratio=CUSTOM MAJOR RATIO
           Target ratio of floating garbage to major heap size for
           out-of-heap memory held by custom values. Default: 44.

       --custom-minor-max-size=CUSTOM MINOR MAX SIZE
           Maximum amount of out-of-heap memory for each custom value
           allocated in the minor heap. Default: 8192 bytes.

       --custom-minor-ratio=CUSTOM MINOR RATIO
           Bound on floating garbage for out-of-heap memory held by custom
           values in the minor heap. Default: 100.

       --gc-verbosity=VERBOSITY
           GC messages on standard error output. Sum of flags. Check GC
           module documentation for details.

       --gc-window-size=WINDOW SIZE
           The size of the window used by the major GC for smoothing out
           variations in its workload. Between 1 adn 50, default: 1.

       --major-heap-increment=MAJOR INCREMENT
           The size increment for the major heap (in words). If less than or
           equal 1000, it is a percentage of the current heap size. If more
           than 1000, it is a fixed number of words. Default: 15.

       --max-space-overhead=MAX SPACE OVERHEAD
           Heap compaction is triggered when the estimated amount of wasted
           memory exceeds this (percentage of live data). If above 1000000,
           compaction is never triggered. Default: 500.

       --minor-heap-size=MINOR SIZE
           The size of the minor heap (in words). Default: 256k.

       --randomize-hashtables=BOOL (absent=true)
           Turn on randomization of all hash tables by default.

       --space-overhead=SPACE OVERHEAD
           The percentage of live data of wasted memory, due to GC does not
           immediately collect unreachable blocks. The major GC speed is
           computed from this parameter, it will work more if smaller.
           Default: 80.

COMMON OPTIONS
       --delay=VAL (absent=0)
           Delay n seconds before starting up

       --help[=FMT] (default=auto)
           Show this help in format FMT. The value FMT must be one of auto,
           pager, groff or plain. With auto, the format is pager or plain
           whenever the TERM env var is dumb or undefined.

EXIT STATUS
       caldav exits with:

       0   on success.

       1   on Solo5 internal error.

       63  on showing this help.

       64  on any argument parsing error.

       125 on unexpected internal errors (bugs) while processing the boot
           parameters.

       255 on OCaml uncaught exception.

Solo5: solo5_exit(63) called
```

</details>

<details>
<summary>Man page after this PR</summary>

```
NAME
       caldav

SYNOPSIS
       caldav [OPTION]…

OPTIONS
       --admin-password=STRING
           Password for the administrator.

       --http=PORT
           Listening HTTP port.

       --https=PORT
           Listening HTTPS port.

       --language=LANGUAGE
           Default interface language for CalDAVZAP. Will be added to the
           configuration as 'globalInterfaceLanguage="VAL"'

       --name=STRING, --host=STRING (required)
           Hostname to use.

       --remote=REMOTE (required)
           Location of calendar data. Use suffix #foo to specify branch
           'foo'.

       --tls-proxy
           TLS proxy in front (use https://<hostname> as base url).

       --tofu
           If a user does not exist, create them and give them a new
           calendar.

HTTP OPTIONS
       --http-headers=HEADERS
           HTTP headers.

       --ssh-authenticator=SSH-AUTHENTICATOR
           SSH authenticator.

       --ssh-key=KEY
           Private SSH key (rsa:<seed> or ed25519:<b64-key>).

       --ssh-password=PASSWORD
           Private SSH password.

TLS OPTIONS
       --tls-authenticator=TLS-AUTHENTICATOR
           TLS authenticator.

HAPPY EYEBALLS OPTIONS
       --he_aaaa_timeout=AAAA-TIMEOUT
           AAAA timeout (in nanoseconds)

       --he_connect_delay=CONNECT-DELAY
           Delay (in nanoseconds) for connection establishment

       --he_connect_timeout=CONNECT-TIMEOUT
           Connection establishment timeout (in nanoseconds)

       --he_resolve_retries=RESOLVE-RETRIES
           Amount of DNS resolution attempts

       --he_resolve_timeout=RESOLVE-TIMEOUT
           DNS resolution timeout (in nanoseconds)

       --he_timer_interval=TIMER-INTERVAL
           Interal (in nanoseconds) for execution of the timer

DNS OPTIONS
       --dns_cache_size=DNS-CACHE-SIZE
           DNS cache size

       --dns_servers=DNS-SERVER
           DNS servers (default to anycast.censurfridns.dk)

       --dns_timeout=DNS-TIMEOUT
           DNS timeout (in nanoseconds)

NETWORK OPTIONS
       --accept-router-advertisements=VAL (absent=true)
           Accept router advertisements for the unikernel.

       --ipv4=PREFIX (absent=10.0.0.2/24)
           The network of the unikernel specified as an IP address and
           netmask, e.g. 192.168.0.1/16 .

       --ipv4-gateway=IP
           The gateway of the unikernel.

       --ipv4-only=VAL (absent=false)
           Only use IPv4 for the unikernel.

       --ipv6=PREFIX
           The network of the unikernel specified as IPv6 address and prefix
           length.

       --ipv6-gateway=IP
           The gateway of the unikernel.

       --ipv6-only=VAL (absent=false)
           Only use IPv6 for the unikernel.

LOG AND MONITORING OPTIONS
       -l LEVEL, --logs=LEVEL
           Be more or less verbose. LEVEL must be of the form
           *:info,foo:debug means that that the log threshold is set to info
           for every log sources but the foo which is set to debug. The log
           level must be one of quiet, app, error, warning, info or debug.

OCAML RUNTIME OPTIONS
       --allocation-policy=ALLOCATION (absent=best-fit)
           The policy used for allocating in the OCaml heap. Possible values
           are: next-fit, first-fit, best-fit. Best-fit is only supported
           since OCaml 4.10.

       --backtrace=BOOL (absent=true)
           Trigger the printing of a stack backtrace when an uncaught
           exception aborts the unikernel.

       --custom-major-ratio=RATIO (absent=100)
           Target ratio of floating garbage to major heap size for
           out-of-heap memory held by custom values.

       --custom-minor-max-size=BYTES (absent=8192)
           Maximum amount of out-of-heap memory for each custom value
           allocated in the minor heap.

       --custom-minor-ratio=RATIO (absent=100)
           Bound on floating garbage for out-of-heap memory held by custom
           values in the minor heap.

       --gc-verbosity=VERBOSITY (absent=0)
           GC messages on standard error output. Sum of flags. Check GC
           module documentation for details.

       --gc-window-size=INT (absent=1)
           The size of the window used by the major GC for smoothing out
           variations in its workload. Between 1 and 50.

       --major-heap-increment=PERCENT/WORDS (absent=15)
           The size increment for the major heap (in words). If less than or
           equal 1000, it is a percentage of the current heap size. If more
           than 1000, it is a fixed number of words.

       --max-space-overhead=PERCENT (absent=500)
           Heap compaction is triggered when the estimated amount of wasted
           memory exceeds this (percentage of live data). If above 1000000,
           compaction is never triggered.

       --minor-heap-size=WORDS (absent=262144)
           The size of the minor heap (in words).

       --randomize-hashtables=BOOL (absent=true)
           Turn on randomization of all hash tables by default.

       --space-overhead=PERCENT (absent=120)
           The percentage of live data of wasted memory, due to GC does not
           immediately collect unreachable blocks. The major GC speed is
           computed from this parameter, it will work more if smaller.

       --stack-limit=WORDS (absent=0)
           The maximum size of the fiber stacks (in words).

COMMON OPTIONS
       --delay=VAL (absent=0)
           Delay n seconds before starting up

       --help[=FMT] (default=auto)
           Show this help in format FMT. The value FMT must be one of auto,
           pager, groff or plain. With auto, the format is pager or plain
           whenever the TERM env var is dumb or undefined.

EXIT STATUS
       caldav exits with:

       0   on success.

       1   on Solo5 internal error.

       63  on showing this help.

       64  on any argument parsing error.

       125 on unexpected internal errors (bugs) while processing the boot
           parameters.

       255 on OCaml uncaught exception.

Solo5: solo5_exit(63) called
```

</details>