### PR TITLE
Refactor: qualify open

### DIFF
--- a/lib/devices/argv.mli
+++ b/lib/devices/argv.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
-val default_argv : argv impl
-val no_argv : argv impl
+val default_argv : Functoria.argv impl
+val no_argv : Functoria.argv impl

--- a/lib/devices/arp.ml
+++ b/lib/devices/arp.ml
@@ -1,6 +1,4 @@
 open Functoria.DSL
-open Ethernet
-open Misc
 
 type arpv4 = Arpv4
 
@@ -12,8 +10,8 @@ let arp_conf =
   in
   let connect _ modname = function
     | [ eth ] -> code ~pos:__POS__ "%s.connect %s" modname eth
-    | _ -> connect_err "arp" 1
+    | _ -> Misc.connect_err "arp" 1
   in
-  impl ~packages ~connect "Arp.Make" (ethernet @-> arpv4)
+  impl ~packages ~connect "Arp.Make" (Ethernet.ethernet @-> arpv4)
 
-let arp (eth : ethernet impl) = arp_conf $ eth
+let arp (eth : Ethernet.ethernet impl) = arp_conf $ eth

--- a/lib/devices/arp.mli
+++ b/lib/devices/arp.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type arpv4
 

--- a/lib/devices/block.ml
+++ b/lib/devices/block.ml
@@ -3,9 +3,6 @@ module Info = Functoria.Info
 module Install = Functoria.Install
 open Functoria.DSL
 open Functoria.Action
-open Misc
-open Kv
-open Cmdliner
 
 type block = BLOCK
 
@@ -38,7 +35,7 @@ let xen_block_packages =
    also understands *)
 let xenstore_conf id =
   let configure i =
-    match get_target i with
+    match Misc.get_target i with
     | `Qubes | `Xen -> ok ()
     | _ ->
         error
@@ -85,9 +82,9 @@ let block_conf file =
     ok ()
   in
   let connect i s _ =
-    match get_target i with
+    match Misc.get_target i with
     | `Muen -> failwith "Block devices not supported on Muen target."
-    | _ -> code ~pos:__POS__ "%s.connect %S" s (connect_name (get_target i))
+    | _ -> code ~pos:__POS__ "%s.connect %S" s (connect_name (Misc.get_target i))
   in
   Functoria.Device.v ~configure ~packages_v ~connect "Block" block
 
@@ -111,7 +108,7 @@ let tar_kv_ro_conf =
   let packages = [ package ~min:"1.0.0" ~max:"4.0.0" "tar-mirage" ] in
   let connect _ modname = function
     | [ block ] -> code ~pos:__POS__ "%s.connect %s" modname block
-    | _ -> connect_err "tar_kv_ro" 1
+    | _ -> Misc.connect_err "tar_kv_ro" 1
   in
   impl ~packages ~connect "Tar_mirage.Make_KV_RO" (block @-> Kv.ro)
 
@@ -119,7 +116,7 @@ let tar_kv_rw_conf =
   let packages = [ package ~min:"2.2.0" ~max:"4.0.0" "tar-mirage" ] in
   let connect _ modname = function
     | [ block ] -> code ~pos:__POS__ "%s.connect %s" modname block
-    | _ -> connect_err "tar_kv_rw" 1
+    | _ -> Misc.connect_err "tar_kv_rw" 1
   in
   impl ~packages ~connect "Tar_mirage.Make_KV_RW" (block @-> Kv.rw)
 
@@ -130,7 +127,7 @@ let fat_conf =
   let packages = [ package ~min:"0.15.0" ~max:"0.16.0" "fat-filesystem" ] in
   let connect _ modname = function
     | [ block ] -> code ~pos:__POS__ "%s.connect %s" modname block
-    | _ -> connect_err "fat" 1
+    | _ -> Misc.connect_err "fat" 1
   in
   impl ~packages ~connect "Fat.KV_RO" (block @-> Kv.ro)
 
@@ -197,14 +194,14 @@ let docteur_unix (mode : mode) extra_deps ~name:_ ~output branch analyze remote
              let f = Rresult.R.(failwith_error_msg <.> reword_error (msgf "%%a" %s.pp_error)) in
              Lwt.map f (%s.connect ~analyze:%s %S)|ocaml}
           modname modname analyze name
-    | _ -> connect_err "docteur_unix" 1
+    | _ -> Misc.connect_err "docteur_unix" 1
   in
   let keys = [ Key.v output ] in
   let runtime_args = Runtime_arg.[ v analyze ] in
   let packages = [ package "docteur-unix" ~min:"0.0.6" ] in
   impl ~runtime_args ~keys ~packages ~dune ~install ~configure ~connect
     (Fmt.str "Docteur_unix.%a" pp_mode mode)
-    ro
+    Kv.ro
 
 let docteur_solo5 (mode : mode) extra_deps ~name ~output branch analyze remote =
   let dune info =
@@ -256,31 +253,31 @@ let docteur_solo5 (mode : mode) extra_deps ~name ~output branch analyze remote =
              let f = Rresult.R.(failwith_error_msg <.> reword_error (msgf "%%a" %s.pp_error)) in
              Lwt.map f (%s.connect ~analyze:%s %S)|ocaml}
           modname modname analyze name
-    | _ -> connect_err "docteur_solo5" 1
+    | _ -> Misc.connect_err "docteur_solo5" 1
   in
   let keys = [ Key.v output; Key.v name ] in
   let runtime_args = Runtime_arg.[ v analyze ] in
   let packages = [ package "docteur-solo5" ~min:"0.0.6" ] in
   impl ~keys ~runtime_args ~packages ~dune ~install ~configure ~connect
     (Fmt.str "Docteur_solo5.%a" pp_mode mode)
-    ro
+    Kv.ro
 
 let disk_name =
   let doc =
-    Arg.info
+    Cmdliner.Arg.info
       ~doc:
         "Name of the docteur disk (for Solo5 targets, the name must contains \
          only alpanumeric characters)."
       [ "disk-name" ]
   in
-  let key = Key.Arg.opt Arg.string "docteur" doc in
+  let key = Key.Arg.opt Cmdliner.Arg.string "docteur" doc in
   Key.create "disk-name" key
 
 let disk_output =
   let doc =
-    Arg.info ~doc:"The output of the generated docteur image." [ "disk-output" ]
+    Cmdliner.Arg.info ~doc:"The output of the generated docteur image." [ "disk-output" ]
   in
-  let key = Key.Arg.opt Arg.string "disk.img" doc in
+  let key = Key.Arg.opt Cmdliner.Arg.string "disk.img" doc in
   Key.create "disk-output" key
 
 let docteur_solo5 (mode : mode) extra_deps ?(name = disk_name)
@@ -320,7 +317,7 @@ let chamelon ~program_block_size =
                  >|= Result.map_error (Fmt.str "%%a" %s.pp_error)
                  >|= Result.fold ~ok:Fun.id ~error:failwith|ocaml}
           modname program_block_size block modname
-    | _ -> connect_err "chameleon" 2
+    | _ -> Misc.connect_err "chameleon" 2
   in
   impl ~packages ~runtime_args ~connect "Kv.Make" (block @-> Kv.rw)
 
@@ -341,6 +338,6 @@ let ccm_block ?nonce_len key =
           key modname
           Fmt.(parens (Dump.option int))
           nonce_len block
-    | _ -> connect_err "ccm_block" 2
+    | _ -> Misc.connect_err "ccm_block" 2
   in
   impl ~packages ~runtime_args ~connect "Block_ccm.Make" (block @-> block)

--- a/lib/devices/block.ml
+++ b/lib/devices/block.ml
@@ -84,7 +84,8 @@ let block_conf file =
   let connect i s _ =
     match Misc.get_target i with
     | `Muen -> failwith "Block devices not supported on Muen target."
