### PR TITLE
Emit output what to do next. This fixes #921

### DIFF
--- a/lib/devices/target.ml
+++ b/lib/devices/target.ml
@@ -398,15 +398,19 @@ let dune i =
   let (module Target) = choose target in
   Target.dune i
 
+let output_message = ref true
+
 let configure i =
   let open Action.Infix in
   let target = Info.get i Key.target in
   let (module Target) = choose target in
   Target.configure i >|= fun () ->
-  Logs.app (fun m ->
-      m
-        "Successfully configured the unikernel. Now run 'make' (or more \
-         fine-grained steps: 'make all', 'make depends', or 'make lock').")
+  if !output_message then (
+    output_message := false;
+    Logs.app (fun m ->
+        m
+          "Successfully configured the unikernel. Now run 'make' (or more \
+           fine-grained steps: 'make all', 'make depends', or 'make lock')."))
 
 let build_context ?build_dir i =
   let target = Info.get i Key.target in

--- a/lib/devices/target.ml
+++ b/lib/devices/target.ml
@@ -399,9 +399,14 @@ let dune i =
   Target.dune i
 
 let configure i =
+  let open Action.Infix in
   let target = Info.get i Key.target in
   let (module Target) = choose target in
-  Target.configure i
+  Target.configure i >|= fun () ->
+  Logs.app (fun m ->
+      m
+        "Successfully configured the unikernel. Now run 'make' (or more \
+         fine-grained steps: 'make all', 'make depends', or 'make lock').")
 
 let build_context ?build_dir i =
   let target = Info.get i Key.target in

--- a/lib/functoria/makefile.ml
+++ b/lib/functoria/makefile.ml
@@ -150,6 +150,7 @@ depends depend::
 build::
 	dune build --profile release --root . $(BUILD_DIR)dist
 	@@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/%s"
+	@@echo "Execute the binary using solo5-hvt, solo5-spt, xl, ..."
 
 clean::
 	mirage clean

--- a/lib/functoria/makefile.ml
+++ b/lib/functoria/makefile.ml
@@ -22,10 +22,19 @@ type t = {
   builder_name : string;
   unikernel_opam_name : Misc.Name.Opam.t;
   extra_repo : (string * string) list;
+  public_name : string;
 }
 
