### PR TITLE
revise syslog, add monitoring

### DIFF
--- a/lib/devices/runtime_arg.ml
+++ b/lib/devices/runtime_arg.ml
@@ -179,17 +179,25 @@ let syslog ?group ?docs default =
   runtime_network_key ~pos:__POS__ "syslog %a%a%a" pp_group group pp_docs docs
     (pp_option pp_ipaddr) default
 
-let monitor ?group ?docs default =
-  runtime_network_key ~pos:__POS__ "monitor %a%a%a" pp_group group pp_docs docs
-    (pp_option pp_ipaddr) default
-
 let syslog_port ?group ?docs default =
   runtime_network_key ~pos:__POS__ "syslog_port %a%a%a" pp_group group pp_docs
     docs (pp_option Fmt.int) default
 
-let syslog_hostname ?group ?docs default =
-  runtime_network_key ~pos:__POS__ "syslog_hostname %a%a%S" pp_group group
-    pp_docs docs default
+let syslog_truncate ?group ?docs default =
+  runtime_network_key ~pos:__POS__ "syslog_truncate %a%a%a" pp_group group
+    pp_docs docs (pp_option Fmt.int) default
+
+let syslog_keyname ?group ?docs default =
+  runtime_network_key ~pos:__POS__ "syslog_keyname %a%a%a" pp_group group
+    pp_docs docs (pp_option Fmt.string) default
+
+let monitor_hostname ?group ?docs () =
+  runtime_network_key ~pos:__POS__ "monitor_hostname %a%a ()" pp_group group
+    pp_docs docs
+
+let monitor ?group ?docs default =
+  runtime_network_key ~pos:__POS__ "monitor %a%a%a" pp_group group pp_docs docs
+    (pp_option pp_ipaddr) default
 
 type log_threshold = [ `All | `Src of string ] * Logs.level option
 

--- a/lib/devices/runtime_arg.mli
+++ b/lib/devices/runtime_arg.mli
@@ -149,20 +149,28 @@ val syslog :
   Ipaddr.t option runtime_arg
 (** The address to send syslog frames to. *)
 
+val syslog_port : ?group:string -> ?docs:string -> int option -> int runtime_arg
+(** The port to send syslog frames to. *)
+
+val syslog_truncate :
+  ?group:string -> ?docs:string -> int option -> int option runtime_arg
+(** Truncate syslog frames to a specific byte count, [docs] defaults to
+    {!Mirage_runtime.s_log}. *)
+
+val syslog_keyname :
+  ?group:string -> ?docs:string -> string option -> string option runtime_arg
+(** TLS key used for syslog, [docs] defaults to {!Mirage_runtime.s_log}. *)
+
+val monitor_hostname :
+  ?group:string -> ?docs:string -> unit -> string runtime_arg
+(** The hostname to use for syslog and monitoring. *)
+
 val monitor :
   ?group:string ->
   ?docs:string ->
   Ipaddr.t option ->
   Ipaddr.t option runtime_arg
 (** The address to send monitor statistics to. *)
-
-val syslog_port :
-  ?group:string -> ?docs:string -> int option -> int option runtime_arg
-(** The port to send syslog frames to. *)
-
-val syslog_hostname :
-  ?group:string -> ?docs:string -> string -> string runtime_arg
-(** The hostname to use in syslog frames. *)
 
 (** {3 Logs} *)
 

--- a/lib/devices/syslog.ml
+++ b/lib/devices/syslog.ml
@@ -18,15 +18,15 @@ let syslog_udp_conf ?group () =
     Runtime_arg.[ v endpoint; v hostname; v port; v truncate ]
   in
   let connect _i modname = function
-    | [ pclock; stack; endpoint; hostname; port; truncate ] ->
+    | [ _pclock; stack; endpoint; hostname; port; truncate ] ->
         code ~pos:__POS__
           "@[<v 2>match %s with@ | None ->Logs.warn (fun m -> m \"no syslog \
            server specified, dumping logs to stdout\"); Lwt.return_unit@ | \
-           Some server ->@ let port = %s in@ let reporter =@ %s.create %s %s \
-           ~hostname:%s ?port server ?truncate:%s ()@ in@ Logs.set_reporter \
-           reporter;@ Lwt.return_unit@]"
-          endpoint port modname pclock stack hostname truncate
-    | _ -> connect_err "syslog_udp" 5
+           Some server ->@ let reporter =@ %s.create %s ~hostname:%s ~port:%s \
+           server ?truncate:%s ()@ in@ Logs.set_reporter reporter;@ \
+           Lwt.return_unit@]"
+          endpoint modname stack hostname port truncate
+    | _ -> connect_err "syslog_udp" 6
   in
   impl ~packages ~runtime_args ~connect "Logs_syslog_mirage.Udp"
     (pclock @-> stackv4v6 @-> syslog)