-    | _ -> code ~pos:__POS__ "%s.connect %S" s (connect_name (Misc.get_target i))
+    | _ ->
+        code ~pos:__POS__ "%s.connect %S" s (connect_name (Misc.get_target i))
   in
   Functoria.Device.v ~configure ~packages_v ~connect "Block" block
 
@@ -275,7 +276,8 @@ let disk_name =
 
 let disk_output =
   let doc =
-    Cmdliner.Arg.info ~doc:"The output of the generated docteur image." [ "disk-output" ]
+    Cmdliner.Arg.info ~doc:"The output of the generated docteur image."
+      [ "disk-output" ]
   in
   let key = Key.Arg.opt Cmdliner.Arg.string "disk.img" doc in
   Key.create "disk-output" key

--- a/lib/devices/block.mli
+++ b/lib/devices/block.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type block
 

--- a/lib/devices/conduit.ml
+++ b/lib/devices/conduit.ml
@@ -1,6 +1,4 @@
 open Functoria.DSL
-open Stack
-open Misc
 
 type conduit = Conduit
 
@@ -11,15 +9,15 @@ let tcp =
   let packages = [ pkg ] in
   let connect _ _ = function
     | [ stack ] -> code ~pos:__POS__ "Lwt.return %s@;" stack
-    | _ -> connect_err "tcp_conduit" 1
+    | _ -> Misc.connect_err "tcp_conduit" 1
   in
-  impl ~packages ~connect "Conduit_mirage.TCP" (stackv4v6 @-> conduit)
+  impl ~packages ~connect "Conduit_mirage.TCP" (Stack.stackv4v6 @-> conduit)
 
 let tls =
   let packages = [ pkg; package ~min:"2.0.0" ~max:"3.0.0" "tls-mirage" ] in
   let connect _ _ = function
     | [ stack ] -> code ~pos:__POS__ "Lwt.return %s@;" stack
-    | _ -> connect_err "tls_conduit" 1
+    | _ -> Misc.connect_err "tls_conduit" 1
   in
   impl ~packages ~connect "Conduit_mirage.TLS" (conduit @-> conduit)
 

--- a/lib/devices/conduit.mli
+++ b/lib/devices/conduit.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type conduit
 

--- a/lib/devices/dns.ml
+++ b/lib/devices/dns.ml
@@ -1,7 +1,4 @@
 open Functoria.DSL
-open Stack
-open Misc
-open Happy_eyeballs
 
 type dns_client = Dns_client
 
@@ -18,7 +15,7 @@ let generic_dns_client ?group ?timeout ?nameservers ?cache_size () =
         code ~pos:__POS__
           {ocaml|%s.connect @[?nameservers:%s ?timeout:%s ?cache_size:%s@ (%s, %s)@]|ocaml}
           modname nameservers timeout cache_size stackv4v6 happy_eyeballs
-    | _ -> connect_err "generic_dns_client" 5
+    | _ -> Misc.connect_err "generic_dns_client" 5
   in
   impl ~runtime_args ~packages ~connect "Dns_client_mirage.Make"
-    (stackv4v6 @-> happy_eyeballs @-> dns_client)
+    (Stack.stackv4v6 @-> Happy_eyeballs.happy_eyeballs @-> dns_client)

--- a/lib/devices/dns.mli
+++ b/lib/devices/dns.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type dns_client
 

--- a/lib/devices/ethernet.ml
+++ b/lib/devices/ethernet.ml
@@ -1,6 +1,4 @@
 open Functoria.DSL
-open Misc
-open Network
 
 type ethernet = ETHERNET
 
@@ -10,8 +8,8 @@ let ethif_conf =
   let packages = [ package ~min:"3.0.0" ~max:"4.0.0" "ethernet" ] in
   let connect _ m = function
     | [ eth ] -> code ~pos:__POS__ "%s.connect %s" m eth
-    | _ -> connect_err "etif" 1
+    | _ -> Misc.connect_err "etif" 1
   in
-  impl ~packages ~connect "Ethernet.Make" (network @-> ethernet)
+  impl ~packages ~connect "Ethernet.Make" (Network.network @-> ethernet)
 
 let ethif network = ethif_conf $ network

--- a/lib/devices/ethernet.mli
+++ b/lib/devices/ethernet.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type ethernet
 

--- a/lib/devices/git.ml
+++ b/lib/devices/git.ml
@@ -1,7 +1,4 @@
 open Functoria.DSL
-open Tcp
-open Mimic
-open Misc
 
 type git_client = Git_client
 
@@ -11,7 +8,7 @@ let git_merge_clients =
   let packages = [ package "mimic" ] in
   let connect _ _modname = function
     | [ a; b ] -> code ~pos:__POS__ "Lwt.return (Mimic.merge %s %s)" a b
-    | _ -> connect_err "git_merge_client" 2
+    | _ -> Misc.connect_err "git_merge_client" 2
   in
   impl ~packages ~connect "Mimic.Merge"
     (git_client @-> git_client @-> git_client)
@@ -21,9 +18,9 @@ let git_tcp =
   let connect _ modname = function
     | [ _tcpv4v6; ctx ] ->
         code ~pos:__POS__ {ocaml|%s.connect %s|ocaml} modname ctx
-    | _ -> connect_err "git_tcp" 2
+    | _ -> Misc.connect_err "git_tcp" 2
   in
-  impl ~packages ~connect "Git_net.TCP.Make" (tcpv4v6 @-> mimic @-> git_client)
+  impl ~packages ~connect "Git_net.TCP.Make" (Tcp.tcpv4v6 @-> Mimic.mimic @-> git_client)
 
 let git_ssh ?group ?authenticator ?key ?password () =
   let packages = [ package ~max:"1.0.0" "git-net" ] in
@@ -36,10 +33,10 @@ let git_ssh ?group ?authenticator ?key ?password () =
         code ~pos:__POS__
           {ocaml|%s.connect %s >>= %s.with_optionnal_key ?authenticator:%s ~key:%s ~password:%s|ocaml}
           modname ctx modname authenticator key password
-    | _ -> connect_err "git_ssh" 5
+    | _ -> Misc.connect_err "git_ssh" 5
   in
   impl ~packages ~connect ~runtime_args "Git_net.SSH.Make"
-    (tcpv4v6 @-> mimic @-> git_client)
+    (Tcp.tcpv4v6 @-> Mimic.mimic @-> git_client)
 
 let git_http ?group ?authenticator ?headers () =
   let packages = [ package ~max:"1.0.0" "git-net" ] in
@@ -51,7 +48,7 @@ let git_http ?group ?authenticator ?headers () =
         code ~pos:__POS__
           {ocaml|%s.connect %s >>= %s.with_optional_tls_config_and_headers ?headers:%s ?authenticator:%s|ocaml}
           modname ctx modname headers authenticator
