### PR TITLE
upgrade to cmdliner 2.0

### DIFF
--- a/lib/devices/key.ml
+++ b/lib/devices/key.ml
@@ -49,10 +49,10 @@ let (target_conv : mode Cmdliner.Arg.conv), target_doc_alts =
       ("unikraft-qemu", `QEMU);
     ]
   in
-  let parser, printer = Cmdliner.Arg.enum enum in
-  ((parser, printer), Cmdliner.Arg.doc_alts_enum enum)
+  let conv = Cmdliner.Arg.enum enum in
+  (conv, Cmdliner.Arg.doc_alts_enum enum)
 
-let pp_target fmt m = snd target_conv fmt m
+let pp_target fmt m = Cmdliner.Arg.conv_printer target_conv fmt m
 
 let default_target =
   match Sys.getenv "MIRAGE_DEFAULT_TARGET" with

--- a/lib/functoria/cli.ml
+++ b/lib/functoria/cli.ml
@@ -408,15 +408,16 @@ module Subcommands = struct
       match topic with
       | None -> `Help (man_format, None)
       | Some topic -> (
-          let parser, _ =
-            Arg.enum (List.rev_map (fun s -> (s, s)) ("topics" :: cmds))
+          let parser =
+            Arg.conv_parser
+              (Arg.enum (List.rev_map (fun s -> (s, s)) ("topics" :: cmds)))
           in
           match parser topic with
-          | `Error e -> `Error (false, e)
-          | `Ok t when t = "topics" ->
+          | Error `Msg e -> `Error (false, e)
+          | Ok t when t = "topics" ->
               List.iter print_endline cmds;
               `Ok ()
-          | `Ok t -> `Help (man_format, Some t))
+          | Ok t -> `Help (man_format, Some t))
     in
     ( Term.(
         const (fun args _ _ _ () -> Help args)

--- a/lib/functoria/cli.ml
+++ b/lib/functoria/cli.ml
@@ -413,7 +413,7 @@ module Subcommands = struct
               (Arg.enum (List.rev_map (fun s -> (s, s)) ("topics" :: cmds)))
           in
           match parser topic with
-          | Error `Msg e -> `Error (false, e)
+          | Error (`Msg e) -> `Error (false, e)
           | Ok t when t = "topics" ->
               List.iter print_endline cmds;
               `Ok ()