@@ -44,16 +44,15 @@ let syslog_tcp_conf ?group () =
     Runtime_arg.[ v endpoint; v hostname; v port; v truncate ]
   in
   let connect _i modname = function
-    | [ pclock; stack; endpoint; hostname; port; truncate ] ->
+    | [ _pclock; stack; endpoint; hostname; port; truncate ] ->
         code ~pos:__POS__
           "@[<v 2>match %s with@ | None -> Logs.warn (fun m -> m \"no syslog \
            server specified, dumping logs to stdout\"); Lwt.return_unit@ | \
-           Some server ->@ let port = %s in@ %s.create %s %s ~hostname:%s \
-           ?port server ?truncate:%s () >>= function@ | Ok reporter -> \
-           Logs.set_reporter reporter; Lwt.return_unit@ | Error e -> \
-           invalid_arg e@]"
-          endpoint port modname pclock stack hostname truncate
-    | _ -> connect_err "syslog_tcp" 5
+           Some server ->@ %s.create %s ~hostname:%s ~port:%s server \
+           ?truncate:%s () >>= function@ | Ok reporter -> Logs.set_reporter \
+           reporter; Lwt.return_unit@ | Error e -> invalid_arg e@]"
+          endpoint modname stack hostname port truncate
+    | _ -> connect_err "syslog_tcp" 6
   in
   impl ~packages ~runtime_args ~connect "Logs_syslog_mirage.Tcp"
     (pclock @-> stackv4v6 @-> syslog)
@@ -72,16 +71,16 @@ let syslog_tls_conf ?group () =
     Runtime_arg.[ v endpoint; v hostname; v port; v truncate; v keyname ]
   in
   let connect _i modname = function
-    | [ pclock; stack; kv; endpoint; hostname; port; truncate; keyname ] ->
+    | [ _pclock; stack; kv; endpoint; hostname; port; truncate; keyname ] ->
         code ~pos:__POS__
           "@[<v 2>match %s with@ | None -> Logs.warn (fun m -> m \"no syslog \
            server specified, dumping logs to stdout\"); Lwt.return_unit@ | \
-           Some server ->@ let port = %s in@ %s.create %s %s %s ~hostname:%s \
-           ?port server ?truncate:%s ?keyname:%s () >>= function@ | Ok \
-           reporter -> Logs.set_reporter reporter; Lwt.return_unit@ | Error e \
-           -> invalid_arg e@]"
-          endpoint port modname pclock stack kv hostname truncate keyname
-    | _ -> connect_err "syslog_tls" 6
+           Some server ->@ %s.create %s %s ~hostname:%s ~port:%s server \
+           ?truncate:%s ?keyname:%s () >>= function@ | Ok reporter -> \
+           Logs.set_reporter reporter; Lwt.return_unit@ | Error e -> \
+           invalid_arg e@]"
+          endpoint modname stack kv hostname port truncate keyname
+    | _ -> connect_err "syslog_tls" 8
   in
   impl ~packages ~runtime_args ~connect "Logs_syslog_mirage_tls.Tls"
     (pclock @-> stackv4v6 @-> Kv.ro @-> syslog)

--- a/lib/devices/syslog.ml
+++ b/lib/devices/syslog.ml
@@ -3,99 +3,109 @@ open Misc
 open Pclock
 open Stack
 
-type syslog_config = {
-  hostname : string;
-  server : Ipaddr.t option;
-  port : int option;
-  truncate : int option;
-}
-
-let syslog_config ?port ?truncate ?server hostname =
-  { hostname; server; port; truncate }
-
-let default_syslog_config =
-  let hostname = "no_name"
-  and server = None
-  and port = None
-  and truncate = None in
-  { hostname; server; port; truncate }
-
 type syslog = SYSLOG
 
 let syslog = typ SYSLOG