-    | _ -> connect_err "git_http" 4
+    | _ -> Misc.connect_err "git_http" 4
   in
   impl ~packages ~connect ~runtime_args "Git_net.HTTP.Make"
-    (tcpv4v6 @-> mimic @-> git_client)
+    (Tcp.tcpv4v6 @-> Mimic.mimic @-> git_client)

--- a/lib/devices/git.ml
+++ b/lib/devices/git.ml
@@ -20,7 +20,8 @@ let git_tcp =
         code ~pos:__POS__ {ocaml|%s.connect %s|ocaml} modname ctx
     | _ -> Misc.connect_err "git_tcp" 2
   in
-  impl ~packages ~connect "Git_net.TCP.Make" (Tcp.tcpv4v6 @-> Mimic.mimic @-> git_client)
+  impl ~packages ~connect "Git_net.TCP.Make"
+    (Tcp.tcpv4v6 @-> Mimic.mimic @-> git_client)
 
 let git_ssh ?group ?authenticator ?key ?password () =
   let packages = [ package ~max:"1.0.0" "git-net" ] in

--- a/lib/devices/git.mli
+++ b/lib/devices/git.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type git_client
 

--- a/lib/devices/happy_eyeballs.ml
+++ b/lib/devices/happy_eyeballs.ml
@@ -1,6 +1,4 @@
 open Functoria.DSL
-open Stack
-open Misc
 
 type happy_eyeballs = Happy_eyeballs
 
@@ -43,7 +41,7 @@ let generic_happy_eyeballs ?group ?aaaa_timeout ?connect_delay ?connect_timeout
 ?connect_timeout:%s ?resolve_timeout:%s ?resolve_retries:%s ?timer_interval:%s %s|ocaml}
           modname aaaa_timeout connect_delay connect_timeout resolve_timeout
           resolve_retries timer_interval stack
-    | _ -> connect_err "generic_happy_eyeballs" 7
+    | _ -> Misc.connect_err "generic_happy_eyeballs" 7
   in
   impl ~runtime_args ~packages ~connect "Happy_eyeballs_mirage.Make"
-    (stackv4v6 @-> happy_eyeballs)
+    (Stack.stackv4v6 @-> happy_eyeballs)

--- a/lib/devices/happy_eyeballs.mli
+++ b/lib/devices/happy_eyeballs.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type happy_eyeballs
 

--- a/lib/devices/http.mli
+++ b/lib/devices/http.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type http
 

--- a/lib/devices/icmp.ml
+++ b/lib/devices/icmp.ml
@@ -1,19 +1,17 @@
 open Functoria.DSL
-open Ip
-open Misc
 
 type 'a icmp = ICMP
-type icmpv4 = v4 icmp
+type icmpv4 = Ip.v4 icmp
 
 let icmp = typ ICMP
 let icmpv4 : icmpv4 typ = icmp
 
 let icmpv4_direct () =
-  let packages_v = right_tcpip_library ~sublibs:[ "icmpv4" ] "tcpip" in
+  let packages_v = Ip.right_tcpip_library ~sublibs:[ "icmpv4" ] "tcpip" in
   let connect _ modname = function
     | [ ip ] -> code ~pos:__POS__ "%s.connect %s" modname ip
-    | _ -> connect_err "icmpv4" 1
+    | _ -> Misc.connect_err "icmpv4" 1
   in
-  impl ~packages_v ~connect "Icmpv4.Make" (ip @-> icmp)
+  impl ~packages_v ~connect "Icmpv4.Make" (Ip.ip @-> icmp)
 
 let direct_icmpv4 ip = icmpv4_direct () $ ip

--- a/lib/devices/icmp.mli
+++ b/lib/devices/icmp.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type icmpv4
 

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -1,9 +1,4 @@
 open Functoria.DSL
-open Arp
-open Ethernet
-open Misc
-open Network
-open Qubesdb
 
 type v4
 type v6
@@ -31,10 +26,10 @@ let ipv4_keyed_conf ~ip ~gateway ~no_init () =
         code ~pos:__POS__
           "%s.connect@[~no_init:%s@ ~cidr:%s@ ?gateway:%s@ %s@ %s@]" modname
           no_init ip gateway etif arp
-    | _ -> connect_err "ipv4 keyed" 5
+    | _ -> Misc.connect_err "ipv4 keyed" 5
   in
   impl ~packages_v ~runtime_args ~connect "Static_ipv4.Make"
-    (ethernet @-> arpv4 @-> ipv4)
+    (Ethernet.ethernet @-> Arp.arpv4 @-> ipv4)
 
 let ipv4_dhcp_conf =
   let packages =
@@ -44,10 +39,10 @@ let ipv4_dhcp_conf =
     | [ network; ethernet; arp ] ->
         code ~pos:__POS__ "%s.connect@[@ %s@ %s@ %s@]" modname network ethernet
           arp
-    | _ -> connect_err "ipv4 dhcp" 3
+    | _ -> Misc.connect_err "ipv4 dhcp" 3
   in
   impl ~packages ~connect "Dhcp_ipv4.Make"
-    (network @-> ethernet @-> arpv4 @-> ipv4)
+    (Network.network @-> Ethernet.ethernet @-> Arp.arpv4 @-> ipv4)
 
 let ipv4_of_dhcp net ethif arp = ipv4_dhcp_conf $ net $ ethif $ arp
 
@@ -69,10 +64,10 @@ let ipv4_qubes_conf =
   let connect _ modname = function
     | [ db; etif; arp ] ->
         code ~pos:__POS__ "%s.connect@[@ %s@ %s@ %s@]" modname db etif arp
-    | _ -> connect_err "qubes_ipv4" 3
+    | _ -> Misc.connect_err "qubes_ipv4" 3
   in
   impl ~packages ~connect "Qubesdb_ipv4.Make"
-    (qubesdb @-> ethernet @-> arpv4 @-> ipv4)
+    (Qubesdb.qubesdb @-> Ethernet.ethernet @-> Arp.arpv4 @-> ipv4)
 
 let ipv4_qubes db ethernet arp = ipv4_qubes_conf $ db $ ethernet $ arp
 
@@ -85,11 +80,11 @@ let ipv6_conf ~ip ~gateway ~handle_ra ~no_init () =
           "%s.connect@[~no_init:%s@ ~handle_ra:%s@ ?cidr:%s@ ?gateway:%s@ %s@ \
            %s@]"
           modname no_init handle_ra ip gateway netif etif
-    | _ -> connect_err "ipv6" 6
+    | _ -> Misc.connect_err "ipv6" 6
   in
 
   impl ~packages_v ~runtime_args ~connect "Ipv6.Make"
-    (network @-> ethernet @-> ipv6)
+    (Network.network @-> Ethernet.ethernet @-> ipv6)
 
 let keyed_create_ipv6 ?group ~no_init netif etif =
   let network, gateway = (None, None) in
@@ -113,7 +108,7 @@ let ipv4v6_conf ~ipv4_only ~ipv6_only () =
     | [ ipv4; ipv6; ipv4_only; ipv6_only ] ->
         code ~pos:__POS__ "%s.connect@[@ ~ipv4_only:%s@ ~ipv6_only:%s@ %s@ %s@]"
           modname ipv4_only ipv6_only ipv4 ipv6
