### PR TITLE
add DHCP device

### DIFF
--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -29,15 +29,6 @@ type ipv6_config = {
   gateway : Ipaddr.V6.t option;
 }
 
-val ipv4_of_dhcp :
-  ?random:random impl ->
-  ?clock:mclock impl ->
-  ?time:Time.time impl ->
-  network impl ->
-  ethernet impl ->
-  arpv4 impl ->
-  ipv4 impl
-
 val create_ipv4 :
   ?group:string ->
   ?config:ipv4_config ->

--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -29,6 +29,15 @@ type ipv6_config = {
   gateway : Ipaddr.V6.t option;
 }
 
+val ipv4_of_dhcp :
+  ?random:random impl ->
+  ?clock:mclock impl ->
+  ?time:Time.time impl ->
+  network impl ->
+  ethernet impl ->
+  arpv4 impl ->
+  ipv4 impl
+
 val create_ipv4 :
   ?group:string ->
   ?config:ipv4_config ->

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -119,6 +119,7 @@ let ipv4 = Ip.ipv4
 let ipv6 = Ip.ipv6
 let ipv4_qubes = Ip.ipv4_qubes
 let ipv4v6 = Ip.ipv4v6
+let ipv4_of_dhcp = Ip.ipv4_of_dhcp
 let create_ipv4 = Ip.create_ipv4
 let create_ipv6 = Ip.create_ipv6
 let create_ipv4v6 = Ip.create_ipv4v6

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -511,6 +511,16 @@ type ipv6_config = {
 }
 (** Types for manual IPv6 configuration. *)
 
+val ipv4_of_dhcp :
+  ?random:random impl ->
+  ?clock:mclock impl ->
+  ?time:time impl ->
+  network impl ->
+  ethernet impl ->
+  arpv4 impl ->
+  ipv4 impl
+(** Configure the interface via DHCP *)
+
 val create_ipv4 :
   ?group:string ->
   ?config:ipv4_config ->

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -38,7 +38,7 @@ Configure the project for Unix:
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 411 "lib/mirage.ml"
+  # 412 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -76,7 +76,7 @@ Configure the project for Unix:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 309 "lib/mirage.ml"
+  # 310 "lib/mirage.ml"
     Unix_os.Time.sleep_ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 60 "mirage/main.ml"
@@ -137,7 +137,7 @@ Configure the project for Unix:
     __mirage_runtime__4 >>= fun _mirage_runtime__4 ->
     __mirage_logs_make__6 >>= fun _mirage_logs_make__6 ->
     __app_make__10 >>= fun _app_make__10 ->
-  # 392 "lib/mirage.ml"
+  # 393 "lib/mirage.ml"
     return ()
   );;
   # 121 "mirage/main.ml"
@@ -199,7 +199,7 @@ Configure the project for Xen:
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 411 "lib/mirage.ml"
+  # 412 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -237,7 +237,7 @@ Configure the project for Xen:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 309 "lib/mirage.ml"
+  # 310 "lib/mirage.ml"
     Xen_os.Time.sleep_ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 60 "mirage/main.ml"
@@ -298,7 +298,7 @@ Configure the project for Xen:
     __mirage_runtime__4 >>= fun _mirage_runtime__4 ->
     __mirage_logs_make__6 >>= fun _mirage_logs_make__6 ->
     __app_make__10 >>= fun _app_make__10 ->
-  # 392 "lib/mirage.ml"
+  # 393 "lib/mirage.ml"
     return ()
   );;
   # 121 "mirage/main.ml"


### PR DESCRIPTION
Dear developers,

While working with the mirage-nat example, I tried to configure the public interface with DHCP, but it failed because `ipv4_of_dhcp` is not currently exported. This PR aims to add it.

`dune runtest` works fine, ~~except for the message `Error (warning 32 [unused-value-declaration]): unused value ipv4_of_dhcp.` but I don't know where I should use it :( ~~ EDIT: It was a redundant declaration, I also fixed line numbers in the tests with the additional line.

I'd be happy to change anything that isn't good enough :)

Best,