-let opt p s = Fmt.(option @@ (any ("~" ^^ s ^^ ":") ++ p))
-let opt_int = opt Fmt.int
-let opt_string = opt (fun pp v -> Format.fprintf pp "%S" v)
 let pkg sublibs = [ package ~min:"0.4.0" ~max:"0.5.0" ~sublibs "logs-syslog" ]
 
-let syslog_udp_conf config =
-  let endpoint = Runtime_arg.syslog config.server in
-  let port = Runtime_arg.syslog_port config.port in
-  let hostname = Runtime_arg.syslog_hostname config.hostname in
+let syslog_udp_conf ?group () =
+  let endpoint = Runtime_arg.syslog ?group None
+  and port = Runtime_arg.syslog_port ?group None
+  and hostname = Runtime_arg.monitor_hostname ?group ()
+  and truncate = Runtime_arg.syslog_truncate ?group None in
   let packages = pkg [ "mirage" ] in
-  let runtime_args = Runtime_arg.[ v endpoint; v hostname; v port ] in
+  let runtime_args =
+    Runtime_arg.[ v endpoint; v hostname; v port; v truncate ]
+  in
   let connect _i modname = function
-    | [ pclock; stack; endpoint; hostname; port ] ->
+    | [ pclock; stack; endpoint; hostname; port; truncate ] ->
         code ~pos:__POS__
-          "@[<v 2>match %s with@ | None -> Lwt.return_unit@ | Some server ->@ \
-           let port = %s in@ let reporter =@ %s.create %s %s ~hostname:%s \
-           ?port server %a ()@ in@ Logs.set_reporter reporter;@ \
-           Lwt.return_unit@]"
-          endpoint port modname pclock stack hostname (opt_int "truncate")
-          config.truncate
+          "@[<v 2>match %s with@ | None ->Logs.warn (fun m -> m \"no syslog \
+           server specified, dumping logs to stdout\"); Lwt.return_unit@ | \
+           Some server ->@ let port = %s in@ let reporter =@ %s.create %s %s \
+           ~hostname:%s ?port server ?truncate:%s ()@ in@ Logs.set_reporter \
+           reporter;@ Lwt.return_unit@]"
+          endpoint port modname pclock stack hostname truncate
     | _ -> connect_err "syslog_udp" 5
   in
   impl ~packages ~runtime_args ~connect "Logs_syslog_mirage.Udp"
     (pclock @-> stackv4v6 @-> syslog)
 
-let syslog_udp ?(config = default_syslog_config) ?(clock = default_posix_clock)
-    stack =
-  syslog_udp_conf config $ clock $ stack
+let syslog_udp ?group ?(clock = default_posix_clock) stack =
+  syslog_udp_conf ?group () $ clock $ stack
 
-let syslog_tcp_conf config =
-  let endpoint = Runtime_arg.syslog config.server in
-  let port = Runtime_arg.syslog_port config.port in
-  let hostname = Runtime_arg.syslog_hostname config.hostname in
+let syslog_tcp_conf ?group () =
+  let endpoint = Runtime_arg.syslog ?group None
+  and port = Runtime_arg.syslog_port ?group None
+  and hostname = Runtime_arg.monitor_hostname ?group ()
+  and truncate = Runtime_arg.syslog_truncate ?group None in
   let packages = pkg [ "mirage" ] in
-  let runtime_args = Runtime_arg.[ v endpoint; v hostname; v port ] in
+  let runtime_args =
+    Runtime_arg.[ v endpoint; v hostname; v port; v truncate ]
+  in
   let connect _i modname = function
-    | [ pclock; stack; endpoint; hostname; port ] ->
+    | [ pclock; stack; endpoint; hostname; port; truncate ] ->
         code ~pos:__POS__