-    | _ -> connect_err "ipv4v6" 4
+    | _ -> Misc.connect_err "ipv4v6" 4
   in
   impl ~packages_v ~runtime_args ~connect "Tcpip_stack_direct.IPV4V6"
     (ipv4 @-> ipv6 @-> ipv4v6)

--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -1,8 +1,4 @@
 open Functoria
-open Arp
-open Ethernet
-open Network
-open Qubesdb
 
 type v4
 type v6
@@ -16,26 +12,26 @@ val ip : 'a ip typ
 val ipv4 : ipv4 typ
 val ipv6 : ipv6 typ
 val ipv4v6 : ipv4v6 typ
-val create_ipv4 : ?group:string -> ethernet impl -> arpv4 impl -> ipv4 impl
+val create_ipv4 : ?group:string -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl
 
 val keyed_create_ipv4 :
   ?group:string ->
   no_init:bool runtime_arg ->
-  ethernet impl ->
-  arpv4 impl ->
+  Ethernet.ethernet impl ->
+  Arp.arpv4 impl ->
   ipv4 impl
 
-val create_ipv6 : ?group:string -> network impl -> ethernet impl -> ipv6 impl
+val create_ipv6 : ?group:string -> Network.network impl -> Ethernet.ethernet impl -> ipv6 impl
 
 val keyed_create_ipv6 :
   ?group:string ->
   no_init:bool runtime_arg ->
-  network impl ->
-  ethernet impl ->
+  Network.network impl ->
+  Ethernet.ethernet impl ->
   ipv6 impl
 
-val ipv4_of_dhcp : network impl -> ethernet impl -> arpv4 impl -> ipv4 impl
-val ipv4_qubes : qubesdb impl -> ethernet impl -> arpv4 impl -> ipv4 impl
+val ipv4_of_dhcp : Network.network impl -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl
+val ipv4_qubes : Qubesdb.qubesdb impl -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl
 val create_ipv4v6 : ?group:string -> ipv4 impl -> ipv6 impl -> ipv4v6 impl
 
 val keyed_ipv4v6 :

--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -12,7 +12,9 @@ val ip : 'a ip typ
 val ipv4 : ipv4 typ
 val ipv6 : ipv6 typ
 val ipv4v6 : ipv4v6 typ
-val create_ipv4 : ?group:string -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl
+
+val create_ipv4 :
+  ?group:string -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl
 
 val keyed_create_ipv4 :
   ?group:string ->
@@ -21,7 +23,8 @@ val keyed_create_ipv4 :
   Arp.arpv4 impl ->
   ipv4 impl
 
-val create_ipv6 : ?group:string -> Network.network impl -> Ethernet.ethernet impl -> ipv6 impl
+val create_ipv6 :
+  ?group:string -> Network.network impl -> Ethernet.ethernet impl -> ipv6 impl
 
 val keyed_create_ipv6 :
   ?group:string ->
@@ -30,8 +33,12 @@ val keyed_create_ipv6 :
   Ethernet.ethernet impl ->
   ipv6 impl
 
-val ipv4_of_dhcp : Network.network impl -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl
-val ipv4_qubes : Qubesdb.qubesdb impl -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl
+val ipv4_of_dhcp :
+  Network.network impl -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl
+
+val ipv4_qubes :
+  Qubesdb.qubesdb impl -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl
+
 val create_ipv4v6 : ?group:string -> ipv4 impl -> ipv6 impl -> ipv4v6 impl
 
 val keyed_ipv4v6 :

--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type v4
 type v6

--- a/lib/devices/key.ml
+++ b/lib/devices/key.ml
@@ -16,8 +16,6 @@
 
 module Action = Functoria.Action
 module Key = Functoria.Key
-open Astring
-open Cmdliner
 
 (** {2 Documentation helper} *)
 
@@ -71,8 +69,8 @@ let target =
       target_doc_alts
   in
   let doc =
-    Arg.info ~docs:mirage_section ~docv:"TARGET" ~doc [ "t"; "target" ]
-      ~env:(Cmd.Env.info "MODE")
+    Cmdliner.Arg.info ~docs:mirage_section ~docv:"TARGET" ~doc [ "t"; "target" ]
+      ~env:(Cmdliner.Cmd.Env.info "MODE")
   in
   let key = Key.Arg.opt target_conv default_target doc in
   Key.create "target" key
@@ -102,8 +100,8 @@ let is_unikraft =
 let configure_key ?(group = "") ~doc ~default conv name =
   let prefix = if group = "" then group else group ^ "-" in
   let doc =
-    Arg.info ~docs:unikernel_section
-      ~docv:(String.Ascii.uppercase name)
+    Cmdliner.Arg.info ~docs:unikernel_section
+      ~docv:(String.uppercase_ascii name)
       ~doc
       [ prefix ^ name ]
   in
