### PR TITLE
Add a ?local_libs parameter to allows local dune libs

### DIFF
--- a/lib/functoria/DSL.ml
+++ b/lib/functoria/DSL.ml
@@ -42,13 +42,16 @@ let dep = Impl.abstract
 let if_impl = Impl.if_
 let match_impl = Impl.match_
 
-let impl ?packages ?packages_v ?install ?install_v ?keys ?runtime_args
-    ?extra_deps ?connect ?dune ?configure ?files module_name module_type =
+let impl ?packages ?packages_v ?local_libs ?install ?install_v ?keys
+    ?runtime_args ?extra_deps ?connect ?dune ?configure ?files module_name
+    module_type =
   of_device
-  @@ Device.v ?packages ?packages_v ?install ?install_v ?keys ?runtime_args
-       ?extra_deps ?connect ?dune ?configure ?files module_name module_type
+  @@ Device.v ?packages ?packages_v ?local_libs ?install ?install_v ?keys
+       ?runtime_args ?extra_deps ?connect ?dune ?configure ?files module_name
+       module_type
 
-let main ?pos ?packages ?packages_v ?runtime_args ?deps module_name ty =
+let main ?pos ?packages ?packages_v ?local_libs ?runtime_args ?deps module_name
+    ty =
   let connect _ = Device.start ?pos in
   let extra_deps =
     if Type.is_functor ty then deps
@@ -60,7 +63,8 @@ let main ?pos ?packages ?packages_v ?runtime_args ?deps module_name ty =
           Some [ dep Job.noop ]
       | _ -> deps
   in
-  impl ?packages ?packages_v ?runtime_args ?extra_deps ~connect module_name ty
+  impl ?packages ?packages_v ?local_libs ?runtime_args ?extra_deps ~connect
+    module_name ty
 
 let runtime_arg ~pos ?packages str =
   Runtime_arg.v (Runtime_arg.create ~pos ?packages str)

--- a/lib/functoria/DSL.mli
+++ b/lib/functoria/DSL.mli
@@ -150,6 +150,7 @@ val main :
   ?pos:string * int * int * int ->
   ?packages:package list ->
   ?packages_v:package list value ->
+  ?local_libs:string list ->
   ?runtime_args:Runtime_arg.t list ->
   ?deps:abstract_impl list ->
   string ->
@@ -178,6 +179,7 @@ val of_device : 'a device -> 'a impl
 val impl :
   ?packages:package list ->
   ?packages_v:package list Key.value ->
+  ?local_libs:string list ->
   ?install:(Info.t -> Install.t) ->
   ?install_v:(Info.t -> Install.t Key.value) ->
   ?keys:Key.t list ->