-          "@[<v 2>match %s with@ | None -> Lwt.return_unit@ | Some server ->@ \
-           let port = %s in@ %s.create %s %s ~hostname:%s ?port server %a () \
-           >>= function@ | Ok reporter -> Logs.set_reporter reporter; \
-           Lwt.return_unit@ | Error e -> invalid_arg e@]"
-          endpoint port modname pclock stack hostname (opt_int "truncate")
-          config.truncate
+          "@[<v 2>match %s with@ | None -> Logs.warn (fun m -> m \"no syslog \
+           server specified, dumping logs to stdout\"); Lwt.return_unit@ | \
+           Some server ->@ let port = %s in@ %s.create %s %s ~hostname:%s \
+           ?port server ?truncate:%s () >>= function@ | Ok reporter -> \
+           Logs.set_reporter reporter; Lwt.return_unit@ | Error e -> \
+           invalid_arg e@]"
+          endpoint port modname pclock stack hostname truncate
     | _ -> connect_err "syslog_tcp" 5
   in
   impl ~packages ~runtime_args ~connect "Logs_syslog_mirage.Tcp"
     (pclock @-> stackv4v6 @-> syslog)
 
-let syslog_tcp ?(config = default_syslog_config) ?(clock = default_posix_clock)
-    stack =
-  syslog_tcp_conf config $ clock $ stack
+let syslog_tcp ?group ?(clock = default_posix_clock) stack =
+  syslog_tcp_conf ?group () $ clock $ stack
 
-let syslog_tls_conf ?keyname config =
-  let endpoint = Runtime_arg.syslog config.server in
-  let port = Runtime_arg.syslog_port config.port in
-  let hostname = Runtime_arg.syslog_hostname config.hostname in
+let syslog_tls_conf ?group () =
+  let endpoint = Runtime_arg.syslog ?group None
+  and port = Runtime_arg.syslog_port ?group None
+  and hostname = Runtime_arg.monitor_hostname ?group ()
+  and truncate = Runtime_arg.syslog_truncate ?group None
+  and keyname = Runtime_arg.syslog_keyname ?group None in
   let packages = pkg [ "mirage"; "mirage.tls" ] in
-  let runtime_args = Runtime_arg.[ v endpoint; v hostname; v port ] in
+  let runtime_args =
+    Runtime_arg.[ v endpoint; v hostname; v port; v truncate; v keyname ]
+  in
   let connect _i modname = function
-    | [ pclock; stack; kv; endpoint; hostname; port ] ->
+    | [ pclock; stack; kv; endpoint; hostname; port; truncate; keyname ] ->
         code ~pos:__POS__
-          "@[<v 2>match %s with@ | None -> Lwt.return_unit@ | Some server ->@ \
-           let port = %s in@ %s.create %s %s %s ~hostname:%s ?port server %a \
-           %a () >>= function@ | Ok reporter -> Logs.set_reporter reporter; \
-           Lwt.return_unit@ | Error e -> invalid_arg e@]"
-          endpoint port modname pclock stack kv hostname (opt_int "truncate")
-          config.truncate (opt_string "keyname") keyname
+          "@[<v 2>match %s with@ | None -> Logs.warn (fun m -> m \"no syslog \
+           server specified, dumping logs to stdout\"); Lwt.return_unit@ | \
+           Some server ->@ let port = %s in@ %s.create %s %s %s ~hostname:%s \
+           ?port server ?truncate:%s ?keyname:%s () >>= function@ | Ok \
+           reporter -> Logs.set_reporter reporter; Lwt.return_unit@ | Error e \
+           -> invalid_arg e@]"
+          endpoint port modname pclock stack kv hostname truncate keyname
     | _ -> connect_err "syslog_tls" 6
   in
   impl ~packages ~runtime_args ~connect "Logs_syslog_mirage_tls.Tls"
     (pclock @-> stackv4v6 @-> Kv.ro @-> syslog)
 
-let syslog_tls ?(config = default_syslog_config) ?keyname
-    ?(clock = default_posix_clock) stack kv =
-  syslog_tls_conf ?keyname config $ clock $ stack $ kv
+let syslog_tls ?group ?(clock = default_posix_clock) stack kv =
+  syslog_tls_conf ?group () $ clock $ stack $ kv
+
+let monitoring_conf ?group () =
+  let monitor_host = Runtime_arg.monitor ?group None
+  and hostname = Runtime_arg.monitor_hostname ?group () in
+  let packages = [ package ~min:"0.0.5" ~max:"0.1.0" "mirage-monitoring" ] in
+  let runtime_args = Runtime_arg.[ v monitor_host; v hostname ] in
+  let connect _i modname = function
+    | [ _; _; stack; name; monitor ] ->
+        code ~pos:__POS__
+          "Lwt.return (match %s with| None -> Logs.warn (fun m -> m \"no \
+           monitor specified, not outputting statistics\")| Some ip -> \
+           %s.create ip ~hostname:%s %s)"
+          monitor modname name stack
+    | _ -> assert false
+  in
+  impl ~packages ~runtime_args ~connect "Mirage_monitoring.Make"
+    (Time.time @-> pclock @-> stackv4v6 @-> Functoria.job)
+
+let monitoring ?group ?(time = Time.default_time) ?(clock = default_posix_clock)
+    stack =
+  monitoring_conf ?group () $ time $ clock $ stack