@@ -127,7 +125,7 @@ let block ?group () =
   let enum =
     [ ("xenstore", `XenstoreId); ("file", `BlockFile); ("ramdisk", `Ramdisk) ]
   in
-  let conv = Arg.enum enum in
+  let conv = Cmdliner.Arg.enum enum in
   let doc =
     Fmt.str "Use %s pass-through implementation for %a."
       (Cmdliner.Arg.doc_alts_enum enum)
@@ -139,7 +137,7 @@ let block ?group () =
 
 let dhcp ?group () =
   let doc = Fmt.str "Enable dhcp for %a." pp_group group in
-  configure_key ~doc ?group ~default:false Arg.bool "dhcp"
+  configure_key ~doc ?group ~default:false Cmdliner.Arg.bool "dhcp"
 
 let net ?group () : [ `Host | `OCaml ] option Key.key =
   let enum =
@@ -153,6 +151,6 @@ let net ?group () : [ `Host | `OCaml ] option Key.key =
       (Cmdliner.Arg.doc_alts_enum enum)
       pp_group group
   in
-  configure_key ~doc ?group ~default:None (Arg.some conv) "net"
+  configure_key ~doc ?group ~default:None (Cmdliner.Arg.some conv) "net"
 
 include Key

--- a/lib/devices/libvirt.mli
+++ b/lib/devices/libvirt.mli
@@ -1,5 +1,3 @@
-open Functoria
-
 val filename : name:string -> Fpath.t
-val configure_main : name:string -> unit Action.t
-val configure_virtio : name:string -> unit Action.t
+val configure_main : name:string -> unit Functoria.Action.t
+val configure_virtio : name:string -> unit Functoria.Action.t

--- a/lib/devices/mimic.ml
+++ b/lib/devices/mimic.ml
@@ -1,8 +1,4 @@
 open Functoria.DSL
-open Dns
-open Stack
-open Happy_eyeballs
-open Misc
 
 type mimic = Mimic
 
@@ -13,7 +9,7 @@ let mimic_happy_eyeballs =
   let connect _ modname = function
     | [ _stackv4v6; happy_eyeballs; _dns_client ] ->
         code ~pos:__POS__ {ocaml|%s.connect %s|ocaml} modname happy_eyeballs
-    | _ -> connect_err "mimic" 3
+    | _ -> Misc.connect_err "mimic" 3
   in
   impl ~packages ~connect "Mimic_happy_eyeballs.Make"
-    (stackv4v6 @-> happy_eyeballs @-> dns_client @-> mimic)
+    (Stack.stackv4v6 @-> Happy_eyeballs.happy_eyeballs @-> Dns.dns_client @-> mimic)

--- a/lib/devices/mimic.ml
+++ b/lib/devices/mimic.ml
@@ -12,4 +12,7 @@ let mimic_happy_eyeballs =
     | _ -> Misc.connect_err "mimic" 3
   in
   impl ~packages ~connect "Mimic_happy_eyeballs.Make"
-    (Stack.stackv4v6 @-> Happy_eyeballs.happy_eyeballs @-> Dns.dns_client @-> mimic)
+    (Stack.stackv4v6
+    @-> Happy_eyeballs.happy_eyeballs
+    @-> Dns.dns_client
+    @-> mimic)

--- a/lib/devices/misc.mli
+++ b/lib/devices/misc.mli
@@ -1,6 +1,3 @@
-open Key
-open Functoria
-
-val get_target : Info.t -> mode
+val get_target : Functoria.Info.t -> Key.mode
 val connect_err : string -> int -> 'a
 val terminal : unit -> bool

--- a/lib/devices/mtime.mli
+++ b/lib/devices/mtime.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type mtime = job
 

--- a/lib/devices/network.ml
+++ b/lib/devices/network.ml
@@ -1,6 +1,5 @@
 open Functoria.DSL
 open Functoria.Action
-open Misc
 
 type network = NETWORK
 
@@ -25,7 +24,7 @@ let network_conf ?(intf : string runtime_arg option) name =
   let connect _ modname = function
     | [] -> code ~pos:__POS__ "%s.connect %S" modname name
     | [ intf ] -> code ~pos:__POS__ "%s.connect %s" modname intf
-    | _ -> connect_err "network_conf (sometimes 0 arguments)" 1
+    | _ -> Misc.connect_err "network_conf (sometimes 0 arguments)" 1
   in
   let configure _ =
     add_new_network name;

--- a/lib/devices/network.mli
+++ b/lib/devices/network.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type network
 

--- a/lib/devices/ptime.mli
+++ b/lib/devices/ptime.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type ptime = job
 

--- a/lib/devices/qubesdb.ml
+++ b/lib/devices/qubesdb.ml
@@ -1,6 +1,5 @@
 open Functoria.DSL
 open Functoria.Action
-open Misc
 
 type qubesdb = QUBES_DB
 
@@ -10,7 +9,7 @@ let pkg = package ~min:"2.0.0" ~max:"3.0.0" "mirage-qubes"
 let default_qubesdb =
   let packages = [ pkg ] in
   let configure i =
-    match get_target i with
+    match Misc.get_target i with
     | `Qubes | `Xen -> ok ()
     | _ ->
         error

--- a/lib/devices/qubesdb.mli
+++ b/lib/devices/qubesdb.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type qubesdb
 

--- a/lib/devices/random.mli
+++ b/lib/devices/random.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type random = job
 

--- a/lib/devices/reporter.ml
+++ b/lib/devices/reporter.ml
@@ -1,5 +1,4 @@
 open Functoria.DSL
-open Misc
 
 type reporter = job
 
@@ -22,7 +21,7 @@ let default_reporter ?(level = Some Logs.Info) () =
           "@[<v 2>let reporter = %s.create () in@ Mirage_runtime.set_level \
            ~default:%a %s;@ Logs.set_reporter reporter;@ Lwt.return reporter@]"
           modname pp_level level logs
-    | _ -> connect_err "log" 1
+    | _ -> Misc.connect_err "log" 1
   in
   impl ~packages ~runtime_args ~connect "Mirage_logs" reporter
 

--- a/lib/devices/reporter.mli
+++ b/lib/devices/reporter.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type reporter = job
 

--- a/lib/devices/resolver.ml
+++ b/lib/devices/resolver.ml
@@ -1,7 +1,5 @@
 open Functoria.DSL
 open Functoria.Action
-open Misc
-open Stack
 
 type resolver = Resolver
 
@@ -14,7 +12,7 @@ let resolver_unix_system =
       []
   in
   let configure i =
-    match get_target i with
+    match Misc.get_target i with
     | `Unix | `MacOSX -> ok ()
     | _ -> error "Unix resolver not supported on non-UNIX targets."
   in
@@ -34,10 +32,10 @@ let resolver_dns_conf ~ns =
            | Ok r -> r@;\
            | Error (`Msg e) -> invalid_arg e@;"
           ns modname stack
-    | _ -> connect_err "resolver" 2
+    | _ -> Misc.connect_err "resolver" 2
   in
   impl ~packages ~runtime_args ~connect "Resolver_mirage.Make"
-    (stackv4v6 @-> resolver)
+    (Stack.stackv4v6 @-> resolver)
 
 let resolver_dns ?ns stack =
   let ns = Runtime_arg.resolver ?default:ns () in

--- a/lib/devices/resolver.mli
+++ b/lib/devices/resolver.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type resolver
 

--- a/lib/devices/runtime_arg.ml
+++ b/lib/devices/runtime_arg.ml
@@ -15,18 +15,18 @@
  *)
 
 open Functoria.DSL
-module Runtime_arg = Functoria.Runtime_arg
+include Functoria.Runtime_arg
 
 (** {2 OCaml runtime} *)
 
 let runtime_arg ~pos name =
-  Runtime_arg.create ~pos
+  create ~pos
     ~packages:[ package "mirage-runtime" ]
     (Fmt.str "Mirage_runtime.%s" name)
 
 let runtime_network_key ~pos fmt =
   Fmt.kstr
