### PR TITLE
Remove some stack exports

### DIFF
--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -18,12 +18,6 @@ let ipv4 : ipv4 typ = ip
 let ipv6 : ipv6 typ = ip
 let ipv4v6 : ipv4v6 typ = ip
 
-type ipv4_config = {
-  network : Ipaddr.V4.Prefix.t;
-  gateway : Ipaddr.V4.t option;
-}
-(** Types for IPv4 manual configuration. *)
-
 (* convenience function for linking tcpip.unix for checksums *)
 let right_tcpip_library ?libs ~sublibs pkg =
   let min = "9.0.0" and max = "10.0.0" in
@@ -57,32 +51,18 @@ let ipv4_dhcp_conf =
 
 let ipv4_of_dhcp net ethif arp = ipv4_dhcp_conf $ net $ ethif $ arp
 
-let keyed_create_ipv4 ?group ?config ~no_init etif arp =
-  let network, gateway =
-    match config with
-    | None -> (Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24", None)
-    | Some { network; gateway } -> (network, gateway)
-  in
+let keyed_create_ipv4 ?group ~no_init etif arp =
+  let network, gateway = (Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24", None) in
   let ip = Runtime_arg.V4.network ?group network
   and gateway = Runtime_arg.V4.gateway ?group gateway in
   ipv4_keyed_conf ~ip ~gateway ~no_init () $ etif $ arp
 
-let create_ipv4 ?group ?config etif arp =
-  let network, gateway =
-    match config with
-    | None -> (Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24", None)
-    | Some { network; gateway } -> (network, gateway)
-  in
+let create_ipv4 ?group etif arp =
+  let network, gateway = (Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24", None) in
   let ip = Runtime_arg.V4.network ?group network
   and gateway = Runtime_arg.V4.gateway ?group gateway
   and no_init = Runtime_arg.ipv6_only ?group () in
   ipv4_keyed_conf ~ip ~gateway ~no_init () $ etif $ arp
-
-type ipv6_config = {
-  network : Ipaddr.V6.Prefix.t;
-  gateway : Ipaddr.V6.t option;
-}
-(** Types for IP manual configuration. *)
 
 let ipv4_qubes_conf =
   let packages = [ package ~min:"2.0.0" ~max:"3.0.0" "mirage-qubes-ipv4" ] in
@@ -111,23 +91,15 @@ let ipv6_conf ~ip ~gateway ~handle_ra ~no_init () =
   impl ~packages_v ~runtime_args ~connect "Ipv6.Make"
     (network @-> ethernet @-> ipv6)
 
-let keyed_create_ipv6 ?group ?config ~no_init netif etif =
-  let network, gateway =
-    match config with
-    | None -> (None, None)
-    | Some { network; gateway } -> (Some network, gateway)
-  in
+let keyed_create_ipv6 ?group ~no_init netif etif =
+  let network, gateway = (None, None) in
   let ip = Runtime_arg.V6.network ?group network
   and gateway = Runtime_arg.V6.gateway ?group gateway
   and handle_ra = Runtime_arg.V6.accept_router_advertisements ?group () in
   ipv6_conf ~ip ~gateway ~handle_ra ~no_init () $ netif $ etif
 
-let create_ipv6 ?group ?config netif etif =
-  let network, gateway =
-    match config with
-    | None -> (None, None)
-    | Some { network; gateway } -> (Some network, gateway)
-  in
+let create_ipv6 ?group netif etif =
+  let network, gateway = (None, None) in
   let ip = Runtime_arg.V6.network ?group network
   and gateway = Runtime_arg.V6.gateway ?group gateway
   and handle_ra = Runtime_arg.V6.accept_router_advertisements ?group ()

--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -16,42 +16,19 @@ val ip : 'a ip typ
 val ipv4 : ipv4 typ
 val ipv6 : ipv6 typ
 val ipv4v6 : ipv4v6 typ
-
-type ipv4_config = {
-  network : Ipaddr.V4.Prefix.t;
-  gateway : Ipaddr.V4.t option;
-}
-
-type ipv6_config = {
-  network : Ipaddr.V6.Prefix.t;
-  gateway : Ipaddr.V6.t option;
-}
-
-val create_ipv4 :
-  ?group:string ->
-  ?config:ipv4_config ->
-  ethernet impl ->
-  arpv4 impl ->
-  ipv4 impl
+val create_ipv4 : ?group:string -> ethernet impl -> arpv4 impl -> ipv4 impl
 
 val keyed_create_ipv4 :
   ?group:string ->
-  ?config:ipv4_config ->
   no_init:bool runtime_arg ->
   ethernet impl ->
   arpv4 impl ->
   ipv4 impl
 
-val create_ipv6 :
-  ?group:string ->
-  ?config:ipv6_config ->
-  network impl ->
-  ethernet impl ->
-  ipv6 impl
+val create_ipv6 : ?group:string -> network impl -> ethernet impl -> ipv6 impl
 
 val keyed_create_ipv6 :
   ?group:string ->
-  ?config:ipv6_config ->
   no_init:bool runtime_arg ->
   network impl ->
   ethernet impl ->

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -64,15 +64,6 @@ let keyed_direct_stackv4v6 ?tcp ~ipv4_only ~ipv6_only network eth arp ipv4 ipv6
   $ direct_udp ip
   $ match tcp with None -> direct_tcp ip | Some tcp -> tcp
 
-let static_ipv4v6_stack ?group ?ipv6_config ?ipv4_config ?(arp = arp) ?tcp tap =
-  let ipv4_only = Runtime_arg.ipv4_only ?group ()
-  and ipv6_only = Runtime_arg.ipv6_only ?group () in
-  let e = ethif tap in
-  let a = arp e in
-  let i4 = create_ipv4 ?group ?config:ipv4_config e a in
-  let i6 = create_ipv6 ?group ?config:ipv6_config tap e in
-  keyed_direct_stackv4v6 ~ipv4_only ~ipv6_only ?tcp tap e a i4 i6
-
 let generic_ipv4v6_stack p ?group ?ipv6_config ?ipv4_config ?(arp = arp) ?tcp
     tap =
   let ipv4_only = Runtime_arg.ipv4_only ?group ()

--- a/lib/devices/stack.mli
+++ b/lib/devices/stack.mli
@@ -16,8 +16,6 @@ val direct_stackv4v6 :
 
 val generic_stackv4v6 :
   ?group:string ->
-  ?ipv6_config:Ip.ipv6_config ->
-  ?ipv4_config:Ip.ipv4_config ->
   ?dhcp_key:bool value ->
   ?net_key:[ `OCaml | `Host ] option value ->
   ?tcp:Tcp.tcpv4v6 impl ->

--- a/lib/devices/stack.mli
+++ b/lib/devices/stack.mli
@@ -4,17 +4,6 @@ type stackv4v6
 
 val stackv4v6 : stackv4v6 typ
 
-val keyed_direct_stackv4v6 :
-  ?tcp:Tcp.tcpv4v6 impl ->
-  ipv4_only:bool runtime_arg ->
-  ipv6_only:bool runtime_arg ->
-  Network.network impl ->
-  Ethernet.ethernet impl ->
-  Arp.arpv4 impl ->
-  Ip.ipv4 impl ->
-  Ip.ipv6 impl ->
-  stackv4v6 impl
-
 val direct_stackv4v6 :
   ?group:string ->
   ?tcp:Tcp.tcpv4v6 impl ->
@@ -23,17 +12,6 @@ val direct_stackv4v6 :
   Arp.arpv4 impl ->
   Ip.ipv4 impl ->
   Ip.ipv6 impl ->
-  stackv4v6 impl
-
-val socket_stackv4v6 : ?group:string -> unit -> stackv4v6 impl
-
-val static_ipv4v6_stack :
-  ?group:string ->
-  ?ipv6_config:Ip.ipv6_config ->
-  ?ipv4_config:Ip.ipv4_config ->
-  ?arp:(Ethernet.ethernet impl -> Arp.arpv4 impl) ->
-  ?tcp:Tcp.tcpv4v6 impl ->
-  Network.network impl ->
   stackv4v6 impl
 
 val generic_stackv4v6 :

--- a/lib/devices/tcp.ml
+++ b/lib/devices/tcp.ml
@@ -36,18 +36,3 @@ let tcpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
     | _ -> connect_err "tcpv4v6_socket_conf" 4
   in
   impl ~packages_v ~configure ~runtime_args ~connect "Tcpv4v6_socket" tcpv4v6
-
-let socket_tcpv4v6 ?group ipv4 ipv6 =
-  let ipv4 =
-    match ipv4 with
-    | None -> Ipaddr.V4.Prefix.global
-    | Some ip -> Ipaddr.V4.Prefix.make 32 ip
-  and ipv6 =
-    match ipv6 with
-    | None -> None
-    | Some ip -> Some (Ipaddr.V6.Prefix.make 128 ip)
-  and ipv4_only = Runtime_arg.ipv4_only ?group ()
-  and ipv6_only = Runtime_arg.ipv6_only ?group () in
-  tcpv4v6_socket_conf ~ipv4_only ~ipv6_only
-    (Runtime_arg.V4.network ?group ipv4)
-    (Runtime_arg.V6.network ?group ipv6)

--- a/lib/devices/tcp.mli
+++ b/lib/devices/tcp.mli
@@ -9,9 +9,6 @@ type tcpv4v6 = Ip.v4v6 tcp
 val tcpv4v6 : tcpv4v6 typ
 val direct_tcp : 'a Ip.ip impl -> 'a tcp impl
 
-val socket_tcpv4v6 :
-  ?group:string -> Ipaddr.V4.t option -> Ipaddr.V6.t option -> tcpv4v6 impl
-
 val tcpv4v6_socket_conf :
   ipv4_only:bool runtime_arg ->
   ipv6_only:bool runtime_arg ->

--- a/lib/devices/udp.ml
+++ b/lib/devices/udp.ml
@@ -36,18 +36,3 @@ let udpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
     | _ -> connect_err "udpv4v6_socket_conf" 4
   in
   impl ~runtime_args ~packages_v ~configure ~connect "Udpv4v6_socket" udpv4v6
-
-let socket_udpv4v6 ?group ipv4 ipv6 =
-  let ipv4 =
-    match ipv4 with
-    | None -> Ipaddr.V4.Prefix.global
-    | Some ip -> Ipaddr.V4.Prefix.make 32 ip
-  and ipv6 =
-    match ipv6 with
-    | None -> None
-    | Some ip -> Some (Ipaddr.V6.Prefix.make 128 ip)
-  and ipv4_only = Runtime_arg.ipv4_only ?group ()
-  and ipv6_only = Runtime_arg.ipv6_only ?group () in
-  udpv4v6_socket_conf ~ipv4_only ~ipv6_only
-    (Runtime_arg.V4.network ?group ipv4)
-    (Runtime_arg.V6.network ?group ipv6)

--- a/lib/devices/udp.mli
+++ b/lib/devices/udp.mli
@@ -9,9 +9,6 @@ type udpv4v6 = Ip.v4v6 udp
 val udpv4v6 : udpv4v6 typ
 val direct_udp : 'a Ip.ip impl -> 'a udp impl
 
-val socket_udpv4v6 :
-  ?group:string -> Ipaddr.V4.t option -> Ipaddr.V6.t option -> udpv4v6 impl
-
 val udpv4v6_socket_conf :
   ipv4_only:bool runtime_arg ->
   ipv6_only:bool runtime_arg ->

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -136,7 +136,6 @@ type udpv4v6 = Udp.udpv4v6
 
 let udpv4v6 = Udp.udpv4v6
 let direct_udp = Udp.direct_udp
-let socket_udpv4v6 = Udp.socket_udpv4v6
 
 type 'a tcp = 'a Tcp.tcp
 
@@ -146,7 +145,6 @@ type tcpv4v6 = Tcp.tcpv4v6
 
 let tcpv4v6 = Tcp.tcpv4v6
 let direct_tcp = Tcp.direct_tcp
-let socket_tcpv4v6 = Tcp.socket_tcpv4v6
 
 type stackv4v6 = Stack.stackv4v6
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -162,9 +162,7 @@ type stackv4v6 = Stack.stackv4v6
 
 let stackv4v6 = Stack.stackv4v6
 let generic_stackv4v6 = Stack.generic_stackv4v6
-let static_ipv4v6_stack = Stack.static_ipv4v6_stack
 let direct_stackv4v6 = Stack.direct_stackv4v6
-let socket_stackv4v6 = Stack.socket_stackv4v6
 
 let tcpv4v6_of_stackv4v6 v =
   let impl =

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -128,16 +128,6 @@ let create_ipv4 = Ip.create_ipv4
 let create_ipv6 = Ip.create_ipv6
 let create_ipv4v6 = Ip.create_ipv4v6
 
-type ipv4_config = Ip.ipv4_config = {
-  network : Ipaddr.V4.Prefix.t;
-  gateway : Ipaddr.V4.t option;
-}
-
-type ipv6_config = Ip.ipv6_config = {
-  network : Ipaddr.V6.Prefix.t;
-  gateway : Ipaddr.V6.t option;
-}
-
 type 'a udp = 'a Udp.udp
 
 let udp = Udp.udp

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -601,22 +601,6 @@ val direct_stackv4v6 :
   stackv4v6 impl
 (** Direct network stack with given ip. *)
 
-val socket_stackv4v6 : ?group:string -> unit -> stackv4v6 impl
-(** Network stack with sockets. *)
-
-val static_ipv4v6_stack :
-  ?group:string ->
-  ?ipv6_config:ipv6_config ->
-  ?ipv4_config:ipv4_config ->
-  ?arp:(ethernet impl -> arpv4 impl) ->
-  ?tcp:tcpv4v6 impl ->
-  network impl ->
-  stackv4v6 impl
-(** Build a stackv4v6 by checking the {!Runtime_arg.V6.network}, and
-    {!Runtime_arg.V6.gateway} keys for IPv4 and IPv6 configuration information,
-    filling in unspecified information from [?config], then building a stack on
-    top of that. *)
-
 val generic_stackv4v6 :
   ?group:string ->
   ?ipv6_config:ipv6_config ->
@@ -628,9 +612,10 @@ val generic_stackv4v6 :
   stackv4v6 impl
 (** Generic stack using a [net] keys: {!Key.net}.
 
-    - If [net] = [host] then {!socket_stackv4v6} is used
-    - Else, if [unix or macosx] then {!socket_stackv4v6} is used
-    - Else, {!static_ipv4v6_stack} is used.
+    - If [net] = [host] then the Unix sockets API is used;
+    - Else, if [qubes], a special IPv4 stack using the QubesDB is used;
+    - Else, if [dhcp] is true, a DHCP client is used for the IPv4 address;
+    - Else, an IP stack with a static IP address is used.
 
     If a key is not provided, it uses {!Key.net} (with the [group] argument) to
     create it. *)

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -540,9 +540,6 @@ val udp : 'a udp typ
 val udpv4v6 : udpv4v6 typ
 val direct_udp : 'a ip impl -> 'a udp impl
 
-val socket_udpv4v6 :
-  ?group:string -> Ipaddr.V4.t option -> Ipaddr.V6.t option -> udpv4v6 impl
-
 (** {2 TCP configuration} *)
 
 type 'a tcp
@@ -553,9 +550,6 @@ val tcp : 'a tcp typ
 
 val tcpv4v6 : tcpv4v6 typ
 val direct_tcp : 'a ip impl -> 'a tcp impl
-
-val socket_tcpv4v6 :
-  ?group:string -> Ipaddr.V4.t option -> Ipaddr.V6.t option -> tcpv4v6 impl
 
 (** {2 Network stack configuration} *)
 

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -512,42 +512,18 @@ val ipv6 : ipv6 typ
 val ipv4v6 : ipv4v6 typ
 (** The [Tcpip.Ip.S] module signature with ipaddr = Ipaddr.t. *)
 
-type ipv4_config = {
-  network : Ipaddr.V4.Prefix.t;
-  gateway : Ipaddr.V4.t option;
-}
-(** Types for manual IPv4 configuration. *)
-
-type ipv6_config = {
-  network : Ipaddr.V6.Prefix.t;
-  gateway : Ipaddr.V6.t option;
-}
-(** Types for manual IPv6 configuration. *)
-
 val ipv4_of_dhcp : network impl -> ethernet impl -> arpv4 impl -> ipv4 impl
 (** Configure the interface via DHCP *)
 
-val create_ipv4 :
-  ?group:string ->
-  ?config:ipv4_config ->
-  ethernet impl ->
-  arpv4 impl ->
-  ipv4 impl
+val create_ipv4 : ?group:string -> ethernet impl -> arpv4 impl -> ipv4 impl
 (** Use an IPv4 address Exposes the keys {!Runtime_arg.V4.network} and
-    {!Runtime_arg.V4.gateway}. If provided, the values of these keys will
-    override those supplied in the ipv4 configuration record, if that has been
-    provided. *)
+    {!Runtime_arg.V4.gateway}. *)
 
 val ipv4_qubes : qubesdb impl -> ethernet impl -> arpv4 impl -> ipv4 impl
 (** Use a given initialized QubesDB to look up and configure the appropriate *
     IPv4 interface. *)
 
-val create_ipv6 :
-  ?group:string ->
-  ?config:ipv6_config ->
-  network impl ->
-  ethernet impl ->
-  ipv6 impl
+val create_ipv6 : ?group:string -> network impl -> ethernet impl -> ipv6 impl
 (** Use an IPv6 address. Exposes the keys {!Runtime_arg.V6.network},
     {!Runtime_arg.V6.gateway}. *)
 
@@ -603,8 +579,6 @@ val direct_stackv4v6 :
 
 val generic_stackv4v6 :
   ?group:string ->
-  ?ipv6_config:ipv6_config ->
-  ?ipv4_config:ipv4_config ->
   ?dhcp_key:bool value ->
   ?net_key:[ `OCaml | `Host ] option value ->
   ?tcp:tcpv4v6 impl ->

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -39,7 +39,7 @@ Configure the project for Unix:
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 394 "lib/mirage.ml"
+  # 384 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -69,7 +69,7 @@ Configure the project for Unix:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 281 "lib/mirage.ml"
+  # 271 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
@@ -106,7 +106,7 @@ Configure the project for Unix:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 290 "lib/mirage.ml"
+  # 280 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -145,7 +145,7 @@ Configure the project for Unix:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 375 "lib/mirage.ml"
+  # 365 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"
@@ -213,7 +213,7 @@ Configure the project for Xen:
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 394 "lib/mirage.ml"
+  # 384 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -243,7 +243,7 @@ Configure the project for Xen:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 281 "lib/mirage.ml"
+  # 271 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
@@ -280,7 +280,7 @@ Configure the project for Xen:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 290 "lib/mirage.ml"
+  # 280 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -319,7 +319,7 @@ Configure the project for Xen:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 375 "lib/mirage.ml"
+  # 365 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -39,7 +39,7 @@ Configure the project for Unix:
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 396 "lib/mirage.ml"
+  # 394 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -69,7 +69,7 @@ Configure the project for Unix:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 283 "lib/mirage.ml"
+  # 281 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
@@ -106,7 +106,7 @@ Configure the project for Unix:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 292 "lib/mirage.ml"
+  # 290 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -145,7 +145,7 @@ Configure the project for Unix:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 377 "lib/mirage.ml"
+  # 375 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"
@@ -213,7 +213,7 @@ Configure the project for Xen:
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 396 "lib/mirage.ml"
+  # 394 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -243,7 +243,7 @@ Configure the project for Xen:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 283 "lib/mirage.ml"
+  # 281 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
@@ -280,7 +280,7 @@ Configure the project for Xen:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 292 "lib/mirage.ml"
+  # 290 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -319,7 +319,7 @@ Configure the project for Xen:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 377 "lib/mirage.ml"
+  # 375 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -39,7 +39,7 @@ Configure the project for Unix:
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 384 "lib/mirage.ml"
+  # 382 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -69,7 +69,7 @@ Configure the project for Unix:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 271 "lib/mirage.ml"
+  # 269 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
@@ -106,7 +106,7 @@ Configure the project for Unix:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 280 "lib/mirage.ml"
+  # 278 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -145,7 +145,7 @@ Configure the project for Unix:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 365 "lib/mirage.ml"
+  # 363 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"
@@ -213,7 +213,7 @@ Configure the project for Xen:
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 384 "lib/mirage.ml"
+  # 382 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -243,7 +243,7 @@ Configure the project for Xen:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 271 "lib/mirage.ml"
+  # 269 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
@@ -280,7 +280,7 @@ Configure the project for Xen:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 280 "lib/mirage.ml"
+  # 278 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -319,7 +319,7 @@ Configure the project for Xen:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 365 "lib/mirage.ml"
+  # 363 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"

--- a/test/mirage/warn-etif/config.ml
+++ b/test/mirage/warn-etif/config.ml
@@ -11,6 +11,11 @@ end
 let rec eth = etif default_network
 let main = main "App.Make" ~pos:__POS__ (ethernet @-> job)
 
+type ipv4_config = {
+  network : Ipaddr.V4.Prefix.t;
+  gateway : Ipaddr.V4.t option;
+}
+
 let () =
   let ramdisk (conf : ipv4_config) =
     match conf with { network } -> ramdisk "secrets\f42"


### PR DESCRIPTION
The main objective is to reduce our code. And do not expose things that have turned up to be not used at all.

This removes some exports of some "stacks", which I haven't found any use of. If there's somewhere a use of these things, please let me know and we can re-add them. The direct_stackv4v6 is used in unikernels that use uTCP.

Also, the types ipv4_config and ipv6_config have been removed. I couldn't find any use of them.