--- a/lib/devices/syslog.mli
+++ b/lib/devices/syslog.mli
@@ -4,32 +4,28 @@ type syslog
 
 val syslog : syslog typ
 
-type syslog_config = {
-  hostname : string;
-  server : Ipaddr.t option;
-  port : int option;
-  truncate : int option;
-}
-
-val syslog_config :
-  ?port:int -> ?truncate:int -> ?server:Ipaddr.t -> string -> syslog_config
-
 val syslog_udp :
-  ?config:syslog_config ->
+  ?group:string ->
   ?clock:Pclock.pclock impl ->
   Stack.stackv4v6 impl ->
   syslog impl
 
 val syslog_tcp :
-  ?config:syslog_config ->
+  ?group:string ->
   ?clock:Pclock.pclock impl ->
   Stack.stackv4v6 impl ->
   syslog impl
 
 val syslog_tls :
-  ?config:syslog_config ->
-  ?keyname:string ->
+  ?group:string ->
   ?clock:Pclock.pclock impl ->
   Stack.stackv4v6 impl ->
   Kv.ro impl ->
   syslog impl
+
+val monitoring :
+  ?group:string ->
+  ?time:Time.time impl ->
+  ?clock:Pclock.pclock impl ->
+  Stack.stackv4v6 impl ->
+  Functoria.job impl

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -223,15 +223,7 @@ let syslog = Syslog.syslog
 let syslog_tls = Syslog.syslog_tls
 let syslog_tcp = Syslog.syslog_tcp
 let syslog_udp = Syslog.syslog_udp
-
-type syslog_config = Syslog.syslog_config = {
-  hostname : string;
-  server : Ipaddr.t option;
-  port : int option;
-  truncate : int option;
-}
-
-let syslog_config = Syslog.syslog_config
+let monitoring = Syslog.monitoring
 
 type http = Http.http
 

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -754,17 +754,6 @@ val generic_dns_client :
     controlled via the {!Mirage_runtime.logs} key. The functionality is provided
     by the [logs-syslog] package. *)
 
-type syslog_config = {
-  hostname : string;
-  server : Ipaddr.t option;
-  port : int option;
-  truncate : int option;
-}
-
-val syslog_config :
-  ?port:int -> ?truncate:int -> ?server:Ipaddr.t -> string -> syslog_config
-(** Helper for constructing a {!type:syslog_config}. *)
-
 type syslog
 (** The type for syslog *)
 
@@ -772,23 +761,31 @@ val syslog : syslog typ
 (** Implementation of the {!type:syslog} type. *)
 
 val syslog_udp :
-  ?config:syslog_config -> ?clock:pclock impl -> stackv4v6 impl -> syslog impl
-(** Emit log messages via UDP to the configured host. *)
+  ?group:string -> ?clock:pclock impl -> stackv4v6 impl -> syslog impl
+(** Emit log messages via UDP. *)
 
 val syslog_tcp :
-  ?config:syslog_config -> ?clock:pclock impl -> stackv4v6 impl -> syslog impl
-(** Emit log messages via TCP to the configured host. *)
+  ?group:string -> ?clock:pclock impl -> stackv4v6 impl -> syslog impl
+(** Emit log messages via TCP. *)
 
 val syslog_tls :
-  ?config:syslog_config ->
-  ?keyname:string ->
+  ?group:string ->
   ?clock:pclock impl ->
   stackv4v6 impl ->
   kv_ro impl ->
   syslog impl
-(** Emit log messages via TLS to the configured host, using the credentials
-    (private key, certificate, trust anchor) provided in the KV_RO using the
-    [keyname]. *)
+(** Emit log messages via TLS, using the credentials (private key, certificate,
+    trust anchor) provided in the KV_RO. *)
+
+(** {2 Monitoring} *)
+val monitoring :
+  ?group:string ->
+  ?time:time impl ->
+  ?clock:pclock impl ->
+  stackv4v6 impl ->
+  job impl
+(** Monitor metrics to a remote Influx host, also allow adjustments to log
+    sources and levels. The provided [stack] should not be publicly reachable. *)
 
 (** {2 Conduit configuration} *)
 