-    (Runtime_arg.create ~pos
+    (create ~pos
        ~packages:[ package "mirage-runtime" ~sublibs:[ "network" ] ])
     ("Mirage_runtime_network." ^^ fmt)
 

--- a/lib/devices/runtime_arg.ml
+++ b/lib/devices/runtime_arg.ml
@@ -26,8 +26,7 @@ let runtime_arg ~pos name =
 
 let runtime_network_key ~pos fmt =
   Fmt.kstr
-    (create ~pos
-       ~packages:[ package "mirage-runtime" ~sublibs:[ "network" ] ])
+    (create ~pos ~packages:[ package "mirage-runtime" ~sublibs:[ "network" ] ])
     ("Mirage_runtime_network." ^^ fmt)
 
 let delay = runtime_arg ~pos:__POS__ "delay"

--- a/lib/devices/runtime_arg.ml
+++ b/lib/devices/runtime_arg.ml
@@ -14,8 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Functoria
-include Runtime_arg
+open Functoria.DSL
+module Runtime_arg = Functoria.Runtime_arg
 
 (** {2 OCaml runtime} *)
 

--- a/lib/devices/sleep.mli
+++ b/lib/devices/sleep.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type sleep = job
 

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -1,16 +1,8 @@
 open Functoria.DSL
-open Arp
-open Ethernet
-open Ip
-open Misc
-open Network
-open Qubesdb
-open Tcp
-open Udp
 
-let dhcp_ipv4 tap e a = ipv4_of_dhcp tap e a
-let static_ipv4 ?group ~no_init e a = keyed_create_ipv4 ?group ~no_init e a
-let qubes_ipv4 ?(qubesdb = default_qubesdb) e a = ipv4_qubes qubesdb e a
+let dhcp_ipv4 tap e a = Ip.ipv4_of_dhcp tap e a
+let static_ipv4 ?group ~no_init e a = Ip.keyed_create_ipv4 ?group ~no_init e a
+let qubes_ipv4 ?(qubesdb = Qubesdb.default_qubesdb) e a = Ip.ipv4_qubes qubesdb e a
 
 (** dual stack *)
 
@@ -19,59 +11,59 @@ type stackv4v6 = STACKV4V6
 let stackv4v6 = typ STACKV4V6
 
 let stackv4v6_direct_conf () =
-  let packages_v = right_tcpip_library ~sublibs:[ "stack-direct" ] "tcpip" in
+  let packages_v = Ip.right_tcpip_library ~sublibs:[ "stack-direct" ] "tcpip" in
   let connect _i modname = function
     | [ interface; ethif; arp; ipv4v6; icmpv4; udp; tcp ] ->
         code ~pos:__POS__ "%s.connect %s %s %s %s %s %s %s" modname interface
           ethif arp ipv4v6 icmpv4 udp tcp
-    | _ -> connect_err "direct stack" 7
+    | _ -> Misc.connect_err "direct stack" 7
   in
   impl ~packages_v ~connect "Tcpip_stack_direct.MakeV4V6"
-    (network
-    @-> ethernet
-    @-> arpv4
-    @-> ipv4v6
+    (Network.network
+    @-> Ethernet.ethernet
+    @-> Arp.arpv4
+    @-> Ip.ipv4v6
     @-> Icmp.icmpv4
-    @-> udp
-    @-> tcp
+    @-> Udp.udp
+    @-> Tcp.tcp
     @-> stackv4v6)
 
 let direct_stackv4v6 ?group ?tcp network eth arp ipv4 ipv6 =
   let ipv4_only = Runtime_arg.ipv4_only ?group ()
   and ipv6_only = Runtime_arg.ipv6_only ?group () in
-  let ip = keyed_ipv4v6 ~ipv4_only ~ipv6_only ipv4 ipv6 in
+  let ip = Ip.keyed_ipv4v6 ~ipv4_only ~ipv6_only ipv4 ipv6 in
   stackv4v6_direct_conf ()
   $ network
   $ eth
   $ arp
   $ ip
   $ Icmp.direct_icmpv4 ipv4
-  $ direct_udp ip
-  $ match tcp with None -> direct_tcp ip | Some tcp -> tcp
+  $ Udp.direct_udp ip
+  $ match tcp with None -> Tcp.direct_tcp ip | Some tcp -> tcp
 
 let keyed_direct_stackv4v6 ?tcp ~ipv4_only ~ipv6_only network eth arp ipv4 ipv6
     =
-  let ip = keyed_ipv4v6 ~ipv4_only ~ipv6_only ipv4 ipv6 in
+  let ip = Ip.keyed_ipv4v6 ~ipv4_only ~ipv6_only ipv4 ipv6 in
   stackv4v6_direct_conf ()
   $ network
   $ eth
   $ arp
   $ ip
   $ Icmp.direct_icmpv4 ipv4
-  $ direct_udp ip
-  $ match tcp with None -> direct_tcp ip | Some tcp -> tcp
+  $ Udp.direct_udp ip
+  $ match tcp with None -> Tcp.direct_tcp ip | Some tcp -> tcp
 
-let generic_ipv4v6_stack p ?group ?(arp = arp) ?tcp tap =
+let generic_ipv4v6_stack p ?group ?(arp = Arp.arp) ?tcp tap =
   let ipv4_only = Runtime_arg.ipv4_only ?group ()
   and ipv6_only = Runtime_arg.ipv6_only ?group () in
-  let e = ethif tap in
+  let e = Ethernet.ethif tap in
   let a = arp e in
   let i4 =
     match_impl p
       [ (`Qubes, qubes_ipv4 e a); (`Dhcp, dhcp_ipv4 tap e a) ]
       ~default:(static_ipv4 ?group ~no_init:ipv6_only e a)
   in
-  let i6 = keyed_create_ipv6 ?group ~no_init:ipv4_only tap e in
+  let i6 = Ip.keyed_create_ipv6 ?group ~no_init:ipv4_only tap e in
   keyed_direct_stackv4v6 ~ipv4_only ~ipv6_only ?tcp tap e a i4 i6
 
 let socket_stackv4v6 ?(group = "") () =
@@ -79,22 +71,22 @@ let socket_stackv4v6 ?(group = "") () =
   let v6key = Runtime_arg.V6.network ~group None in
   let ipv4_only = Runtime_arg.ipv4_only ~group () in
   let ipv6_only = Runtime_arg.ipv6_only ~group () in
-  let packages_v = right_tcpip_library ~sublibs:[ "stack-socket" ] "tcpip" in
+  let packages_v = Ip.right_tcpip_library ~sublibs:[ "stack-socket" ] "tcpip" in
   let extra_deps =
     [
-      dep (udpv4v6_socket_conf ~ipv4_only ~ipv6_only v4key v6key);
-      dep (tcpv4v6_socket_conf ~ipv4_only ~ipv6_only v4key v6key);
+      dep (Udp.udpv4v6_socket_conf ~ipv4_only ~ipv6_only v4key v6key);
+      dep (Tcp.tcpv4v6_socket_conf ~ipv4_only ~ipv6_only v4key v6key);
     ]
   in
   let connect _i modname = function
     | [ udp; tcp ] -> code ~pos:__POS__ "%s.connect %s %s" modname udp tcp
-    | _ -> connect_err "socket_stackv4v6" 2
+    | _ -> Misc.connect_err "socket_stackv4v6" 2
   in
   impl ~packages_v ~extra_deps ~connect "Tcpip_stack_socket.V4V6" stackv4v6
 
 (** Generic stack *)
 let generic_stackv4v6 ?group ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
-    ?(net_key = Key.value @@ Key.net ?group ()) ?tcp (tap : network impl) :
+    ?(net_key = Key.value @@ Key.net ?group ()) ?tcp (tap : Network.network impl) :
     stackv4v6 impl =
   let choose target net dhcp =
     match (target, net, dhcp) with

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -2,7 +2,9 @@ open Functoria.DSL
 
 let dhcp_ipv4 tap e a = Ip.ipv4_of_dhcp tap e a
 let static_ipv4 ?group ~no_init e a = Ip.keyed_create_ipv4 ?group ~no_init e a
-let qubes_ipv4 ?(qubesdb = Qubesdb.default_qubesdb) e a = Ip.ipv4_qubes qubesdb e a
+
+let qubes_ipv4 ?(qubesdb = Qubesdb.default_qubesdb) e a =
+  Ip.ipv4_qubes qubesdb e a
 
 (** dual stack *)
 
@@ -86,8 +88,8 @@ let socket_stackv4v6 ?(group = "") () =
 
 (** Generic stack *)
 let generic_stackv4v6 ?group ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
-    ?(net_key = Key.value @@ Key.net ?group ()) ?tcp (tap : Network.network impl) :
-    stackv4v6 impl =
+    ?(net_key = Key.value @@ Key.net ?group ()) ?tcp
+    (tap : Network.network impl) : stackv4v6 impl =
   let choose target net dhcp =
     match (target, net, dhcp) with
     | `Qubes, _, _ -> `Qubes

--- a/lib/devices/stack.mli
+++ b/lib/devices/stack.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type stackv4v6
 

--- a/lib/devices/syslog.ml
+++ b/lib/devices/syslog.ml
@@ -1,6 +1,4 @@
 open Functoria.DSL
-open Misc
-open Stack
 
 type syslog = SYSLOG
 
@@ -22,10 +20,10 @@ let syslog_udp_conf ?group () =
            ~hostname:(Mirage_runtime.name ()) ~port:%s server ?truncate:%s ()@ \
            in@ Logs.set_reporter reporter;@ Lwt.return_unit@]"
           endpoint modname stack port truncate
-    | _ -> connect_err "syslog_udp" 5
+    | _ -> Misc.connect_err "syslog_udp" 5
   in
   impl ~packages ~runtime_args ~connect "Logs_syslog_mirage.Udp"
-    (stackv4v6 @-> syslog)
+    (Stack.stackv4v6 @-> syslog)
 
 let syslog_udp ?group stack = syslog_udp_conf ?group () $ stack
 
@@ -45,10 +43,10 @@ let syslog_tcp_conf ?group () =
            Logs.set_reporter reporter; Lwt.return_unit@ | Error e -> \
            invalid_arg e@]"
           endpoint modname stack port truncate