--- a/lib/functoria/device.ml
+++ b/lib/functoria/device.ml
@@ -34,6 +34,7 @@ type ('a, 'impl) t = {
   keys : Key.t list;
   runtime_args : Runtime_arg.t list;
   packages : package list value;
+  local_libs : string list;
   install : info -> Install.t value;
   connect : info -> string -> string list -> 'a code;
   dune : info -> Dune.stanza list;
@@ -75,7 +76,7 @@ let merge empty union a b =
 let merge_packages = merge [] List.append
 let merge_install = merge Install.empty Install.union
 
-let v ?packages ?packages_v ?install ?install_v ?(keys = [])
+let v ?packages ?packages_v ?(local_libs = []) ?install ?install_v ?(keys = [])
     ?(runtime_args = []) ?(extra_deps = []) ?(connect = default_connect)
     ?(dune = nil) ?(configure = niet) ?files module_name module_type =
   let id = Typeid.gen () in
@@ -92,6 +93,7 @@ let v ?packages ?packages_v ?install ?install_v ?(keys = [])
     runtime_args;
     connect;
     packages;
+    local_libs;
     install;
     dune;
     configure;
@@ -103,6 +105,7 @@ let id t = Typeid.id t.id
 let module_name t = t.module_name
 let module_type t = t.module_type
 let packages t = t.packages
+let local_libs t = t.local_libs
 let install t = t.install
 let connect t = t.connect
 let configure t = t.configure

--- a/lib/functoria/device.mli
+++ b/lib/functoria/device.mli
@@ -33,6 +33,9 @@ val module_name : ('a, 'b) t -> string
 val packages : ('a, 'b) t -> Package.t list Key.value
 (** [packages t] is the list of OPAM packages that are needed by [t].*)
 
+val local_libs : ('a, 'b) t -> string list
+(** [local_libs t] is the list of local libraries that are needed by [t]. *)
+
 val install : ('a, 'b) t -> Info.t -> Install.t Key.value
 (** [install t i] is the list of files installed by [t], using the build
     information [i]. *)
@@ -116,6 +119,7 @@ val configure : ('a, 'b) t -> Info.t -> unit Action.t
 val v :
   ?packages:Package.t list ->
   ?packages_v:Package.t list Key.value ->
+  ?local_libs:string list ->
   ?install:(Info.t -> Install.t) ->
   ?install_v:(Info.t -> Install.t Key.value) ->
   ?keys:Key.t list ->

--- a/lib/functoria/impl.ml
+++ b/lib/functoria/impl.ml
@@ -59,6 +59,7 @@ let rec app_has_no_arguments : type a. a t -> bool = function
 
 let mk_dev ~args ~deps dev = Dev { dev; args; deps }
 let of_device dev = mk_dev ~args:Nil ~deps:(Device.extra_deps dev) dev
+let local_libs = function Dev { dev; _ } -> Device.local_libs dev | _ -> []
 
 let v ?packages ?packages_v ?runtime_args ?keys ?extra_deps ?connect ?dune
     ?configure ?files module_name module_type =

--- a/lib/functoria/impl.mli
+++ b/lib/functoria/impl.mli
@@ -54,6 +54,9 @@ val match_ : 'b Key.value -> default:'a t -> ('b * 'a t) list -> 'a t
 val of_device : 'a device -> 'a t
 (** [of_device t] is the tementation device [t]. *)
 
+val local_libs : 'a t -> string list
+(** [local_libs t] is the list of of local libraries that are needed by [t]. *)
+
 val v :
   ?packages:Package.t list ->
   ?packages_v:Package.t list Key.value ->

--- a/lib/functoria/info.ml
+++ b/lib/functoria/info.ml
@@ -27,6 +27,7 @@ type t = {
   runtime_args : Runtime_arg.Set.t;
   context : Context.t;
   packages : Package.t String.Map.t;
+  local_libs : string list;
   opam :
     extra_repo:(string * string) list ->
     install:Install.t ->
@@ -56,7 +57,7 @@ let libraries ps =
     (List.fold_left String.Set.union String.Set.empty (List.map libs ps))
 
 let packages t = List.map snd (String.Map.bindings t.packages)
-let libraries t = libraries (packages t)
+let libraries t = libraries (packages t) @ t.local_libs
 
 let pins packages =
   List.fold_left
@@ -67,9 +68,9 @@ let keys t = Key.Set.elements t.keys
 let runtime_args t = Runtime_arg.Set.elements t.runtime_args
 let context t = t.context
 
-let v ?(config_file = Fpath.v "config.ml") ~packages ~keys ~runtime_args
-    ~context ?configure_cmd ?pre_build_cmd ?lock_location ~build_cmd ~src
-    ~project_name name =
+let v ?(config_file = Fpath.v "config.ml") ~packages ~local_libs ~keys
+    ~runtime_args ~context ?configure_cmd ?pre_build_cmd ?lock_location
+    ~build_cmd ~src ~project_name name =
   let keys = Key.Set.of_list keys in
   let runtime_args = Runtime_arg.Set.of_list runtime_args in
   let opam ~extra_repo ~install ~opam_name =
@@ -96,6 +97,7 @@ let v ?(config_file = Fpath.v "config.ml") ~packages ~keys ~runtime_args
     keys;
     runtime_args;
     packages;
+    local_libs;
     context;
     output = None;
     opam;
@@ -125,7 +127,8 @@ let pp verbose ppf ({ name; keys; context; output; _ } as t) =
 
 let t =
   let i =
-    v ~config_file:(Fpath.v "config.ml") ~packages:[] ~keys:[] ~runtime_args:[]
+    v ~config_file:(Fpath.v "config.ml") ~packages:[] ~local_libs:[] ~keys:[]
+      ~runtime_args:[]
       ~build_cmd:(fun _ -> "dummy")
       ~context:Context.empty ~src:`None "dummy" ~project_name:"dummy"
   in

--- a/lib/functoria/info.mli
+++ b/lib/functoria/info.mli
@@ -70,6 +70,7 @@ val get : t -> 'a Key.key -> 'a
 val v :
   ?config_file:Fpath.t ->
   packages:Package.t list ->
+  local_libs:string list ->
   keys:Key.t list ->
   runtime_args:Runtime_arg.t list ->
   context:Context.t ->

--- a/lib/functoria/lib.ml
+++ b/lib/functoria/lib.ml
@@ -35,6 +35,7 @@ module Config = struct
     lock_location : Fpath.t option -> string -> string;
     build_cmd : Fpath.t option -> string;
     packages : package list Key.value;
+    local_libs : string list;
     if_keys : Key.Set.t;
     runtime_args : Runtime_arg.Set.t;
     init : job impl list;
@@ -59,6 +60,7 @@ module Config = struct
 
   let v ?(config_file = Fpath.v "config.ml") ?(init = []) ~configure_cmd
       ~pre_build_cmd ~lock_location ~build_cmd ~src ~project_name name jobs =
+    let local_libs = Impl.local_libs jobs in
     let jobs = Impl.abstract jobs in
     let if_keys = get_if_context jobs in
     let runtime_args = Runtime_arg.Set.empty in
@@ -74,6 +76,7 @@ module Config = struct
       lock_location;
       build_cmd;
       packages = Key.pure [];
+      local_libs;
       jobs;
       src;
     }
@@ -88,6 +91,7 @@ module Config = struct
         lock_location;
         build_cmd;
         packages;
+        local_libs;
         if_keys;
         runtime_args;
         jobs;
@@ -105,7 +109,7 @@ module Config = struct
     let keys = Key.Set.(elements (union if_keys all_keys)) in
     let mk packages _ context =
       let info =
-        Info.v ~config_file ~packages ~keys ~runtime_args ~context
+        Info.v ~config_file ~packages ~local_libs ~keys ~runtime_args ~context
           ~configure_cmd ~pre_build_cmd ~lock_location ~build_cmd ~src
           ~project_name n
       in

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -361,11 +361,12 @@ let run t = %s.Main.run t ; exit 0|ocaml}
       Key.match_ Key.(value target) @@ fun target ->
       Target.packages target @ common
     in
+    let local_libs = List.map Impl.local_libs jobs |> List.concat in
     let install = Target.install in
     let extra_deps = List.map dep jobs in
     let connect _ _ _ = code ~pos:__POS__ "return ()" in
-    impl ~keys ~packages_v ~configure ~dune ~connect ~extra_deps ~install
-      "Mirage_runtime" job
+    impl ~keys ~packages_v ~local_libs ~configure ~dune ~connect ~extra_deps
+      ~install "Mirage_runtime" job
 end
 
 include Lib.Make (Project)

--- a/test/mirage/action/test.ml
+++ b/test/mirage/action/test.ml
@@ -14,7 +14,7 @@ let print_banner s =
   print_newline ()
 
 let info context =
-  Info.v ~packages:[] ~keys:[] ~runtime_args:[]
+  Info.v ~packages:[] ~local_libs:[] ~keys:[] ~runtime_args:[]
     ~build_cmd:(fun sub ->
       Fmt.str "make%a build"
         Fmt.(option ~none:(any "") (any " " ++ Fpath.pp))


### PR DESCRIPTION
This PR allows using local dune libraries in a Mirage unikernel, as suggested in #1372.

This also (somewhat) solves #1359: the sources that need to be preprocessed can be put in a local library with its own `dune` file.