--- a/lib_runtime/mirage_runtime_network.ml
+++ b/lib_runtime/mirage_runtime_network.ml
@@ -165,26 +165,34 @@ let http_headers ?group ?(docs = Mirage_runtime.s_http) default =
     "http-headers"
 
 let syslog ?group ?(docs = Mirage_runtime.s_log) default =
-  let doc = str "syslog server" in
+  let doc = str "syslog server IP" in
   runtime_arg ~doc ~docv:"IP" ~docs ?group ~default
     Arg.(some ip_address)
     "syslog"
+
+let syslog_port ?group ?(docs = Mirage_runtime.s_log) default =
+  let default = Option.value ~default:514 default in
+  let doc = str "syslog server port" in
+  runtime_arg ~doc ~docs ~docv:"PORT" ?group ~default Arg.int "syslog-port"
+
+let syslog_truncate ?group ?(docs = Mirage_runtime.s_log) default =
+  let doc = str "truncate syslog messages" in
+  runtime_arg ~doc ~docs ?group ~default Arg.(some int) "syslog-truncate"
+
+let syslog_keyname ?group ?(docs = Mirage_runtime.s_log) default =
+  let doc = str "TLS key name used for syslog" in
+  runtime_arg ~doc ~docs ?group ~default Arg.(some string) "syslog-keyname"
+
+let monitor_hostname ?(group = "") ?(docs = Mirage_runtime.s_log) () =
+  let doc = str "hostname used for syslog and monitoring" in
+  let prefix = if group = "" then group else group ^ "-" in
+  let doc = Arg.info ~docs ~docv:"NAME" ~doc [ prefix ^ "monitor-hostname" ] in
+  Arg.(required & opt (some string) None doc)
 
 let monitor ?group ?(docs = Mirage_runtime.s_log) default =
   let doc = str "monitor server" in
   runtime_arg ~doc ~docv:"IP" ~docs ?group ~default
     Arg.(some ip_address)
     "monitor"
-
-let syslog_port ?group ?(docs = Mirage_runtime.s_log) default =
-  let doc = str "syslog server port" in
-  runtime_arg ~doc ~docs ~docv:"PORT" ?group ~default
-    Arg.(some int)
-    "syslog-port"
-
-let syslog_hostname ?group ?(docs = Mirage_runtime.s_log) default =
-  let doc = str "hostname to report to syslog" in
-  runtime_arg ~doc ~docs ~docv:"NAME" ?group ~default Arg.string
-    "syslog-hostname"
 
 module Arg = Conv

--- a/lib_runtime/mirage_runtime_network.mli
+++ b/lib_runtime/mirage_runtime_network.mli
@@ -133,16 +133,24 @@ val syslog :
 (** The address to send syslog frames to, [docs] defaults to
     {!Mirage_runtime.s_log}. *)
 
-val monitor :
-  ?group:string -> ?docs:string -> Ipaddr.t option -> Ipaddr.t option Term.t
-(** The address to send monitor statistics to, [docs] defaults to
-    {!Mirage_runtime.s_log}. *)
-
-val syslog_port :
-  ?group:string -> ?docs:string -> int option -> int option Term.t
+val syslog_port : ?group:string -> ?docs:string -> int option -> int Term.t
 (** The port to send syslog frames to, [docs] defaults to
     {!Mirage_runtime.s_log}. *)
 