-    | _ -> connect_err "syslog_tcp" 5
+    | _ -> Misc.connect_err "syslog_tcp" 5
   in
   impl ~packages ~runtime_args ~connect "Logs_syslog_mirage.Tcp"
-    (stackv4v6 @-> syslog)
+    (Stack.stackv4v6 @-> syslog)
 
 let syslog_tcp ?group stack = syslog_tcp_conf ?group () $ stack
 
@@ -71,10 +69,10 @@ let syslog_tls_conf ?group () =
            reporter -> Logs.set_reporter reporter; Lwt.return_unit@ | Error e \
            -> invalid_arg e@]"
           endpoint modname stack kv port truncate keyname
-    | _ -> connect_err "syslog_tls" 8
+    | _ -> Misc.connect_err "syslog_tls" 8
   in
   impl ~packages ~runtime_args ~connect "Logs_syslog_mirage_tls.Tls"
-    (stackv4v6 @-> Kv.ro @-> syslog)
+    (Stack.stackv4v6 @-> Kv.ro @-> syslog)
 
 let syslog_tls ?group stack kv = syslog_tls_conf ?group () $ stack $ kv
 
@@ -92,6 +90,6 @@ let monitoring_conf ?group () =
     | _ -> assert false
   in
   impl ~packages ~runtime_args ~connect "Mirage_monitoring.Make"
-    (stackv4v6 @-> Functoria.job)
+    (Stack.stackv4v6 @-> Functoria.job)
 
 let monitoring ?group stack = monitoring_conf ?group () $ stack

--- a/lib/devices/syslog.mli
+++ b/lib/devices/syslog.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type syslog
 

--- a/lib/devices/tcp.ml
+++ b/lib/devices/tcp.ml
@@ -21,7 +21,9 @@ let direct_tcp ip = tcp_direct_func () $ ip
 let tcpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
   let v = Runtime_arg.v in
   let runtime_args = [ v ipv4_only; v ipv6_only; v ipv4_key; v ipv6_key ] in
-  let packages_v = Ip.right_tcpip_library ~sublibs:[ "tcpv4v6-socket" ] "tcpip" in
+  let packages_v =
+    Ip.right_tcpip_library ~sublibs:[ "tcpv4v6-socket" ] "tcpip"
+  in
   let configure i =
     match Misc.get_target i with
     | `Unix | `MacOSX -> ok ()

--- a/lib/devices/tcp.ml
+++ b/lib/devices/tcp.ml
@@ -1,31 +1,29 @@
 open Functoria.DSL
-open Ip
-open Misc
 open Functoria.Action
 
 type 'a tcp = TCP
-type tcpv4v6 = v4v6 tcp
+type tcpv4v6 = Ip.v4v6 tcp
 
 let tcp = Functoria.Type.Type TCP
 let tcpv4v6 : tcpv4v6 typ = tcp
 
 (* this needs to be a function due to the value restriction. *)
 let tcp_direct_func () =
-  let packages_v = right_tcpip_library ~sublibs:[ "tcp" ] "tcpip" in
+  let packages_v = Ip.right_tcpip_library ~sublibs:[ "tcp" ] "tcpip" in
   let connect _ modname = function
     | [ ip ] -> code ~pos:__POS__ "%s.connect %s" modname ip
-    | _ -> connect_err "tcp" 1
+    | _ -> Misc.connect_err "tcp" 1
   in
-  impl ~packages_v ~connect "Tcp.Flow.Make" (ip @-> tcp)
+  impl ~packages_v ~connect "Tcp.Flow.Make" (Ip.ip @-> tcp)
 
 let direct_tcp ip = tcp_direct_func () $ ip
 
 let tcpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
   let v = Runtime_arg.v in
   let runtime_args = [ v ipv4_only; v ipv6_only; v ipv4_key; v ipv6_key ] in
-  let packages_v = right_tcpip_library ~sublibs:[ "tcpv4v6-socket" ] "tcpip" in
+  let packages_v = Ip.right_tcpip_library ~sublibs:[ "tcpv4v6-socket" ] "tcpip" in
   let configure i =
-    match get_target i with
+    match Misc.get_target i with
     | `Unix | `MacOSX -> ok ()
     | _ -> error "TCPv4v6 socket not supported on non-UNIX targets."
   in
@@ -33,6 +31,6 @@ let tcpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
     | [ ipv4_only; ipv6_only; ipv4_key; ipv6_key ] ->
         code ~pos:__POS__ "%s.connect ~ipv4_only:%s ~ipv6_only:%s %s %s" modname
           ipv4_only ipv6_only ipv4_key ipv6_key
-    | _ -> connect_err "tcpv4v6_socket_conf" 4
+    | _ -> Misc.connect_err "tcpv4v6_socket_conf" 4
   in
   impl ~packages_v ~configure ~runtime_args ~connect "Tcpv4v6_socket" tcpv4v6

--- a/lib/devices/tcp.mli
+++ b/lib/devices/tcp.mli
@@ -1,4 +1,4 @@
-open Functoria
+open Functoria.DSL
 
 type 'a tcp
 

--- a/lib/devices/udp.ml
+++ b/lib/devices/udp.ml
@@ -1,31 +1,29 @@
 module Action = Functoria.Action
 open Functoria.DSL
-open Ip
-open Misc
 
 type 'a udp = UDP
-type udpv4v6 = v4v6 udp
+type udpv4v6 = Ip.v4v6 udp
 
 let udp = Functoria.Type.Type UDP
 let udpv4v6 : udpv4v6 typ = udp
 
 (* Value restriction ... *)
 let udp_direct_func () =