-let v ?(extra_repo = []) ~build_dir ~builder_name ~depext unikernel_opam_name =
-  { depext; build_dir; builder_name; unikernel_opam_name; extra_repo }
+let v ?(extra_repo = []) ~build_dir ~builder_name ~depext ~public_name
+    unikernel_opam_name =
+  {
+    depext;
+    build_dir;
+    builder_name;
+    unikernel_opam_name;
+    extra_repo;
+    public_name;
+  }
 
 let depext_rules =
   {|
@@ -121,14 +130,17 @@ $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opa
 
 lock::
 	@@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+	@@echo "The lock file has been generated. Run 'make pull' to retrieve the sources, or 'make install-switch' to install the host dependencies."
 
 pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
 	@@echo " ↳ fetch monorepo dependencies in the duniverse folder"
 	@@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
+	@@echo "The sources have been pulled to the duniverse folder. Run 'make build' to build the unikernel."
 
 install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
 	@@echo " ↳ opam install switch dependencies"
 	@@$(OPAM) install $< --deps-only --yes%a%a
+	@@echo "The dependencies have been installed. Run 'make build' to build the unikernel."
 
 depends depend::
 	@@$(MAKE) --no-print-directory lock
@@ -137,6 +149,7 @@ depends depend::
 
 build::
 	dune build --profile release --root . $(BUILD_DIR)dist
+	@@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/%s"
 
 clean::
 	mirage clean
@@ -144,4 +157,4 @@ clean::
     Fpath.pp t.build_dir Fpath.pp mirage_dir
     (Misc.Name.Opam.to_string t.unikernel_opam_name)
     pp_extra_rules t pp_add_repo t.extra_repo pp_or_remove_repo t.extra_repo
-    pp_no_depext t.depext pp_depext_lockfile t.depext
+    pp_no_depext t.depext pp_depext_lockfile t.depext t.public_name

--- a/lib/functoria/makefile.mli
+++ b/lib/functoria/makefile.mli
@@ -23,6 +23,7 @@ val v :
   build_dir:Fpath.t ->
   builder_name:string ->
   depext:bool ->
+  public_name:string ->
   Misc.Name.Opam.t ->
   t
 

--- a/test/functoria/e2e/build.t
+++ b/test/functoria/e2e/build.t
@@ -5,6 +5,7 @@ Build an application.
   $ make build
   dune build --profile release --root . app/dist
   Your unikernel binary is now ready in app/dist/noop
+  Execute the binary using solo5-hvt, solo5-spt, xl, ...
   $ ls -a app/
   .
   ..
@@ -41,6 +42,7 @@ Test `--output`:
   $ make build
   dune build --profile release --root . app/dist
   Your unikernel binary is now ready in app/dist/toto
+  Execute the binary using solo5-hvt, solo5-spt, xl, ...
   $ ls -a app/
   .
   ..

--- a/test/functoria/e2e/build.t
+++ b/test/functoria/e2e/build.t
@@ -4,6 +4,7 @@ Build an application.
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   $ make build
   dune build --profile release --root . app/dist
+  Your unikernel binary is now ready in app/dist/noop
   $ ls -a app/
   .
   ..
@@ -39,6 +40,7 @@ Test `--output`:
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   $ make build
   dune build --profile release --root . app/dist
+  Your unikernel binary is now ready in app/dist/toto
   $ ls -a app/
   .
   ..

--- a/test/functoria/e2e/cache.t
+++ b/test/functoria/e2e/cache.t
@@ -5,5 +5,6 @@ Test that the cache is escaping entries correctly:
   $ make build
   dune build --profile release --root . app/dist
   Your unikernel binary is now ready in app/dist/noop
+  Execute the binary using solo5-hvt, solo5-spt, xl, ...
   $ cat app/test/vote
   foo;;bar;;;\n\nllll;;;sdaads;;\n\t\0

--- a/test/functoria/e2e/cache.t
+++ b/test/functoria/e2e/cache.t
@@ -4,5 +4,6 @@ Test that the cache is escaping entries correctly:
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   $ make build
   dune build --profile release --root . app/dist
+  Your unikernel binary is now ready in app/dist/noop
   $ cat app/test/vote
   foo;;bar;;;\n\nllll;;;sdaads;;\n\t\0

--- a/test/functoria/e2e/keys.t
+++ b/test/functoria/e2e/keys.t
@@ -4,6 +4,7 @@ Test keys.
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   $ make build
   dune build --profile release --root . app/dist
+  Your unikernel binary is now ready in app/dist/noop
   $ cat app/test/vote
   cat
   $ ./test.exe clean --file app/config.ml
@@ -14,5 +15,6 @@ Change the key at configure time:
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   $ make build
   dune build --profile release --root . app/dist
+  Your unikernel binary is now ready in app/dist/noop
   $ cat app/test/vote
   dog

--- a/test/functoria/e2e/keys.t
+++ b/test/functoria/e2e/keys.t
@@ -5,6 +5,7 @@ Test keys.
   $ make build
   dune build --profile release --root . app/dist
   Your unikernel binary is now ready in app/dist/noop
+  Execute the binary using solo5-hvt, solo5-spt, xl, ...
   $ cat app/test/vote
   cat
   $ ./test.exe clean --file app/config.ml
@@ -16,5 +17,6 @@ Change the key at configure time:
   $ make build
   dune build --profile release --root . app/dist
   Your unikernel binary is now ready in app/dist/noop
+  Execute the binary using solo5-hvt, solo5-spt, xl, ...
   $ cat app/test/vote
   dog

--- a/test/mirage/job-no-device-arg/configure.t
+++ b/test/mirage/job-no-device-arg/configure.t
@@ -3,4 +3,3 @@
 Configure
   $ ./config.exe configure
   Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
-  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').

--- a/test/mirage/job-no-device-arg/configure.t
+++ b/test/mirage/job-no-device-arg/configure.t
@@ -2,3 +2,5 @@
 
 Configure
   $ ./config.exe configure
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -90,6 +90,7 @@ Query makefile
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
   	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop-functor.v0"
+  	@echo "Execute the binary using solo5-hvt, solo5-spt, xl, ..."
   
   clean::
   	mirage clean

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -1,5 +1,6 @@
 Query unikernel dune
   $ ./config_dash_in_name.exe query dune.build
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   (copy_files# ./mirage/main.ml)
   
   (rule
@@ -68,15 +69,18 @@ Query makefile
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  	@echo "The lock file has been generated. Run 'make pull' to retrieve the sources, or 'make install-switch' to install the host dependencies."
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
+  	@echo "The sources have been pulled to the duniverse folder. Run 'make build' to build the unikernel."
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
+  	@echo "The dependencies have been installed. Run 'make build' to build the unikernel."
   
   depends depend::
   	@$(MAKE) --no-print-directory lock
@@ -85,6 +89,7 @@ Query makefile
   
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
+  	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop-functor.v0"
   
   clean::
   	mirage clean
@@ -101,6 +106,7 @@ Query dune-project
 
 Query unikernel dune (hvt)
   $ ./config_dash_in_name.exe query --target hvt dune.build
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   (copy_files# ./mirage/main.ml)
   
   (copy_files ./mirage/manifest.json)

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -67,6 +67,7 @@ Query packages
 
 Query files
   $ ./config.exe query --target hvt files
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   main.ml manifest.json manifest.ml
 
 Query Makefile
@@ -108,15 +109,18 @@ Query Makefile
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  	@echo "The lock file has been generated. Run 'make pull' to retrieve the sources, or 'make install-switch' to install the host dependencies."
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
+  	@echo "The sources have been pulled to the duniverse folder. Run 'make build' to build the unikernel."
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
+  	@echo "The dependencies have been installed. Run 'make build' to build the unikernel."
   
   depends depend::
   	@$(MAKE) --no-print-directory lock
@@ -125,6 +129,7 @@ Query Makefile
   
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
+  	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
   
   clean::
   	mirage clean
@@ -163,14 +168,17 @@ Query Makefile without depexts
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  	@echo "The lock file has been generated. Run 'make pull' to retrieve the sources, or 'make install-switch' to install the host dependencies."
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
+  	@echo "The sources have been pulled to the duniverse folder. Run 'make build' to build the unikernel."
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes --no-depexts
+  	@echo "The dependencies have been installed. Run 'make build' to build the unikernel."
   
   depends depend::
   	@$(MAKE) --no-print-directory lock
@@ -179,6 +187,7 @@ Query Makefile without depexts
   
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
+  	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
   
   clean::
   	mirage clean
@@ -223,15 +232,18 @@ Query Makefile with depext
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  	@echo "The lock file has been generated. Run 'make pull' to retrieve the sources, or 'make install-switch' to install the host dependencies."
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
+  	@echo "The sources have been pulled to the duniverse folder. Run 'make build' to build the unikernel."
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
+  	@echo "The dependencies have been installed. Run 'make build' to build the unikernel."
   
   depends depend::
   	@$(MAKE) --no-print-directory lock
@@ -240,6 +252,7 @@ Query Makefile with depext
   
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
+  	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
   
   clean::
   	mirage clean
@@ -250,6 +263,7 @@ Query version
 
 Query unikernel dune
   $ ./config.exe query --target hvt dune.build
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   (copy_files# ./mirage/main.ml)
   
   (copy_files ./mirage/manifest.json)

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -130,6 +130,7 @@ Query Makefile
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
   	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
+  	@echo "Execute the binary using solo5-hvt, solo5-spt, xl, ..."
   
   clean::
   	mirage clean
@@ -188,6 +189,7 @@ Query Makefile without depexts
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
   	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
+  	@echo "Execute the binary using solo5-hvt, solo5-spt, xl, ..."
   
   clean::
   	mirage clean
@@ -253,6 +255,7 @@ Query Makefile with depext
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
   	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
+  	@echo "Execute the binary using solo5-hvt, solo5-spt, xl, ..."
   
   clean::
   	mirage clean

--- a/test/mirage/query/run-noop.t
+++ b/test/mirage/query/run-noop.t
@@ -90,6 +90,7 @@ Query makefile
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
   	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
+  	@echo "Execute the binary using solo5-hvt, solo5-spt, xl, ..."
   
   clean::
   	mirage clean

--- a/test/mirage/query/run-noop.t
+++ b/test/mirage/query/run-noop.t
@@ -1,5 +1,6 @@
 Query unikernel dune
   $ ./config_noop.exe query dune.build
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   (copy_files# ./mirage/main.ml)
   
   (rule
@@ -68,15 +69,18 @@ Query makefile
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  	@echo "The lock file has been generated. Run 'make pull' to retrieve the sources, or 'make install-switch' to install the host dependencies."
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
+  	@echo "The sources have been pulled to the duniverse folder. Run 'make build' to build the unikernel."
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
+  	@echo "The dependencies have been installed. Run 'make build' to build the unikernel."
   
   depends depend::
   	@$(MAKE) --no-print-directory lock
@@ -85,6 +89,7 @@ Query makefile
   
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
+  	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
   
   clean::
   	mirage clean
@@ -101,6 +106,7 @@ Query dune-project
 
 Query unikernel dune (hvt)
   $ ./config_noop.exe query --target hvt dune.build
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   (copy_files# ./mirage/main.ml)
   
   (copy_files ./mirage/manifest.json)

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -67,6 +67,7 @@ Query packages
 
 Query files
   $ ./config.exe query files
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   main.ml
 
 Query Makefile
@@ -108,15 +109,18 @@ Query Makefile
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  	@echo "The lock file has been generated. Run 'make pull' to retrieve the sources, or 'make install-switch' to install the host dependencies."
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
+  	@echo "The sources have been pulled to the duniverse folder. Run 'make build' to build the unikernel."
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
+  	@echo "The dependencies have been installed. Run 'make build' to build the unikernel."
   
   depends depend::
   	@$(MAKE) --no-print-directory lock
@@ -125,6 +129,7 @@ Query Makefile
   
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
+  	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
   
   clean::
   	mirage clean
@@ -164,14 +169,17 @@ Query Makefile without depexts
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  	@echo "The lock file has been generated. Run 'make pull' to retrieve the sources, or 'make install-switch' to install the host dependencies."
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
+  	@echo "The sources have been pulled to the duniverse folder. Run 'make build' to build the unikernel."
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes --no-depexts
+  	@echo "The dependencies have been installed. Run 'make build' to build the unikernel."
   
   depends depend::
   	@$(MAKE) --no-print-directory lock
@@ -180,6 +188,7 @@ Query Makefile without depexts
   
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
+  	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
   
   clean::
   	mirage clean
@@ -225,15 +234,18 @@ Query Makefile with depext
   
   lock::
   	@$(MAKE) -B $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
+  	@echo "The lock file has been generated. Run 'make pull' to retrieve the sources, or 'make install-switch' to install the host dependencies."
   
   pull:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked
   	@echo " ↳ fetch monorepo dependencies in the duniverse folder"
   	@env OPAMVAR_monorepo="opam-monorepo" $(OPAM) monorepo pull -l $< -r $(abspath $(BUILD_DIR))
+  	@echo "The sources have been pulled to the duniverse folder. Run 'make build' to build the unikernel."
   
   install-switch:: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
   	@echo " ↳ opam install switch dependencies"
   	@$(OPAM) install $< --deps-only --yes
   	@$(MAKE) -s depext-lockfile
+  	@echo "The dependencies have been installed. Run 'make build' to build the unikernel."
   
   depends depend::
   	@$(MAKE) --no-print-directory lock
@@ -242,6 +254,7 @@ Query Makefile with depext
   
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
+  	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
   
   clean::
   	mirage clean
@@ -253,6 +266,7 @@ Query version
 
 Query unikernel dune
   $ ./config.exe query dune.build
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   (copy_files# ./mirage/main.ml)
   
   (rule

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -130,6 +130,7 @@ Query Makefile
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
   	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
+  	@echo "Execute the binary using solo5-hvt, solo5-spt, xl, ..."
   
   clean::
   	mirage clean
@@ -189,6 +190,7 @@ Query Makefile without depexts
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
   	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
+  	@echo "Execute the binary using solo5-hvt, solo5-spt, xl, ..."
   
   clean::
   	mirage clean
@@ -255,6 +257,7 @@ Query Makefile with depext
   build::
   	dune build --profile release --root . $(BUILD_DIR)dist
   	@echo "Your unikernel binary is now ready in $(BUILD_DIR)dist/noop"
+  	@echo "Execute the binary using solo5-hvt, solo5-spt, xl, ..."
   
   clean::
   	mirage clean

--- a/test/mirage/random/run-opam-git.t
+++ b/test/mirage/random/run-opam-git.t
@@ -26,7 +26,6 @@ Configure the project for Unix:
   $ mirage configure -t unix
   mirage: [WARNING] Skipping version check, since our_version is not watermarked
   Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
-  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
 
 Check the source url of the generated opam package
 
@@ -41,7 +40,6 @@ Configure the project again for Unix:
 
   $ mirage configure -t unix
   mirage: [WARNING] Skipping version check, since our_version is not watermarked
-  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
 
 Check the source url of the generated opam package

--- a/test/mirage/random/run-opam-git.t
+++ b/test/mirage/random/run-opam-git.t
@@ -25,6 +25,8 @@ Configure the project for Unix:
 
   $ mirage configure -t unix
   mirage: [WARNING] Skipping version check, since our_version is not watermarked
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
 
 Check the source url of the generated opam package
 
@@ -39,6 +41,8 @@ Configure the project again for Unix:
 
   $ mirage configure -t unix
   mirage: [WARNING] Skipping version check, since our_version is not watermarked
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
 
 Check the source url of the generated opam package
 

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -3,7 +3,6 @@ Configure the project for Unix:
   $ mirage configure -t unix
   mirage: [WARNING] Skipping version check, since our_version is not watermarked
   Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
-  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   $ ls . mirage/
   .:
   Makefile
@@ -160,7 +159,6 @@ Configure the project for Xen:
 
   $ mirage configure -t xen
   mirage: [WARNING] Skipping version check, since our_version is not watermarked
-  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   $ ls . mirage/
   .:

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -2,6 +2,8 @@ Configure the project for Unix:
 
   $ mirage configure -t unix
   mirage: [WARNING] Skipping version check, since our_version is not watermarked
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   $ ls . mirage/
   .:
   Makefile
@@ -158,6 +160,8 @@ Configure the project for Xen:
 
   $ mirage configure -t xen
   mirage: [WARNING] Skipping version check, since our_version is not watermarked
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   $ ls . mirage/
   .:
   Makefile

--- a/test/mirage/warn-etif/run.t
+++ b/test/mirage/warn-etif/run.t
@@ -1,6 +1,8 @@
 Configure the project for Unix:
 
   $ mirage configure -t unix 2>/dev/null
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
+  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
 
 The command succeeded and created a number of files. It produced a load of
 warnings, but matching on the warnings given different compiler versions with

--- a/test/mirage/warn-etif/run.t
+++ b/test/mirage/warn-etif/run.t
@@ -2,7 +2,6 @@ Configure the project for Unix:
 
   $ mirage configure -t unix 2>/dev/null
   Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
-  Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
 
 The command succeeded and created a number of files. It produced a load of
 warnings, but matching on the warnings given different compiler versions with


### PR DESCRIPTION
It gives some hints to the user what they should do next.

The only thing slightly worrying is that the cram test cases have the log message two times - any hints why this is the case?

----

We could after the `build` improve depending on the target, if we would have access to the target. But I have a tough time to figure out how to pass this information through.

So, this is ready for review :D