-val syslog_hostname : ?group:string -> ?docs:string -> string -> string Term.t
-(** The hostname to use in syslog frames, [docs] defaults to
+val syslog_truncate :
+  ?group:string -> ?docs:string -> int option -> int option Term.t
+(** Truncate syslog frames to a specific byte count, [docs] defaults to
+    {!Mirage_runtime.s_log}. *)
+
+val syslog_keyname :
+  ?group:string -> ?docs:string -> string option -> string option Term.t
+(** TLS key used for syslog, [docs] defaults to {!Mirage_runtime.s_log}. *)
+
+val monitor_hostname : ?group:string -> ?docs:string -> unit -> string Term.t
+(** The hostname used for syslog and monitoring, [docs] defaults to
+    {!Mirage_runtime.s_log}. *)
+
+val monitor :
+  ?group:string -> ?docs:string -> Ipaddr.t option -> Ipaddr.t option Term.t
+(** The address to send monitor statistics to, [docs] defaults to
     {!Mirage_runtime.s_log}. *)

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -33,12 +33,12 @@ Configure the project for Unix:
   ;;
   
   let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
-  # 196 "lib/devices/runtime_arg.ml"
+  # 204 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 412 "lib/mirage.ml"
+  # 404 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -76,7 +76,7 @@ Configure the project for Unix:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 310 "lib/mirage.ml"
+  # 302 "lib/mirage.ml"
     Unix_os.Time.sleep_ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 60 "mirage/main.ml"
@@ -137,7 +137,7 @@ Configure the project for Unix:
     __mirage_runtime__4 >>= fun _mirage_runtime__4 ->
     __mirage_logs_make__6 >>= fun _mirage_logs_make__6 ->
     __app_make__10 >>= fun _app_make__10 ->
-  # 393 "lib/mirage.ml"
+  # 385 "lib/mirage.ml"
     return ()
   );;
   # 121 "mirage/main.ml"
@@ -194,12 +194,12 @@ Configure the project for Xen:
   ;;
   
   let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
-  # 196 "lib/devices/runtime_arg.ml"
+  # 204 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 412 "lib/mirage.ml"
+  # 404 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -237,7 +237,7 @@ Configure the project for Xen:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 310 "lib/mirage.ml"
+  # 302 "lib/mirage.ml"
     Xen_os.Time.sleep_ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 60 "mirage/main.ml"
@@ -298,7 +298,7 @@ Configure the project for Xen:
     __mirage_runtime__4 >>= fun _mirage_runtime__4 ->
     __mirage_logs_make__6 >>= fun _mirage_logs_make__6 ->
     __app_make__10 >>= fun _app_make__10 ->
-  # 393 "lib/mirage.ml"
+  # 385 "lib/mirage.ml"
     return ()
   );;
   # 121 "mirage/main.ml"

--- a/test/mirage/warn-etif/config.ml
+++ b/test/mirage/warn-etif/config.ml
@@ -12,7 +12,7 @@ let rec eth = etif default_network
 let main = main "App.Make" ~pos:__POS__ (ethernet @-> job)
 
 let () =
-  let ramdisk (conf : syslog_config) =
-    match conf with { hostname } -> ramdisk "secrets\f42"
+  let ramdisk (conf : ipv4_config) =
+    match conf with { network } -> ramdisk "secrets\f42"
   in
   register "etif" [ main $ eth ]


### PR DESCRIPTION
this removes the type syslog_config, and introduces boot parameters for your syslog configuration

also, mirage-monitoring is integrated into the possible mirage devices

----

The goal is to reduce the amount of code in `config.ml` across the unikernels that we use. Now, the approach to provide boot parameters for configuration instead of hardcoded values is now applied to syslog as well.

Bits to be upstreamed are:

```OCaml
let enable_monitoring =
  let doc = Key.Arg.info
      ~doc:"Enable monitoring (syslog, metrics to influx, log level, statmemprof tracing)"
      [ "enable-monitoring" ]
  in
  Key.(create "enable-monitoring" Arg.(flag doc))

let management_stack =
  if_impl
    (Key.value enable_monitoring)
    (generic_stackv4v6 ~group:"management" (netif ~group:"management" "management"))
    stack

let optional_monitoring time pclock stack =
  if_impl (Key.value enable_monitoring)
    (monitoring $ time $ pclock $ stack)
    noop

let optional_syslog pclock stack =
  if_impl (Key.value enable_monitoring)
    (syslog $ pclock $ stack)
    noop

let () =
  register ...
    [
      optional_syslog default_posix_clock management_stack ;
      optional_monitoring default_time default_posix_clock management_stack ;
      ...
    ]
```

But this requires some more thoughts. I guess a `--enable-monitoring` configuration time parameter would be sensible. The question remains whether we should hardcode syslog_udp, or provide as well a configuration parameter (or embed UDP and TCP support into the unikernel anyways). For syslog-tls, I don't really have a usecase (I use separate network devices for service and management, as seen above).

WDYT?