-  let packages_v = right_tcpip_library ~sublibs:[ "udp" ] "tcpip" in
+  let packages_v = Ip.right_tcpip_library ~sublibs:[ "udp" ] "tcpip" in
   let connect _ modname = function
     | [ ip ] -> code ~pos:__POS__ "%s.connect %s" modname ip
-    | _ -> connect_err "udp" 1
+    | _ -> Misc.connect_err "udp" 1
   in
-  impl ~packages_v ~connect "Udp.Make" (ip @-> udp)
+  impl ~packages_v ~connect "Udp.Make" (Ip.ip @-> udp)
 
 let direct_udp ip = udp_direct_func () $ ip
 
 let udpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
   let v = Runtime_arg.v in
   let runtime_args = [ v ipv4_only; v ipv6_only; v ipv4_key; v ipv6_key ] in
-  let packages_v = right_tcpip_library ~sublibs:[ "udpv4v6-socket" ] "tcpip" in
+  let packages_v = Ip.right_tcpip_library ~sublibs:[ "udpv4v6-socket" ] "tcpip" in
   let configure i =
-    match get_target i with
+    match Misc.get_target i with
     | `Unix | `MacOSX -> Action.ok ()
     | _ -> Action.error "UDPv4v6 socket not supported on non-UNIX targets."
   in
@@ -33,6 +31,6 @@ let udpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
     | [ ipv4_only; ipv6_only; ipv4_key; ipv6_key ] ->
         code ~pos:__POS__ "%s.connect ~ipv4_only:%s ~ipv6_only:%s %s %s" modname
           ipv4_only ipv6_only ipv4_key ipv6_key
-    | _ -> connect_err "udpv4v6_socket_conf" 4
+    | _ -> Misc.connect_err "udpv4v6_socket_conf" 4
   in
   impl ~runtime_args ~packages_v ~configure ~connect "Udpv4v6_socket" udpv4v6

--- a/lib/devices/udp.ml
+++ b/lib/devices/udp.ml
@@ -21,7 +21,9 @@ let direct_udp ip = udp_direct_func () $ ip
 let udpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
   let v = Runtime_arg.v in
   let runtime_args = [ v ipv4_only; v ipv6_only; v ipv4_key; v ipv6_key ] in
-  let packages_v = Ip.right_tcpip_library ~sublibs:[ "udpv4v6-socket" ] "tcpip" in
+  let packages_v =
+    Ip.right_tcpip_library ~sublibs:[ "udpv4v6-socket" ] "tcpip"
+  in
   let configure i =
     match Misc.get_target i with
     | `Unix | `MacOSX -> Action.ok ()

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -16,7 +16,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Functoria.DSL
 open Devices
 module Type = Functoria.Type
 module Impl = Functoria.Impl

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -16,13 +16,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Functoria
+open Functoria.DSL
 open Devices
-module Type = Type
+module Type = Functoria.Type
 module Impl = Functoria.Impl
-module Info = Info
-module Dune = Dune
-module Context = Context
+module Info = Functoria.Info
+module Dune = Functoria.Dune
+module Context = Functoria.Context
 module Key = Devices.Key
 module Runtime_arg = Devices.Runtime_arg
 include Functoria.DSL
@@ -258,7 +258,7 @@ let git_ssh ?group ?authenticator ?key ?password tcpv4v6 ctx =
 let git_http ?group ?authenticator ?headers tcpv4v6 ctx =
   Git.git_http ?group ?authenticator ?headers () $ tcpv4v6 $ ctx
 
-let delay = job
+let delay = Functoria.job
 
 let delay_startup =
   let delay_key = Runtime_arg.delay in
@@ -271,7 +271,7 @@ let delay_startup =
   in
   impl ~packages ~runtime_args ~connect "Mirage_runtime" delay
 
-let unikernel_name = job
+let unikernel_name = Functoria.job
 
 let unikernel_name =
   let connect i _ _ =
@@ -365,8 +365,8 @@ let run t = %s.Main.run t ; exit 0|ocaml}
       ~install "Mirage_runtime" job
 end
 
-include Lib.Make (Project)
-module Tool = Tool.Make (Project)
+include Functoria.Lib.Make (Project)
+module Tool = Functoria.Tool.Make (Project)
 
 (** Custom registration *)
 

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -29,17 +29,17 @@ Configure the project for Unix:
   0
   
   let mirage_runtime_delay__key = Mirage_runtime.register_arg @@
-  # 33 "lib/devices/runtime_arg.ml"
+  # 32 "lib/devices/runtime_arg.ml"
     Mirage_runtime.delay
   ;;
   
   let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
-  # 200 "lib/devices/runtime_arg.ml"
+  # 199 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 382 "lib/mirage.ml"
+  # 381 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -69,14 +69,14 @@ Configure the project for Unix:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 269 "lib/mirage.ml"
+  # 268 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
   
   let mirage_logs__5 = lazy (
     let _mirage_runtime_logs = (mirage_runtime_logs__key ()) in
-  # 21 "lib/devices/reporter.ml"
+  # 20 "lib/devices/reporter.ml"
     let reporter = Mirage_logs.create () in
     Mirage_runtime.set_level ~default:(Some Logs.Info) _mirage_runtime_logs;
     Logs.set_reporter reporter;
@@ -106,7 +106,7 @@ Configure the project for Unix:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 278 "lib/mirage.ml"
+  # 277 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -145,7 +145,7 @@ Configure the project for Unix:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 363 "lib/mirage.ml"
+  # 362 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"
@@ -203,17 +203,17 @@ Configure the project for Xen:
   0
   
   let mirage_runtime_delay__key = Mirage_runtime.register_arg @@
-  # 33 "lib/devices/runtime_arg.ml"
+  # 32 "lib/devices/runtime_arg.ml"
     Mirage_runtime.delay
   ;;
   
   let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
-  # 200 "lib/devices/runtime_arg.ml"
+  # 199 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 382 "lib/mirage.ml"
+  # 381 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -243,14 +243,14 @@ Configure the project for Xen:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 269 "lib/mirage.ml"
+  # 268 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
   
   let mirage_logs__5 = lazy (
     let _mirage_runtime_logs = (mirage_runtime_logs__key ()) in
-  # 21 "lib/devices/reporter.ml"
+  # 20 "lib/devices/reporter.ml"
     let reporter = Mirage_logs.create () in
     Mirage_runtime.set_level ~default:(Some Logs.Info) _mirage_runtime_logs;
     Logs.set_reporter reporter;
@@ -280,7 +280,7 @@ Configure the project for Xen:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 278 "lib/mirage.ml"
+  # 277 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -319,7 +319,7 @@ Configure the project for Xen:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 363 "lib/mirage.ml"
+  # 362 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"


### PR DESCRIPTION
This PR removes a bunch of `open _` top level phrases in `lib/devices/`. The motivation is that these `open _` top level phrases makes it more challenging to find the definition of symbols - especially if you are unfamiliar with the code base. The refactoring was guided by Merlin in Vim via `:MerlinRefactorOpenQualify`.

I mostly kept the `open _` top level phrases that refer to functoria modules. The exception being in one case where `open Functoria` shadowed another `Key` module. I also dropped `Astring` in one module as we did not use any functions that aren't in the stdlib's `String` module.

I may look into defining `Syntax` sub-modules in functoria so we reduce what we bring into scope all over the place.