--- a/lib/functoria/cli.mli
+++ b/lib/functoria/cli.mli
@@ -109,7 +109,7 @@ val pp_action : 'a Fmt.t -> 'a action Fmt.t
 val args : 'a action -> 'a args
 (** [args a] are [a]'s global arguments. *)
 
-(** {1 Evalutation} *)
+(** {1 Evaluation} *)
 
 val eval :
   ?with_setup:bool ->

--- a/lib/functoria/cli.mli
+++ b/lib/functoria/cli.mli
@@ -124,7 +124,7 @@ val eval :
   help:'a Term.t ->
   mname:string ->
   string array ->
-  'a action Term.result
+  [ `Ok of 'a action | `Error of [`Parse | `Term | `Exn ] | `Version | `Help ]
 (** Parse the functoria command line. The arguments to [~configure],
     [~describe], etc., describe extra command-line arguments that should be
     accepted by the corresponding subcommands.

--- a/lib/functoria/cli.mli
+++ b/lib/functoria/cli.mli
@@ -124,7 +124,7 @@ val eval :
   help:'a Term.t ->
   mname:string ->
   string array ->
-  [ `Ok of 'a action | `Error of [`Parse | `Term | `Exn ] | `Version | `Help ]
+  [ `Ok of 'a action | `Error of [ `Parse | `Term | `Exn ] | `Version | `Help ]
 (** Parse the functoria command line. The arguments to [~configure],
     [~describe], etc., describe extra command-line arguments that should be
     accepted by the corresponding subcommands.

--- a/lib/functoria/key.ml
+++ b/lib/functoria/key.ml
@@ -29,7 +29,7 @@ module Arg = struct
     | Required : 'a Arg.conv -> 'a option kind
     | Flag : bool kind
 
-  let pp_conv c = snd c
+  let pp_conv c = Arg.conv_printer c
 
   let pp_kind : type a. a kind -> a Fmt.t = function
     | Opt (_, c) -> pp_conv c
@@ -39,7 +39,7 @@ module Arg = struct
 
   let compare_kind : type a b. a kind -> b kind -> int =
    fun a b ->
-    let default cx x = Fmt.to_to_string (snd cx) x in
+    let default cx x = Fmt.to_to_string (Arg.conv_printer cx) x in
     match (a, b) with
     | Opt (x, cx), Opt (y, cy) -> String.compare (default cx x) (default cy y)
     | Required _, Required _ -> 0

--- a/lib/functoria/key.mli
+++ b/lib/functoria/key.mli
@@ -55,6 +55,7 @@ module Arg : sig
     ?deprecated:string ->
     ?absent:string ->
     ?docs:string ->
+    ?doc_envs:Cmd.Env.info list ->
     ?docv:string ->
     ?doc:string ->
     ?env:Cmd.Env.info ->

--- a/lib/functoria/tool.ml
+++ b/lib/functoria/tool.ml
@@ -138,7 +138,7 @@ module Make (P : S) = struct
         let file = context_file t in
         let+ is_file = Action.is_file file in
         if is_file then
-          Array.append argv [| "--context"; Fpath.to_string file |]
+          Array.append argv [| "--context-file"; Fpath.to_string file |]
         else (* should only happen when doing configure --help *) argv
 
   let run_cmd ?ppf ?err_ppf command =

--- a/mirage.opam
+++ b/mirage.opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "astring"
   "cmdliner" {>= "1.2.0"}
-  "cmdliner" {with-test & >= "1.3.0"}
+  "cmdliner" {with-test & >= "2.0.0"}
   "emile" {>= "1.1"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.0.0"}

--- a/test/functoria/e2e/configure.t
+++ b/test/functoria/e2e/configure.t
@@ -83,8 +83,7 @@ Check that `test help configure` works when no config.ml file is present.
 
 Check that errors are reported correcty:
 
-  $ ./test.exe configure a b c --file=app/config.ml
+  $ ./test.exe configure a b c --file=app/config.ml | tr -d \'
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   Usage: test configure [--help] [OPTION]…
-  test: too many arguments, don't know what to do with 'a', 'b', 'c'
-  [1]
+  test: too many arguments, don't know what to do with a, b, c

--- a/test/functoria/e2e/configure.t
+++ b/test/functoria/e2e/configure.t
@@ -85,7 +85,6 @@ Check that errors are reported correcty:
 
   $ ./test.exe configure a b c --file=app/config.ml
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
-  test: too many arguments, don't know what to do with 'a', 'b', 'c'
-  Usage: test configure [OPTION]…
-  Try 'test configure --help' or 'test --help' for more information.
+  Usage: test configure [--help] [OPTION]…
+  test: too many arguments, don't know what to do with a, b, c
   [1]

--- a/test/functoria/e2e/configure.t
+++ b/test/functoria/e2e/configure.t
@@ -86,5 +86,5 @@ Check that errors are reported correcty:
   $ ./test.exe configure a b c --file=app/config.ml
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   Usage: test configure [--help] [OPTION]…
-  test: too many arguments, don't know what to do with a, b, c
+  test: too many arguments, don't know what to do with 'a', 'b', 'c'
   [1]

--- a/test/functoria/e2e/configure.t
+++ b/test/functoria/e2e/configure.t
@@ -83,7 +83,7 @@ Check that `test help configure` works when no config.ml file is present.
 
 Check that errors are reported correcty:
 
-  $ ./test.exe configure a b c --file=app/config.ml | tr -d \'
+  $ ./test.exe configure a b c --file=app/config.ml 2>&1 | tr -d \'
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   Usage: test configure [--help] [OPTION]…
-  test: too many arguments, don't know what to do with a, b, c
+  test: too many arguments, dont know what to do with a, b, c

--- a/test/functoria/e2e/context.t
+++ b/test/functoria/e2e/context.t
@@ -51,7 +51,7 @@ Describe - y target  - x.context
              warn_error=false (default)
 
 Bad context cache
-  $ ./test.exe configure -t nonexistent --context-file=context/z.context -f context/config.ml | tr -d \'
+  $ ./test.exe configure -t nonexistent --context-file=context/z.context -f context/config.ml 2>&1 | tr -d \'
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   Usage: test configure [--help] [-t ENUM] [OPTION]…
   test: option -t: invalid value nonexistent, expected either y or x

--- a/test/functoria/e2e/context.t
+++ b/test/functoria/e2e/context.t
@@ -1,23 +1,23 @@
 Query package - no target - x.context
-  $ ./test.exe query package --context-file=context/x.context -f context/config.ml
+  $ ./test.exe query packages --context-file=context/x.context -f context/config.ml
   "fmt" { ?monorepo }
   "mirage-runtime" { ?monorepo }
   "x" { ?monorepo }
 
 Query package - no target - y.context
-  $ ./test.exe query package --context-file=context/y.context -f context/config.ml
+  $ ./test.exe query packages --context-file=context/y.context -f context/config.ml
   "fmt" { ?monorepo }
   "mirage-runtime" { ?monorepo }
   "y" { ?monorepo }
 
 Query package - x target  - y.context
-  $ ./test.exe query package -t x --context-file=context/y.context -f context/config.ml
+  $ ./test.exe query packages -t x --context-file=context/y.context -f context/config.ml
   "fmt" { ?monorepo }
   "mirage-runtime" { ?monorepo }
   "x" { ?monorepo }
 
 Query package - y target  - x.context
-  $ ./test.exe query package -t y --context-file=context/x.context -f context/config.ml
+  $ ./test.exe query packages -t y --context-file=context/x.context -f context/config.ml
   "fmt" { ?monorepo }
   "mirage-runtime" { ?monorepo }
   "y" { ?monorepo }
@@ -53,7 +53,6 @@ Describe - y target  - x.context
 Bad context cache
   $ ./test.exe configure -t nonexistent --context-file=context/z.context -f context/config.ml
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
-  test: option '-t': invalid value 'nonexistent', expected either 'y' or 'x'
-  Usage: test configure [-t VAL] [OPTION]…
-  Try 'test configure --help' or 'test --help' for more information.
+  Usage: test configure [--help] [-t ENUM] [OPTION]…
+  test: option -t: invalid value nonexistent, expected either y or x
   [1]

--- a/test/functoria/e2e/context.t
+++ b/test/functoria/e2e/context.t
@@ -51,8 +51,7 @@ Describe - y target  - x.context
              warn_error=false (default)
 
 Bad context cache
-  $ ./test.exe configure -t nonexistent --context-file=context/z.context -f context/config.ml
+  $ ./test.exe configure -t nonexistent --context-file=context/z.context -f context/config.ml | tr -d \'
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   Usage: test configure [--help] [-t ENUM] [OPTION]…
-  test: option '-t': invalid value 'nonexistent', expected either 'y' or 'x'
-  [1]
+  test: option -t: invalid value nonexistent, expected either y or x

--- a/test/functoria/e2e/context.t
+++ b/test/functoria/e2e/context.t
@@ -54,5 +54,5 @@ Bad context cache
   $ ./test.exe configure -t nonexistent --context-file=context/z.context -f context/config.ml
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
   Usage: test configure [--help] [-t ENUM] [OPTION]…
-  test: option -t: invalid value nonexistent, expected either y or x
+  test: option '-t': invalid value 'nonexistent', expected either 'y' or 'x'
   [1]

--- a/test/functoria/e2e/context/config.ml
+++ b/test/functoria/e2e/context/config.ml
@@ -6,8 +6,7 @@ let x = Impl.v ~packages:[ package "x" ] "X" job
 let y = Impl.v ~packages:[ package "y" ] "Y" job
 
 let target_conv : [ `X | `Y ] Cmdliner.Arg.conv =
-  let parser, printer = Cmdliner.Arg.enum [ ("y", `Y); ("x", `X) ] in
-  (parser, printer)
+  Cmdliner.Arg.enum [ ("y", `Y); ("x", `X) ]
 
 let target =
   let doc = Arg.info ~doc:"Target." [ "t" ] in

--- a/test/functoria/e2e/run.t
+++ b/test/functoria/e2e/run.t
@@ -2,7 +2,7 @@ Run an application
 
   $ ./test.exe configure --file app/config.ml
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
-  $ dune exec -- ./app/main.exe --arg=yo --require=bar
+  $ dune exec -- ./app/main.exe --arg=yo --required=bar
   Success: hello=Hello World! arg=yo
   $ dune exec -- ./app/main.exe --help=plain
   NAME

--- a/test/functoria/test_cli.ml
+++ b/test/functoria/test_cli.ml
@@ -67,7 +67,7 @@ let test_describe () =
       [|
         "name";
         "describe";
-        "--context=config.json";
+        "--context-file=config.json";
         "--cde";
         "--color=always";
         "--dot-command=dot";


### PR DESCRIPTION
in contrast to #1604, here the tests are running. Turns out, some testcases used no longer available cmdliner functionality, and the "expect tests" used shortforms of the arguments (i.e. `package` instead of `packages`). Furthermore, functoria embedded a `--context` argument to argv, while it should be `--context-file`.

I understand that capturing cmdliner output is something @dbuenzli is against, and I agree with him -- but I've no other idea for these "e2e" tests. So I'll let them be there.