### PR TITLE
Dhcp ipv4 and leases

### DIFF
--- a/lib/devices/dns.ml
+++ b/lib/devices/dns.ml
@@ -31,17 +31,13 @@ let generic_dns_client ?dhcp ?group ?timeout ?nameservers ?cache_size () =
             ] ->
               (* The nameservers argument has to be turned into a string. *)
               code ~pos:__POS__
-                "let nameservers =@[@ \
-                   match %s, %s with@ | None, None -> None@ \
-                   | Some ns, _ -> Some ns@ \
-                   | None, Some lease ->@[@ \
-                     let nameservers = Dhcp_wire.collect_name_servers lease in@.\
-                     Some (List.concat_map (fun ip -> \
-                            [Fmt.str \"udp:%%a\" Ipaddr.V4.pp ip; \
-                             Fmt.str \"tcp:%%a\" Ipaddr.V4.pp ip]) nameservers)\
-                 @]@]@.\
-                 in@.\
-                 %s.connect @[?nameservers ?timeout:%s ?cache_size:%s@ (%s, %s)@]"
+                "let nameservers =@[@ match %s, %s with@ | None, None -> None@ \
+                 | Some ns, _ -> Some ns@ | None, Some lease ->@[@ let \
+                 nameservers = Dhcp_wire.collect_name_servers lease in@.Some \
+                 (List.concat_map (fun ip -> [Fmt.str \"udp:%%a\" Ipaddr.V4.pp \
+                 ip; Fmt.str \"tcp:%%a\" Ipaddr.V4.pp ip]) \
+                 nameservers)@]@]@.in@.%s.connect @[?nameservers ?timeout:%s \
+                 ?cache_size:%s@ (%s, %s)@]"
                 nameservers lease modname timeout cache_size stackv4v6
                 happy_eyeballs
           | _ -> Misc.connect_err "generic_dns_client" 6

--- a/lib/devices/dns.ml
+++ b/lib/devices/dns.ml
@@ -42,7 +42,7 @@ let generic_dns_client ?dhcp ?group ?timeout ?nameservers ?cache_size () =
                 happy_eyeballs
           | _ -> Misc.connect_err "generic_dns_client" 6
         in
-        ( package ~min:"2.0.0" ~max:"3.0.0" "charrua" :: packages,
+        ( package ~min:"2.0.0" ~max:"4.0.0" "charrua" :: packages,
           Some [ dep lease ],
           connect )
   in

--- a/lib/devices/dns.ml
+++ b/lib/devices/dns.ml
@@ -29,11 +29,17 @@ let generic_dns_client ?dhcp ?group ?timeout ?nameservers ?cache_size () =
           | [
               stackv4v6; happy_eyeballs; lease; nameservers; timeout; cache_size;
             ] ->
+              (* The nameservers argument has to be turned into a string. *)
               code ~pos:__POS__
                 "let nameservers =@[@ \
-                 match %s, %s with@ | None, None -> None@ \
-                 | Some ns, _ -> Some ns@ \
-                 | None, Some lease ->@ Some (Dhcp_wire.collect_name_servers lease)@ @]\
+                   match %s, %s with@ | None, None -> None@ \
+                   | Some ns, _ -> Some ns@ \
+                   | None, Some lease ->@[@ \
+                     let nameservers = Dhcp_wire.collect_name_servers lease in@.\
+                     Some (List.concat_map (fun ip -> \
+                            [Fmt.str \"udp:%%a\" Ipaddr.V4.pp ip; \
+                             Fmt.str \"tcp:%%a\" Ipaddr.V4.pp ip]) nameservers)\
+                 @]@]@.\
                  in@.\
                  %s.connect @[?nameservers ?timeout:%s ?cache_size:%s@ (%s, %s)@]"
                 nameservers lease modname timeout cache_size stackv4v6

--- a/lib/devices/dns.ml
+++ b/lib/devices/dns.ml
@@ -4,18 +4,40 @@ type dns_client = Dns_client
 
 let dns_client = typ Dns_client
 
-let generic_dns_client ?group ?timeout ?nameservers ?cache_size () =
+let generic_dns_client ?dhcp ?group ?timeout ?nameservers ?cache_size () =
+  Option.iter
+    (fun (requests, _) -> Ip.Dhcp_requests.add requests 6 (* DNS_SERVERS *))
+    dhcp;
   let packages = [ package "dns-client-mirage" ~min:"10.0.0" ~max:"11.0.0" ] in
   let nameservers = Runtime_arg.dns_servers ?group nameservers
   and timeout = Runtime_arg.dns_timeout ?group timeout
   and cache_size = Runtime_arg.dns_cache_size ?group cache_size in
   let runtime_args = Runtime_arg.[ v nameservers; v timeout; v cache_size ] in
-  let connect _info modname = function
-    | [ stackv4v6; happy_eyeballs; nameservers; timeout; cache_size ] ->
-        code ~pos:__POS__
-          {ocaml|%s.connect @[?nameservers:%s ?timeout:%s ?cache_size:%s@ (%s, %s)@]|ocaml}
-          modname nameservers timeout cache_size stackv4v6 happy_eyeballs
-    | _ -> Misc.connect_err "generic_dns_client" 5
+  let packages, extra_deps, connect =
+    match dhcp with
+    | None ->
+        let connect _info modname = function
+          | [ stackv4v6; happy_eyeballs; nameservers; timeout; cache_size ] ->
+              code ~pos:__POS__
+                {ocaml|%s.connect @[?nameservers:%s ?timeout:%s ?cache_size:%s@ (%s, %s)@]|ocaml}
+                modname nameservers timeout cache_size stackv4v6 happy_eyeballs
+          | _ -> Misc.connect_err "generic_dns_client" 5
+        in
+        (packages, None, connect)
+    | Some (_, lease) ->
+        let connect _info modname = function
+          | [
+              stackv4v6; happy_eyeballs; lease; nameservers; timeout; cache_size;
+            ] ->
+              code ~pos:__POS__
+                {ocaml|let nameservers = match %s, %s with | None, None -> None | Some ns, _ -> Some ns | None, Some lease -> Some (Dhcp_wire.collect_name_servers lease) in %s.connect @[?nameservers ?timeout:%s ?cache_size:%s@ (%s, %s)@]|ocaml}
+                nameservers lease modname timeout cache_size stackv4v6
+                happy_eyeballs
+          | _ -> Misc.connect_err "generic_dns_client" 6
+        in
+        ( package ~min:"2.0.0" ~max:"3.0.0" "charrua" :: packages,
+          Some [ dep lease ],
+          connect )
   in
-  impl ~runtime_args ~packages ~connect "Dns_client_mirage.Make"
+  impl ~runtime_args ~packages ?extra_deps ~connect "Dns_client_mirage.Make"
     (Stack.stackv4v6 @-> Happy_eyeballs.happy_eyeballs @-> dns_client)

--- a/lib/devices/dns.ml
+++ b/lib/devices/dns.ml
@@ -33,7 +33,7 @@ let generic_dns_client ?dhcp ?group ?timeout ?nameservers ?cache_size () =
               code ~pos:__POS__
                 "let nameservers =@[@ match %s, %s with@ | None, None -> None@ \
                  | Some ns, _ -> Some ns@ | None, Some lease ->@[@ let \
-                 nameservers = Dhcp_wire.collect_name_servers lease in@.Some \
+                 nameservers = Dhcp_wire.collect_dns_servers lease in@.Some \
                  (List.concat_map (fun ip -> [Fmt.str \"udp:%%a\" Ipaddr.V4.pp \
                  ip; Fmt.str \"tcp:%%a\" Ipaddr.V4.pp ip]) \
                  nameservers)@]@]@.in@.%s.connect @[?nameservers ?timeout:%s \

--- a/lib/devices/dns.ml
+++ b/lib/devices/dns.ml
@@ -30,7 +30,12 @@ let generic_dns_client ?dhcp ?group ?timeout ?nameservers ?cache_size () =
               stackv4v6; happy_eyeballs; lease; nameservers; timeout; cache_size;
             ] ->
               code ~pos:__POS__
-                {ocaml|let nameservers = match %s, %s with | None, None -> None | Some ns, _ -> Some ns | None, Some lease -> Some (Dhcp_wire.collect_name_servers lease) in %s.connect @[?nameservers ?timeout:%s ?cache_size:%s@ (%s, %s)@]|ocaml}
+                "let nameservers =@[@ \
+                 match %s, %s with@ | None, None -> None@ \
+                 | Some ns, _ -> Some ns@ \
+                 | None, Some lease ->@ Some (Dhcp_wire.collect_name_servers lease)@ @]\
+                 in@.\
+                 %s.connect @[?nameservers ?timeout:%s ?cache_size:%s@ (%s, %s)@]"
                 nameservers lease modname timeout cache_size stackv4v6
                 happy_eyeballs
           | _ -> Misc.connect_err "generic_dns_client" 6

--- a/lib/devices/dns.ml
+++ b/lib/devices/dns.ml
@@ -33,9 +33,10 @@ let generic_dns_client ?dhcp ?group ?timeout ?nameservers ?cache_size () =
               code ~pos:__POS__
                 "let nameservers =@[@ match %s, %s with@ | None, None -> None@ \
                  | Some ns, _ -> Some ns@ | None, Some lease ->@[@ let \
-                 nameservers = Dhcp_wire.collect_dns_servers lease in@.Some \
-                 (List.concat_map (fun ip -> [Fmt.str \"udp:%%a\" Ipaddr.V4.pp \
-                 ip; Fmt.str \"tcp:%%a\" Ipaddr.V4.pp ip]) \
+                 nameservers = Dhcp_wire.collect_dns_servers lease in@.if \
+                 nameservers = [] then None@.else Some (List.concat_map (fun \
+                 ip -> [Fmt.str \"udp:%%a\" Ipaddr.V4.pp ip; Fmt.str \
+                 \"tcp:%%a\" Ipaddr.V4.pp ip]) \
                  nameservers)@]@]@.in@.%s.connect @[?nameservers ?timeout:%s \
                  ?cache_size:%s@ (%s, %s)@]"
                 nameservers lease modname timeout cache_size stackv4v6

--- a/lib/devices/dns.mli
+++ b/lib/devices/dns.mli
@@ -5,6 +5,7 @@ type dns_client
 val dns_client : dns_client typ
 
 val generic_dns_client :
+  ?dhcp:Ip.Dhcp_requests.t * Ip.lease impl ->
   ?group:string ->
   ?timeout:int64 ->
   ?nameservers:string list ->

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -7,11 +7,32 @@ type 'a ip = IP
 type ipv4 = v4 ip
 type ipv6 = v6 ip
 type ipv4v6 = v4v6 ip
+type dhcp_ipv4 = DHCP_IPV4
+type lease = LEASE
 
 let ip = Functoria.Type.Type IP
 let ipv4 : ipv4 typ = ip
 let ipv6 : ipv6 typ = ip
 let ipv4v6 : ipv4v6 typ = ip
+let dhcp_ipv4 = typ DHCP_IPV4
+let lease = typ LEASE
+
+module Dhcp_requests = struct
+  module IntSet = Set.Make (Int)
+
+  type t = { mutable requests : IntSet.t; mutable consumed : bool }
+
+  let make () = { requests = IntSet.empty; consumed = false }
+
+  let add t req =
+    if t.consumed then invalid_arg "DHCP option code added too late";
+    t.requests <- IntSet.add req t.requests
+
+  let consume t =
+    assert (not t.consumed);
+    t.consumed <- true;
+    match IntSet.to_list t.requests with [] -> None | xs -> Some xs
+end
 
 (* convenience function for linking tcpip.unix for checksums *)
 let right_tcpip_library sublibs =
@@ -31,20 +52,51 @@ let ipv4_keyed_conf ~ip ~gateway ~no_init () =
   impl ~packages ~runtime_args ~connect "Static_ipv4.Make"
     (Ethernet.ethernet @-> Arp.arpv4 @-> ipv4)
 
-let ipv4_dhcp_conf =
+let ipv4_dhcp_conf () =
+  let requests = Dhcp_requests.make () in
   let packages =
     [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
   in
   let connect _ modname = function
     | [ network; ethernet; arp ] ->
-        code ~pos:__POS__ "%s.connect@[@ %s@ %s@ %s@]" modname network ethernet
-          arp
+        Dhcp_requests.add requests 1 (* SUBNET_MASK *);
+        Dhcp_requests.add requests 3 (* ROUTERS *);
+        let requests = Dhcp_requests.consume requests in
+        code ~pos:__POS__
+          "let requests =@[@ Option.map (List.map \
+           Dhcp_wire.int_to_option_code_exn) %a@]@ in@ %s.connect@[@ \
+           ?requests@ %s@ %s@ %s@]"
+          Fmt.(Dump.option (Dump.list int))
+          requests modname network ethernet arp
     | _ -> Misc.connect_err "ipv4 dhcp" 3
   in
-  impl ~packages ~connect "Dhcp_ipv4.Make"
-    (Network.network @-> Ethernet.ethernet @-> Arp.arpv4 @-> ipv4)
+  ( requests,
+    impl ~packages ~connect "Dhcp_ipv4.Make"
+      (Network.network @-> Ethernet.ethernet @-> Arp.arpv4 @-> dhcp_ipv4) )
 
-let ipv4_of_dhcp net ethif arp = ipv4_dhcp_conf $ net $ ethif $ arp
+let ipv4_of_dhcp net ethif arp =
+  let requests, conf = ipv4_dhcp_conf () in
+  (requests, conf $ net $ ethif $ arp)
+
+let dhcp_proj_ipv4 =
+  let packages =
+    [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
+  in
+  let connect _ modname = function
+    | [ dhcp ] -> code ~pos:__POS__ "%s.connect@[@ %s@]" modname dhcp
+    | _ -> Misc.connect_err "dhcp_proj_ipv4" 1
+  in
+  impl ~packages ~connect "Dhcp_ipv4.Proj_ipv4" (dhcp_ipv4 @-> ipv4)
+
+let dhcp_proj_lease =
+  let packages =
+    [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
+  in
+  let connect _ modname = function
+    | [ dhcp ] -> code ~pos:__POS__ "%s.connect@[@ %s@]" modname dhcp
+    | _ -> Misc.connect_err "dhcp_proj_ipv4" 1
+  in
+  impl ~packages ~connect "Dhcp_ipv4.Proj_lease" (dhcp_ipv4 @-> lease)
 
 let keyed_create_ipv4 ?group
     ?(network = Ipaddr.V4.Prefix.of_string_exn "10.0.0.2/24") ?gateway ~no_init

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -64,7 +64,7 @@ let ipv4_dhcp_conf () =
         let requests = Dhcp_requests.consume requests in
         code ~pos:__POS__
           "let requests =@[@ Option.map (List.map \
-           Dhcp_wire.int_to_option_code_exn) %a@]@ in@ %s.connect@[@ \
+           Dhcp_wire.int_to_option_code_exn) (%a)@]@ in@ %s.connect@[@ \
            ?requests@ %s@ %s@ %s@]"
           Fmt.(Dump.option (Dump.list int))
           requests modname network ethernet arp

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -31,7 +31,7 @@ module Dhcp_requests = struct
   let consume t =
     assert (not t.consumed);
     t.consumed <- true;
-    match IntSet.to_list t.requests with [] -> None | xs -> Some xs
+    match IntSet.elements t.requests with [] -> None | xs -> Some xs
 end
 
 (* convenience function for linking tcpip.unix for checksums *)

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -26,6 +26,7 @@ module Dhcp_requests = struct
 
   let add t req =
     if t.consumed then invalid_arg "DHCP option code added too late";
+    if req <= 1 || req >= 255 then invalid_arg "Invalid DHCP option code";
     t.requests <- IntSet.add req t.requests
 
   let consume t =

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -26,7 +26,8 @@ module Dhcp_requests = struct
 
   let add t req =
     if t.consumed then invalid_arg "DHCP option code added too late";
-    if req <= 1 || req >= 255 then invalid_arg "Invalid DHCP option code";
+    (* Option codes are in 0-255, option 0 is PAD, option 255 is END *)
+    if req <= 0 || req >= 255 then invalid_arg "Invalid DHCP option code";
     t.requests <- IntSet.add req t.requests
 
   let consume t =

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -52,6 +52,10 @@ let ipv4_keyed_conf ~ip ~gateway ~no_init () =
   impl ~packages ~runtime_args ~connect "Static_ipv4.Make"
     (Ethernet.ethernet @-> Arp.arpv4 @-> ipv4)
 
+let no_lease =
+  let connect _ _ _ = code ~pos:__POS__ "Lwt.return None" in
+  impl ~connect "Lwt" lease
+
 let ipv4_dhcp_conf ~ip ~gateway ~no_init requests =
   let packages =
     [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -78,6 +78,16 @@ let ipv4_of_dhcp net ethif arp =
   let requests, conf = ipv4_dhcp_conf () in
   (requests, conf $ net $ ethif $ arp)
 
+let dhcp_proj_net =
+  let packages =
+    [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
+  in
+  let connect _ modname = function
+    | [ dhcp ] -> code ~pos:__POS__ "%s.connect@[@ %s@]" modname dhcp
+    | _ -> Misc.connect_err "dhcp_proj_net" 1
+  in
+  impl ~packages ~connect "Dhcp_ipv4.Proj_net" (dhcp_ipv4 @-> Network.network)
+
 let dhcp_proj_ipv4 =
   let packages =
     [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -52,8 +52,7 @@ let ipv4_keyed_conf ~ip ~gateway ~no_init () =
   impl ~packages ~runtime_args ~connect "Static_ipv4.Make"
     (Ethernet.ethernet @-> Arp.arpv4 @-> ipv4)
 
-let ipv4_dhcp_conf ~ip ~gateway ~no_init () =
-  let requests = Dhcp_requests.make () in
+let ipv4_dhcp_conf ~ip ~gateway ~no_init requests =
   let packages =
     [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
   in
@@ -71,19 +70,18 @@ let ipv4_dhcp_conf ~ip ~gateway ~no_init () =
           modname no_init ip gateway network ethernet arp
     | _ -> Misc.connect_err "ipv4 dhcp" 6
   in
-  ( requests,
-    impl ~packages ~runtime_args ~connect "Dhcp_ipv4.Make"
-      (Network.network @-> Ethernet.ethernet @-> Arp.arpv4 @-> dhcp_ipv4) )
+  impl ~packages ~runtime_args ~connect "Dhcp_ipv4.Make"
+    (Network.network @-> Ethernet.ethernet @-> Arp.arpv4 @-> dhcp_ipv4)
 
-let keyed_ipv4_of_dhcp ?group ?gateway ~no_init net ethif arp =
+let keyed_ipv4_of_dhcp ?group ?(dhcp_requests = Dhcp_requests.make ()) ?gateway ~no_init net ethif arp =
   let ip = Runtime_arg.V4.optional_network ?group ()
   and gateway = Runtime_arg.V4.gateway ?group gateway in
-  let requests, conf = ipv4_dhcp_conf ~ip ~gateway ~no_init () in
-  (requests, conf $ net $ ethif $ arp)
+  let conf = ipv4_dhcp_conf ~ip ~gateway ~no_init dhcp_requests in
+  conf $ net $ ethif $ arp
 
-let ipv4_of_dhcp ?group ?gateway net ethif arp =
+let ipv4_of_dhcp ?group ?dhcp_requests ?gateway net ethif arp =
   let no_init = Runtime_arg.ipv6_only ?group () in
-  keyed_ipv4_of_dhcp ?gateway ~no_init net ethif arp
+  keyed_ipv4_of_dhcp ?group ?dhcp_requests ?gateway ~no_init net ethif arp
 
 let dhcp_proj_net =
   let packages =

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -52,31 +52,38 @@ let ipv4_keyed_conf ~ip ~gateway ~no_init () =
   impl ~packages ~runtime_args ~connect "Static_ipv4.Make"
     (Ethernet.ethernet @-> Arp.arpv4 @-> ipv4)
 
-let ipv4_dhcp_conf () =
+let ipv4_dhcp_conf ~ip ~gateway ~no_init () =
   let requests = Dhcp_requests.make () in
   let packages =
     [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
   in
+  let runtime_args = Runtime_arg.[ v ip; v gateway; v no_init ] in
   let connect _ modname = function
-    | [ network; ethernet; arp ] ->
+    | [ network; ethernet; arp; ip; gateway; no_init ] ->
         Dhcp_requests.add requests 1 (* SUBNET_MASK *);
         Dhcp_requests.add requests 3 (* ROUTERS *);
         let requests = Dhcp_requests.consume requests in
         code ~pos:__POS__
           "let requests =@[@ Option.map (List.map \
-           Dhcp_wire.int_to_option_code_exn) (%a)@]@ in@ %s.connect@[@ \
-           ?requests@ %s@ %s@ %s@]"
-          Fmt.(Dump.option (Dump.list int))
-          requests modname network ethernet arp
-    | _ -> Misc.connect_err "ipv4 dhcp" 3
+           Dhcp_wire.int_to_option_code_exn)@ %a@]@ in@ %s.connect@[@ \
+           ?requests@ ~no_init:%s@ ?cidr:%s@ ?gateway:%s@ %s@ %s@ %s@]"
+          Fmt.(parens (Dump.option (Dump.list int))) requests
+          modname no_init ip gateway network ethernet arp
+    | _ -> Misc.connect_err "ipv4 dhcp" 6
   in
   ( requests,
-    impl ~packages ~connect "Dhcp_ipv4.Make"
+    impl ~packages ~runtime_args ~connect "Dhcp_ipv4.Make"
       (Network.network @-> Ethernet.ethernet @-> Arp.arpv4 @-> dhcp_ipv4) )
 
-let ipv4_of_dhcp net ethif arp =
-  let requests, conf = ipv4_dhcp_conf () in
+let keyed_ipv4_of_dhcp ?group ?gateway ~no_init net ethif arp =
+  let ip = Runtime_arg.V4.optional_network ?group ()
+  and gateway = Runtime_arg.V4.gateway ?group gateway in
+  let requests, conf = ipv4_dhcp_conf ~ip ~gateway ~no_init () in
   (requests, conf $ net $ ethif $ arp)
+
+let ipv4_of_dhcp ?group ?gateway net ethif arp =
+  let no_init = Runtime_arg.ipv6_only ?group () in
+  keyed_ipv4_of_dhcp ?gateway ~no_init net ethif arp
 
 let dhcp_proj_net =
   let packages =

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -66,14 +66,15 @@ let ipv4_dhcp_conf ~ip ~gateway ~no_init requests =
           "let requests =@[@ Option.map (List.map \
            Dhcp_wire.int_to_option_code_exn)@ %a@]@ in@ %s.connect@[@ \
            ?requests@ ~no_init:%s@ ?cidr:%s@ ?gateway:%s@ %s@ %s@ %s@]"
-          Fmt.(parens (Dump.option (Dump.list int))) requests
-          modname no_init ip gateway network ethernet arp
+          Fmt.(parens (Dump.option (Dump.list int)))
+          requests modname no_init ip gateway network ethernet arp
     | _ -> Misc.connect_err "ipv4 dhcp" 6
   in
   impl ~packages ~runtime_args ~connect "Dhcp_ipv4.Make"
     (Network.network @-> Ethernet.ethernet @-> Arp.arpv4 @-> dhcp_ipv4)
 
-let keyed_ipv4_of_dhcp ?group ?(dhcp_requests = Dhcp_requests.make ()) ?gateway ~no_init net ethif arp =
+let keyed_ipv4_of_dhcp ?group ?(dhcp_requests = Dhcp_requests.make ()) ?gateway
+    ~no_init net ethif arp =
   let ip = Runtime_arg.V4.optional_network ?group ()
   and gateway = Runtime_arg.V4.gateway ?group gateway in
   let conf = ipv4_dhcp_conf ~ip ~gateway ~no_init dhcp_requests in

--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -58,7 +58,7 @@ let no_lease =
 
 let ipv4_dhcp_conf ~ip ~gateway ~no_init requests =
   let packages =
-    [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
+    [ package ~min:"3.0.0" ~max:"4.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
   in
   let runtime_args = Runtime_arg.[ v ip; v gateway; v no_init ] in
   let connect _ modname = function
@@ -90,7 +90,7 @@ let ipv4_of_dhcp ?group ?dhcp_requests ?gateway net ethif arp =
 
 let dhcp_proj_net =
   let packages =
-    [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
+    [ package ~min:"3.0.0" ~max:"4.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
   in
   let connect _ modname = function
     | [ dhcp ] -> code ~pos:__POS__ "%s.connect@[@ %s@]" modname dhcp
@@ -100,7 +100,7 @@ let dhcp_proj_net =
 
 let dhcp_proj_ipv4 =
   let packages =
-    [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
+    [ package ~min:"3.0.0" ~max:"4.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
   in
   let connect _ modname = function
     | [ dhcp ] -> code ~pos:__POS__ "%s.connect@[@ %s@]" modname dhcp
@@ -110,7 +110,7 @@ let dhcp_proj_ipv4 =
 
 let dhcp_proj_lease =
   let packages =
-    [ package ~min:"2.0.0" ~max:"3.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
+    [ package ~min:"3.0.0" ~max:"4.0.0" ~sublibs:[ "mirage" ] "charrua-client" ]
   in
   let connect _ modname = function
     | [ dhcp ] -> code ~pos:__POS__ "%s.connect@[@ %s@]" modname dhcp

--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -7,11 +7,21 @@ type 'a ip
 type ipv4 = v4 ip
 type ipv6 = v6 ip
 type ipv4v6 = v4v6 ip
+type dhcp_ipv4
+type lease
 
 val ip : 'a ip typ
 val ipv4 : ipv4 typ
 val ipv6 : ipv6 typ
 val ipv4v6 : ipv4v6 typ
+val dhcp_ipv4 : dhcp_ipv4 typ
+val lease : lease typ
+
+module Dhcp_requests : sig
+  type t
+
+  val add : t -> int -> unit
+end
 
 val create_ipv4 :
   ?group:string -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl
@@ -38,7 +48,13 @@ val keyed_create_ipv6 :
   ipv6 impl
 
 val ipv4_of_dhcp :
-  Network.network impl -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl
+  Network.network impl ->
+  Ethernet.ethernet impl ->
+  Arp.arpv4 impl ->
+  Dhcp_requests.t * dhcp_ipv4 impl
+
+val dhcp_proj_ipv4 : (dhcp_ipv4 -> ipv4) impl
+val dhcp_proj_lease : (dhcp_ipv4 -> lease) impl
 
 val ipv4_qubes :
   Qubesdb.qubesdb impl -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl

--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -53,6 +53,7 @@ val ipv4_of_dhcp :
   Arp.arpv4 impl ->
   Dhcp_requests.t * dhcp_ipv4 impl
 
+val dhcp_proj_net : (dhcp_ipv4 -> Network.network) impl
 val dhcp_proj_ipv4 : (dhcp_ipv4 -> ipv4) impl
 val dhcp_proj_lease : (dhcp_ipv4 -> lease) impl
 

--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -21,6 +21,8 @@ module Dhcp_requests : sig
   type t
 
   val add : t -> int -> unit
+
+  val make : unit -> t
 end
 
 val create_ipv4 :
@@ -49,20 +51,22 @@ val keyed_create_ipv6 :
 
 val keyed_ipv4_of_dhcp :
   ?group:string ->
+  ?dhcp_requests:Dhcp_requests.t ->
   ?gateway:Ipaddr.V4.t ->
   no_init:bool runtime_arg ->
   Network.network impl ->
   Ethernet.ethernet impl ->
   Arp.arpv4 impl ->
-  Dhcp_requests.t * dhcp_ipv4 impl
+  dhcp_ipv4 impl
 
 val ipv4_of_dhcp :
   ?group:string ->
+  ?dhcp_requests:Dhcp_requests.t ->
   ?gateway:Ipaddr.V4.t ->
   Network.network impl ->
   Ethernet.ethernet impl ->
   Arp.arpv4 impl ->
-  Dhcp_requests.t * dhcp_ipv4 impl
+  dhcp_ipv4 impl
 
 val dhcp_proj_net : (dhcp_ipv4 -> Network.network) impl
 val dhcp_proj_ipv4 : (dhcp_ipv4 -> ipv4) impl

--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -47,7 +47,18 @@ val keyed_create_ipv6 :
   Ethernet.ethernet impl ->
   ipv6 impl
 
+val keyed_ipv4_of_dhcp :
+  ?group:string ->
+  ?gateway:Ipaddr.V4.t ->
+  no_init:bool runtime_arg ->
+  Network.network impl ->
+  Ethernet.ethernet impl ->
+  Arp.arpv4 impl ->
+  Dhcp_requests.t * dhcp_ipv4 impl
+
 val ipv4_of_dhcp :
+  ?group:string ->
+  ?gateway:Ipaddr.V4.t ->
   Network.network impl ->
   Ethernet.ethernet impl ->
   Arp.arpv4 impl ->

--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -21,7 +21,6 @@ module Dhcp_requests : sig
   type t
 
   val add : t -> int -> unit
-
   val make : unit -> t
 end
 

--- a/lib/devices/ip.mli
+++ b/lib/devices/ip.mli
@@ -70,6 +70,7 @@ val ipv4_of_dhcp :
 val dhcp_proj_net : (dhcp_ipv4 -> Network.network) impl
 val dhcp_proj_ipv4 : (dhcp_ipv4 -> ipv4) impl
 val dhcp_proj_lease : (dhcp_ipv4 -> lease) impl
+val no_lease : lease impl
 
 val ipv4_qubes :
   Qubesdb.qubesdb impl -> Ethernet.ethernet impl -> Arp.arpv4 impl -> ipv4 impl

--- a/lib/devices/key.ml
+++ b/lib/devices/key.ml
@@ -136,8 +136,9 @@ let block ?group () =
 (** {3 Stack keys} *)
 
 let dhcp ?group () =
-  let doc = Fmt.str "Enable dhcp for %a." pp_group group in
-  configure_key ~doc ?group ~default:false Cmdliner.Arg.bool "dhcp"
+  let default = true in
+  let doc = Fmt.str "Enable dhcp for %a (default %B)." pp_group group default in
+  configure_key ~doc ?group ~default Cmdliner.Arg.bool "dhcp"
 
 let net ?group () : [ `Host | `OCaml ] option Key.key =
   let enum =

--- a/lib/devices/resolver.ml
+++ b/lib/devices/resolver.ml
@@ -21,22 +21,49 @@ let resolver_unix_system =
   in
   impl ~packages_v ~configure ~connect "Resolver_lwt" resolver
 
-let resolver_dns_conf ~ns =
+let resolver_dns_conf ~dhcp ~ns =
+  Option.iter
+    (fun (requests, _) -> Ip.Dhcp_requests.add requests 6 (* DNS_SERVERS *))
+    dhcp;
   let packages = [ Conduit.pkg ] in
   let runtime_args = Runtime_arg.[ v ns ] in
-  let connect _ modname = function
-    | [ stack; ns ] ->
-        code ~pos:__POS__
-          "let nameservers = %s in@;\
-           %s.v ?nameservers %s >|= function@;\
-           | Ok r -> r@;\
-           | Error (`Msg e) -> invalid_arg e@;"
-          ns modname stack
-    | _ -> Misc.connect_err "resolver" 2
+  let packages, extra_deps, connect =
+    match dhcp with
+    | None ->
+        let connect _ modname = function
+          | [ stack; ns ] ->
+              code ~pos:__POS__
+                "let nameservers = %s in@;\
+                 %s.v ?nameservers %s >|= function@;\
+                 | Ok r -> r@;\
+                 | Error (`Msg e) -> invalid_arg e@;"
+                ns modname stack
+          | _ -> Misc.connect_err "resolver" 2
+        in
+        (packages, None, connect)
+    | Some (_, lease) ->
+        let connect _ modname = function
+          | [ stack; lease; ns ] ->
+              code ~pos:__POS__
+                "let nameservers =@[@ match %s, %s with@ | None, None -> None@ \
+                 | Some ns, _ -> Some ns@ | None, Some lease ->@[@ let \
+                 nameservers = Dhcp_wire.collect_dns_servers lease in@.Some \
+                 (List.concat_map (fun ip -> [Fmt.str \"udp:%%a\" Ipaddr.V4.pp \
+                 ip; Fmt.str \"tcp:%%a\" Ipaddr.V4.pp ip]) nameservers)@]@]@.in\n\
+                \             %s.v ?nameservers %s >|= function@;\
+                 | Ok r -> r@;\
+                 | Error (`Msg e) -> invalid_arg e@;"
+                ns lease modname stack
+          | _ -> Misc.connect_err "resolver" 3
+        in
+        let packages =
+          package ~min:"2.0.0" ~max:"3.0.0" "charrua" :: packages
+        in
+        (packages, Some [ dep lease ], connect)
   in
-  impl ~packages ~runtime_args ~connect "Resolver_mirage.Make"
+  impl ~packages ?extra_deps ~runtime_args ~connect "Resolver_mirage.Make"
     (Stack.stackv4v6 @-> resolver)
 
-let resolver_dns ?ns stack =
+let resolver_dns ?dhcp ?ns stack =
   let ns = Runtime_arg.resolver ?default:ns () in
-  resolver_dns_conf ~ns $ stack
+  resolver_dns_conf ~dhcp ~ns $ stack

--- a/lib/devices/resolver.ml
+++ b/lib/devices/resolver.ml
@@ -57,7 +57,7 @@ let resolver_dns_conf ~dhcp ~ns =
           | _ -> Misc.connect_err "resolver" 3
         in
         let packages =
-          package ~min:"2.0.0" ~max:"3.0.0" "charrua" :: packages
+          package ~min:"2.0.0" ~max:"4.0.0" "charrua" :: packages
         in
         (packages, Some [ dep lease ], connect)
   in

--- a/lib/devices/resolver.mli
+++ b/lib/devices/resolver.mli
@@ -3,5 +3,11 @@ open Functoria.DSL
 type resolver
 
 val resolver : resolver typ
-val resolver_dns : ?ns:string list -> Stack.stackv4v6 impl -> resolver impl
+
+val resolver_dns :
+  ?dhcp:Ip.Dhcp_requests.t * Ip.lease impl ->
+  ?ns:string list ->
+  Stack.stackv4v6 impl ->
+  resolver impl
+
 val resolver_unix_system : resolver impl

--- a/lib/devices/runtime_arg.ml
+++ b/lib/devices/runtime_arg.ml
@@ -64,7 +64,8 @@ module V4 = struct
       docs pp_prefix default
 
   let optional_network ?group ?docs () =
-    runtime_network_key ~pos:__POS__ "V4.optional_network %a%a()" pp_group group pp_docs docs
+    runtime_network_key ~pos:__POS__ "V4.optional_network %a%a()" pp_group group
+      pp_docs docs
 
   let gateway ?group ?docs default =
     runtime_network_key ~pos:__POS__ "V4.gateway %a%a%a" pp_group group pp_docs

--- a/lib/devices/runtime_arg.ml
+++ b/lib/devices/runtime_arg.ml
@@ -63,6 +63,9 @@ module V4 = struct
     runtime_network_key ~pos:__POS__ "V4.network %a%a%a" pp_group group pp_docs
       docs pp_prefix default
 
+  let optional_network ?group ?docs () =
+    runtime_network_key ~pos:__POS__ "V4.optional_network %a%a()" pp_group group pp_docs docs
+
   let gateway ?group ?docs default =
     runtime_network_key ~pos:__POS__ "V4.gateway %a%a%a" pp_group group pp_docs
       docs (pp_option pp) default

--- a/lib/devices/runtime_arg.mli
+++ b/lib/devices/runtime_arg.mli
@@ -41,6 +41,10 @@ module V4 : sig
     ?group:string -> ?docs:string -> Prefix.t -> Prefix.t runtime_arg
   (** A network defined by an address and netmask. *)
 
+  val optional_network :
+    ?group:string -> ?docs:string -> unit -> Prefix.t runtime_arg
+  (** An optional network defined by an address and a netmask. *)
+
   val gateway :
     ?group:string -> ?docs:string -> t option -> t option runtime_arg
   (** A default gateway option. *)

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -64,7 +64,7 @@ let generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway ?ip
   let a = arp e in
   let dhcp_ipv4 = Ip.ipv4_of_dhcp ?dhcp_requests tap e a in
   let tap =
-    match_impl p [ (`Dchp, Ip.dhcp_proj_net $ dhcp_ipv4) ] ~default:tap
+    match_impl p [ (`Dhcp, Ip.dhcp_proj_net $ dhcp_ipv4) ] ~default:tap
   in
   let i4 =
     match_impl p

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -74,7 +74,9 @@ let generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway
       ~no_init:ipv4_only tap e
   in
   let lease =
-    match_impl p [ (`Dhcp, Ip.dhcp_proj_lease $ dhcp_ipv4) ] ~default:Ip.no_lease
+    match_impl p
+      [ (`Dhcp, Ip.dhcp_proj_lease $ dhcp_ipv4) ]
+      ~default:Ip.no_lease
   in
   (keyed_direct_stackv4v6 ~ipv4_only ~ipv6_only ?tcp tap e a i4 i6, lease)
 
@@ -118,7 +120,8 @@ let generic_stackv4v6_with_lease ?group ?dhcp_requests
   ( match_impl p
       [ (`Socket, socket_stackv4v6 ?group ()) ]
       ~default:(fst generic_ipv4v6_stack),
-    match_impl p [ (`Socket, Ip.no_lease) ] ~default:(snd generic_ipv4v6_stack) )
+    match_impl p [ (`Socket, Ip.no_lease) ] ~default:(snd generic_ipv4v6_stack)
+  )
 
 let generic_stackv4v6 ?group ?dhcp_key ?net_key ?ipv4_network ?ipv4_gateway
     ?ipv6_network ?ipv6_gateway ?tcp tap =

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -1,7 +1,5 @@
 open Functoria.DSL
 
-let dhcp_ipv4 tap e a = Ip.ipv4_of_dhcp tap e a
-
 let qubes_ipv4 ?(qubesdb = Qubesdb.default_qubesdb) e a =
   Ip.ipv4_qubes qubesdb e a
 
@@ -54,19 +52,24 @@ let keyed_direct_stackv4v6 ?tcp ~ipv4_only ~ipv6_only network eth arp ipv4 ipv6
   $ Udp.direct_udp ip
   $ match tcp with None -> Tcp.direct_tcp ip | Some tcp -> tcp
 
-let generic_ipv4v6_stack p ?group ?ipv4_network ?ipv4_gateway ?ipv6_network
+let no_lease =
+  let connect _ _ _ = code ~pos:__POS__ "Lwt.return None" in
+  impl ~connect "Lwt" Ip.lease
+
+let generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway ?ipv6_network
     ?ipv6_gateway ?(arp = Arp.arp) ?tcp tap =
   let ipv4_only = Runtime_arg.ipv4_only ?group ()
   and ipv6_only = Runtime_arg.ipv6_only ?group () in
   let e = Ethernet.ethif tap in
   let a = arp e in
+  let dhcp_ipv4 = Ip.ipv4_of_dhcp ?dhcp_requests tap e a in
   let tap =
-    match_impl p [ (`Dchp, Ip.dhcp_proj_net $ dhcp_ipv4 tap e a) ] ~default:tap
+    match_impl p [ (`Dchp, Ip.dhcp_proj_net $ dhcp_ipv4) ] ~default:tap
   in
   let i4 =
     match_impl p
       [
-        (`Qubes, qubes_ipv4 e a); (`Dhcp, Ip.dhcp_proj_ipv4 $ dhcp_ipv4 tap e a);
+        (`Qubes, qubes_ipv4 e a); (`Dhcp, Ip.dhcp_proj_ipv4 $ dhcp_ipv4);
       ]
       ~default:
         (Ip.keyed_create_ipv4 ?group ?network:ipv4_network ?gateway:ipv4_gateway
@@ -76,7 +79,10 @@ let generic_ipv4v6_stack p ?group ?ipv4_network ?ipv4_gateway ?ipv6_network
     Ip.keyed_create_ipv6 ?group ?network:ipv6_network ?gateway:ipv6_gateway
       ~no_init:ipv4_only tap e
   in
-  keyed_direct_stackv4v6 ~ipv4_only ~ipv6_only ?tcp tap e a i4 i6
+  let lease =
+    match_impl p [ `Dhcp, Ip.dhcp_proj_lease $ dhcp_ipv4 ] ~default:no_lease
+  in
+  keyed_direct_stackv4v6 ~ipv4_only ~ipv6_only ?tcp tap e a i4 i6, lease
 
 let socket_stackv4v6 ?(group = "") () =
   let v4key = Runtime_arg.V4.network ~group Ipaddr.V4.Prefix.global in
@@ -97,10 +103,10 @@ let socket_stackv4v6 ?(group = "") () =
   impl ~packages ~extra_deps ~connect "Tcpip_stack_socket.V4V6" stackv4v6
 
 (** Generic stack *)
-let generic_stackv4v6 ?group ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
+let generic_stackv4v6_with_lease ?group ?dhcp_requests ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
     ?(net_key = Key.value @@ Key.net ?group ()) ?ipv4_network ?ipv4_gateway
     ?ipv6_network ?ipv6_gateway ?tcp (tap : Network.network impl) :
-    stackv4v6 impl =
+    stackv4v6 impl * Ip.lease impl =
   let choose target net dhcp =
     match (target, net, dhcp) with
     | `Qubes, _, _ -> `Qubes
@@ -110,8 +116,17 @@ let generic_stackv4v6 ?group ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
     | _, _, _ -> `Static
   in
   let p = Key.(pure choose $ Key.(value target) $ net_key $ dhcp_key) in
+  let generic_ipv4v6_stack =
+    generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway ?ipv6_network
+      ?ipv6_gateway ?tcp tap
+  in
   match_impl p
     [ (`Socket, socket_stackv4v6 ?group ()) ]
-    ~default:
-      (generic_ipv4v6_stack p ?group ?ipv4_network ?ipv4_gateway ?ipv6_network
-         ?ipv6_gateway ?tcp tap)
+    ~default:(fst generic_ipv4v6_stack),
+  match_impl p
+    [ (`Socket, no_lease) ]
+    ~default:(snd generic_ipv4v6_stack)
+
+let generic_stackv4v6 ?group ?dhcp_key ?net_key ?ipv4_network ?ipv4_gateway ?ipv6_network ?ipv6_gateway ?tcp tap =
+  generic_stackv4v6_with_lease ?group ?dhcp_requests:None ?dhcp_key ?net_key ?ipv4_network ?ipv4_gateway ?ipv6_network ?ipv6_gateway ?tcp tap
+  |> fst

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -1,6 +1,6 @@
 open Functoria.DSL
 
-let dhcp_ipv4 tap e a = snd (Ip.ipv4_of_dhcp tap e a)
+let dhcp_ipv4 tap e a = Ip.ipv4_of_dhcp tap e a
 
 let qubes_ipv4 ?(qubesdb = Qubesdb.default_qubesdb) e a =
   Ip.ipv4_qubes qubesdb e a

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -1,6 +1,6 @@
 open Functoria.DSL
 
-let dhcp_ipv4 tap e a = Ip.dhcp_proj_ipv4 $ snd (Ip.ipv4_of_dhcp tap e a)
+let dhcp_ipv4 tap e a = snd (Ip.ipv4_of_dhcp tap e a)
 
 let qubes_ipv4 ?(qubesdb = Qubesdb.default_qubesdb) e a =
   Ip.ipv4_qubes qubesdb e a
@@ -60,9 +60,14 @@ let generic_ipv4v6_stack p ?group ?ipv4_network ?ipv4_gateway ?ipv6_network
   and ipv6_only = Runtime_arg.ipv6_only ?group () in
   let e = Ethernet.ethif tap in
   let a = arp e in
+  let tap =
+    match_impl p [ (`Dchp, Ip.dhcp_proj_net $ dhcp_ipv4 tap e a) ] ~default:tap
+  in
   let i4 =
     match_impl p
-      [ (`Qubes, qubes_ipv4 e a); (`Dhcp, dhcp_ipv4 tap e a) ]
+      [
+        (`Qubes, qubes_ipv4 e a); (`Dhcp, Ip.dhcp_proj_ipv4 $ dhcp_ipv4 tap e a);
+      ]
       ~default:
         (Ip.keyed_create_ipv4 ?group ?network:ipv4_network ?gateway:ipv4_gateway
            ~no_init:ipv6_only e a)

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -56,8 +56,8 @@ let no_lease =
   let connect _ _ _ = code ~pos:__POS__ "Lwt.return None" in
   impl ~connect "Lwt" Ip.lease
 
-let generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway ?ipv6_network
-    ?ipv6_gateway ?(arp = Arp.arp) ?tcp tap =
+let generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway
+    ?ipv6_network ?ipv6_gateway ?(arp = Arp.arp) ?tcp tap =
   let ipv4_only = Runtime_arg.ipv4_only ?group ()
   and ipv6_only = Runtime_arg.ipv6_only ?group () in
   let e = Ethernet.ethif tap in
@@ -68,9 +68,7 @@ let generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway ?ip
   in
   let i4 =
     match_impl p
-      [
-        (`Qubes, qubes_ipv4 e a); (`Dhcp, Ip.dhcp_proj_ipv4 $ dhcp_ipv4);
-      ]
+      [ (`Qubes, qubes_ipv4 e a); (`Dhcp, Ip.dhcp_proj_ipv4 $ dhcp_ipv4) ]
       ~default:
         (Ip.keyed_create_ipv4 ?group ?network:ipv4_network ?gateway:ipv4_gateway
            ~no_init:ipv6_only e a)
@@ -80,9 +78,9 @@ let generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway ?ip
       ~no_init:ipv4_only tap e
   in
   let lease =
-    match_impl p [ `Dhcp, Ip.dhcp_proj_lease $ dhcp_ipv4 ] ~default:no_lease
+    match_impl p [ (`Dhcp, Ip.dhcp_proj_lease $ dhcp_ipv4) ] ~default:no_lease
   in
-  keyed_direct_stackv4v6 ~ipv4_only ~ipv6_only ?tcp tap e a i4 i6, lease
+  (keyed_direct_stackv4v6 ~ipv4_only ~ipv6_only ?tcp tap e a i4 i6, lease)
 
 let socket_stackv4v6 ?(group = "") () =
   let v4key = Runtime_arg.V4.network ~group Ipaddr.V4.Prefix.global in
@@ -103,7 +101,8 @@ let socket_stackv4v6 ?(group = "") () =
   impl ~packages ~extra_deps ~connect "Tcpip_stack_socket.V4V6" stackv4v6
 
 (** Generic stack *)
-let generic_stackv4v6_with_lease ?group ?dhcp_requests ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
+let generic_stackv4v6_with_lease ?group ?dhcp_requests
+    ?(dhcp_key = Key.value @@ Key.dhcp ?group ())
     ?(net_key = Key.value @@ Key.net ?group ()) ?ipv4_network ?ipv4_gateway
     ?ipv6_network ?ipv6_gateway ?tcp (tap : Network.network impl) :
     stackv4v6 impl * Ip.lease impl =
@@ -117,16 +116,16 @@ let generic_stackv4v6_with_lease ?group ?dhcp_requests ?(dhcp_key = Key.value @@
   in
   let p = Key.(pure choose $ Key.(value target) $ net_key $ dhcp_key) in
   let generic_ipv4v6_stack =
-    generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway ?ipv6_network
-      ?ipv6_gateway ?tcp tap
+    generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway
+      ?ipv6_network ?ipv6_gateway ?tcp tap
   in
-  match_impl p
-    [ (`Socket, socket_stackv4v6 ?group ()) ]
-    ~default:(fst generic_ipv4v6_stack),
-  match_impl p
-    [ (`Socket, no_lease) ]
-    ~default:(snd generic_ipv4v6_stack)
+  ( match_impl p
+      [ (`Socket, socket_stackv4v6 ?group ()) ]
+      ~default:(fst generic_ipv4v6_stack),
+    match_impl p [ (`Socket, no_lease) ] ~default:(snd generic_ipv4v6_stack) )
 
-let generic_stackv4v6 ?group ?dhcp_key ?net_key ?ipv4_network ?ipv4_gateway ?ipv6_network ?ipv6_gateway ?tcp tap =
-  generic_stackv4v6_with_lease ?group ?dhcp_requests:None ?dhcp_key ?net_key ?ipv4_network ?ipv4_gateway ?ipv6_network ?ipv6_gateway ?tcp tap
+let generic_stackv4v6 ?group ?dhcp_key ?net_key ?ipv4_network ?ipv4_gateway
+    ?ipv6_network ?ipv6_gateway ?tcp tap =
+  generic_stackv4v6_with_lease ?group ?dhcp_requests:None ?dhcp_key ?net_key
+    ?ipv4_network ?ipv4_gateway ?ipv6_network ?ipv6_gateway ?tcp tap
   |> fst

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -1,6 +1,6 @@
 open Functoria.DSL
 
-let dhcp_ipv4 tap e a = Ip.ipv4_of_dhcp tap e a
+let dhcp_ipv4 tap e a = Ip.dhcp_proj_ipv4 $ snd (Ip.ipv4_of_dhcp tap e a)
 
 let qubes_ipv4 ?(qubesdb = Qubesdb.default_qubesdb) e a =
   Ip.ipv4_qubes qubesdb e a

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -52,10 +52,6 @@ let keyed_direct_stackv4v6 ?tcp ~ipv4_only ~ipv6_only network eth arp ipv4 ipv6
   $ Udp.direct_udp ip
   $ match tcp with None -> Tcp.direct_tcp ip | Some tcp -> tcp
 
-let no_lease =
-  let connect _ _ _ = code ~pos:__POS__ "Lwt.return None" in
-  impl ~connect "Lwt" Ip.lease
-
 let generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway
     ?ipv6_network ?ipv6_gateway ?(arp = Arp.arp) ?tcp tap =
   let ipv4_only = Runtime_arg.ipv4_only ?group ()
@@ -78,7 +74,7 @@ let generic_ipv4v6_stack p ?group ?dhcp_requests ?ipv4_network ?ipv4_gateway
       ~no_init:ipv4_only tap e
   in
   let lease =
-    match_impl p [ (`Dhcp, Ip.dhcp_proj_lease $ dhcp_ipv4) ] ~default:no_lease
+    match_impl p [ (`Dhcp, Ip.dhcp_proj_lease $ dhcp_ipv4) ] ~default:Ip.no_lease
   in
   (keyed_direct_stackv4v6 ~ipv4_only ~ipv6_only ?tcp tap e a i4 i6, lease)
 
@@ -122,7 +118,7 @@ let generic_stackv4v6_with_lease ?group ?dhcp_requests
   ( match_impl p
       [ (`Socket, socket_stackv4v6 ?group ()) ]
       ~default:(fst generic_ipv4v6_stack),
-    match_impl p [ (`Socket, no_lease) ] ~default:(snd generic_ipv4v6_stack) )
+    match_impl p [ (`Socket, Ip.no_lease) ] ~default:(snd generic_ipv4v6_stack) )
 
 let generic_stackv4v6 ?group ?dhcp_key ?net_key ?ipv4_network ?ipv4_gateway
     ?ipv6_network ?ipv6_gateway ?tcp tap =

--- a/lib/devices/stack.mli
+++ b/lib/devices/stack.mli
@@ -25,3 +25,16 @@ val generic_stackv4v6 :
   ?tcp:Tcp.tcpv4v6 impl ->
   Network.network impl ->
   stackv4v6 impl
+
+val generic_stackv4v6_with_lease :
+  ?group:string ->
+  ?dhcp_requests:Ip.Dhcp_requests.t ->
+  ?dhcp_key:bool value ->
+  ?net_key:[ `OCaml | `Host ] option value ->
+  ?ipv4_network:Ipaddr.V4.Prefix.t ->
+  ?ipv4_gateway:Ipaddr.V4.t ->
+  ?ipv6_network:Ipaddr.V6.Prefix.t ->
+  ?ipv6_gateway:Ipaddr.V6.t ->
+  ?tcp:Tcp.tcpv4v6 impl ->
+  Network.network impl ->
+  stackv4v6 impl * Ip.lease impl

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -159,6 +159,7 @@ type stackv4v6 = Stack.stackv4v6
 
 let stackv4v6 = Stack.stackv4v6
 let generic_stackv4v6 = Stack.generic_stackv4v6
+let generic_stackv4v6_with_lease = Stack.generic_stackv4v6_with_lease
 let direct_stackv4v6 = Stack.direct_stackv4v6
 
 let tcpv4v6_of_stackv4v6 v =

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -134,6 +134,7 @@ let dhcp_proj_lease = Ip.dhcp_proj_lease
 let create_ipv4 = Ip.create_ipv4
 let create_ipv6 = Ip.create_ipv6
 let create_ipv4v6 = Ip.create_ipv4v6
+let make_dhcp_requests = Ip.Dhcp_requests.make
 let add_dhcp_request = Ip.Dhcp_requests.add
 
 type 'a udp = 'a Udp.udp

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -117,15 +117,23 @@ type 'a ip = 'a Ip.ip
 type ipv4 = Ip.ipv4
 type ipv6 = Ip.ipv6
 type ipv4v6 = Ip.ipv4v6
+type dhcp_ipv4 = Ip.dhcp_ipv4
+type lease = Ip.lease
+type dhcp_requests = Ip.Dhcp_requests.t
 
 let ipv4 = Ip.ipv4
 let ipv6 = Ip.ipv6
 let ipv4_qubes = Ip.ipv4_qubes
 let ipv4v6 = Ip.ipv4v6
+let dhcp_ipv4 = Ip.dhcp_ipv4
+let lease = Ip.lease
 let ipv4_of_dhcp = Ip.ipv4_of_dhcp
+let dhcp_proj_ipv4 = Ip.dhcp_proj_ipv4
+let dhcp_proj_lease = Ip.dhcp_proj_lease
 let create_ipv4 = Ip.create_ipv4
 let create_ipv6 = Ip.create_ipv6
 let create_ipv4v6 = Ip.create_ipv4v6
+let add_dhcp_request = Ip.Dhcp_requests.add
 
 type 'a udp = 'a Udp.udp
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -128,6 +128,7 @@ let ipv4v6 = Ip.ipv4v6
 let dhcp_ipv4 = Ip.dhcp_ipv4
 let lease = Ip.lease
 let ipv4_of_dhcp = Ip.ipv4_of_dhcp
+let dhcp_proj_net = Ip.dhcp_proj_net
 let dhcp_proj_ipv4 = Ip.dhcp_proj_ipv4
 let dhcp_proj_lease = Ip.dhcp_proj_lease
 let create_ipv4 = Ip.create_ipv4

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -196,9 +196,9 @@ type dns_client = Dns.dns_client
 
 let dns_client = Dns.dns_client
 
-let generic_dns_client ?group ?timeout ?nameservers ?cache_size stackv4v6
+let generic_dns_client ?dhcp ?group ?timeout ?nameservers ?cache_size stackv4v6
     happy_eyeballs =
-  Dns.generic_dns_client ?group ?timeout ?nameservers ?cache_size ()
+  Dns.generic_dns_client ?dhcp ?group ?timeout ?nameservers ?cache_size ()
   $ stackv4v6
   $ happy_eyeballs
 

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -131,6 +131,7 @@ let ipv4_of_dhcp = Ip.ipv4_of_dhcp
 let dhcp_proj_net = Ip.dhcp_proj_net
 let dhcp_proj_ipv4 = Ip.dhcp_proj_ipv4
 let dhcp_proj_lease = Ip.dhcp_proj_lease
+let no_lease = Ip.no_lease
 let create_ipv4 = Ip.create_ipv4
 let create_ipv6 = Ip.create_ipv6
 let create_ipv4v6 = Ip.create_ipv4v6

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -522,7 +522,7 @@ val lease : lease typ
 (** The [Dhcp_wire.dhcp_option list option] type. *)
 
 val ipv4_of_dhcp :
-  network impl -> ethernet impl -> arpv4 impl -> dhcp_requests * dhcp_ipv4 impl
+  ?group:string -> ?gateway:Ipaddr.V4.t -> network impl -> ethernet impl -> arpv4 impl -> dhcp_requests * dhcp_ipv4 impl
 (** Configure the interface via DHCP *)
 
 val add_dhcp_request : dhcp_requests -> int -> unit

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -620,6 +620,19 @@ val generic_stackv4v6 :
     If a key is not provided, it uses {!Key.net} (with the [group] argument) to
     create it. *)
 
+val generic_stackv4v6_with_lease :
+  ?group:string ->
+  ?dhcp_requests:dhcp_requests ->
+  ?dhcp_key:bool value ->
+  ?net_key:[ `OCaml | `Host ] option value ->
+  ?ipv4_network:Ipaddr.V4.Prefix.t ->
+  ?ipv4_gateway:Ipaddr.V4.t ->
+  ?ipv6_network:Ipaddr.V6.Prefix.t ->
+  ?ipv6_gateway:Ipaddr.V6.t ->
+  ?tcp:tcpv4v6 impl ->
+  network impl ->
+  stackv4v6 impl * lease impl
+
 val tcpv4v6_of_stackv4v6 : stackv4v6 impl -> tcpv4v6 impl
 (** [tcpv4v6 stackv4v6] is an helper to extract the TCP/IP stack regardless the
     UDP/IP stack expected by some {i devices} such as protocols. *)

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -522,8 +522,11 @@ val lease : lease typ
 (** The [Dhcp_wire.dhcp_option list option] type. *)
 
 val ipv4_of_dhcp :
-  ?group:string -> ?gateway:Ipaddr.V4.t -> network impl -> ethernet impl -> arpv4 impl -> dhcp_requests * dhcp_ipv4 impl
+  ?group:string -> ?dhcp_requests:dhcp_requests -> ?gateway:Ipaddr.V4.t -> network impl -> ethernet impl -> arpv4 impl -> dhcp_ipv4 impl
 (** Configure the interface via DHCP *)
+
+val make_dhcp_requests : unit -> dhcp_requests
+(** [make_dhcp_requests ()] is the empty set of desired dhcp option codes. *)
 
 val add_dhcp_request : dhcp_requests -> int -> unit
 (** [add_dhcp_request requests request] adds the dhcp option code [request] to

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -502,6 +502,9 @@ type 'a ip
 type ipv4 = v4 ip
 type ipv6 = v6 ip
 type ipv4v6 = v4v6 ip
+type dhcp_ipv4
+type lease
+type dhcp_requests
 
 val ipv4 : ipv4 typ
 (** The [Tcpip.Ip.S] module signature with ipaddr = Ipaddr.V4. *)
@@ -512,8 +515,27 @@ val ipv6 : ipv6 typ
 val ipv4v6 : ipv4v6 typ
 (** The [Tcpip.Ip.S] module signature with ipaddr = Ipaddr.t. *)
 
-val ipv4_of_dhcp : network impl -> ethernet impl -> arpv4 impl -> ipv4 impl
+val dhcp_ipv4 : dhcp_ipv4 typ
+(** The [Dhcp_ipv4.S] module signature. *)
+
+val lease : lease typ
+(** The [Dhcp_wire.dhcp_option list option] type. *)
+
+val ipv4_of_dhcp :
+  network impl -> ethernet impl -> arpv4 impl -> dhcp_requests * dhcp_ipv4 impl
 (** Configure the interface via DHCP *)
+
+val add_dhcp_request : dhcp_requests -> int -> unit
+(** [add_dhcp_request requests request] adds the dhcp option code [request] to
+    the desired dhcp options [requests]. *)
+
+val dhcp_proj_ipv4 : (dhcp_ipv4 -> ipv4) impl
+(** Projection from [Dhcp_ipv4.S] to [Tcpip.Ip.S] module signature with ipaddr =
+    Ipaddr.V4.t. *)
+
+val dhcp_proj_lease : (dhcp_ipv4 -> lease) impl
+(** Projection from [Dhcp_ipv4.S] to [Dhcp_wire.dhcp_option list option] type.
+*)
 
 val create_ipv4 : ?group:string -> ethernet impl -> arpv4 impl -> ipv4 impl
 (** Use an IPv4 address Exposes the keys {!Runtime_arg.V4.network} and

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -652,7 +652,13 @@ val tcpv4v6_of_stackv4v6 : stackv4v6 impl -> tcpv4v6 impl
 type resolver
 
 val resolver : resolver typ
-val resolver_dns : ?ns:string list -> stackv4v6 impl -> resolver impl
+
+val resolver_dns :
+  ?dhcp:dhcp_requests * lease impl ->
+  ?ns:string list ->
+  stackv4v6 impl ->
+  resolver impl
+
 val resolver_unix_system : resolver impl
 
 (** {2 Happy-eyeballs} *)

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -522,7 +522,13 @@ val lease : lease typ
 (** The [Dhcp_wire.dhcp_option list option] type. *)
 
 val ipv4_of_dhcp :
-  ?group:string -> ?dhcp_requests:dhcp_requests -> ?gateway:Ipaddr.V4.t -> network impl -> ethernet impl -> arpv4 impl -> dhcp_ipv4 impl
+  ?group:string ->
+  ?dhcp_requests:dhcp_requests ->
+  ?gateway:Ipaddr.V4.t ->
+  network impl ->
+  ethernet impl ->
+  arpv4 impl ->
+  dhcp_ipv4 impl
 (** Configure the interface via DHCP *)
 
 val make_dhcp_requests : unit -> dhcp_requests

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -674,6 +674,7 @@ type dns_client
 val dns_client : dns_client typ
 
 val generic_dns_client :
+  ?dhcp:dhcp_requests * lease impl ->
   ?group:string ->
   ?timeout:int64 ->
   ?nameservers:string list ->

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -529,6 +529,9 @@ val add_dhcp_request : dhcp_requests -> int -> unit
 (** [add_dhcp_request requests request] adds the dhcp option code [request] to
     the desired dhcp options [requests]. *)
 
+val dhcp_proj_net : (dhcp_ipv4 -> network) impl
+(** Projection from [Dhcp_ipv4.S] to [Mirage_net.S] module signature. *)
+
 val dhcp_proj_ipv4 : (dhcp_ipv4 -> ipv4) impl
 (** Projection from [Dhcp_ipv4.S] to [Tcpip.Ip.S] module signature with ipaddr =
     Ipaddr.V4.t. *)

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -519,7 +519,8 @@ val dhcp_ipv4 : dhcp_ipv4 typ
 (** The [Dhcp_ipv4.S] module signature. *)
 
 val lease : lease typ
-(** The [Dhcp_wire.dhcp_option list option] type. *)
+(** The [Dhcp_wire.dhcp_option list option] type. It is [None] when no lease is
+    acquired and otherwise [Some _]. *)
 
 val ipv4_of_dhcp :
   ?group:string ->
@@ -548,6 +549,9 @@ val dhcp_proj_ipv4 : (dhcp_ipv4 -> ipv4) impl
 val dhcp_proj_lease : (dhcp_ipv4 -> lease) impl
 (** Projection from [Dhcp_ipv4.S] to [Dhcp_wire.dhcp_option list option] type.
 *)
+
+val no_lease : lease impl
+(** Constant [None] "lease". *)
 
 val create_ipv4 : ?group:string -> ethernet impl -> arpv4 impl -> ipv4 impl
 (** Use an IPv4 address Exposes the keys {!Runtime_arg.V4.network} and

--- a/lib_runtime/mirage_runtime_network.ml
+++ b/lib_runtime/mirage_runtime_network.ml
@@ -41,6 +41,15 @@ module V4 = struct
     in
     runtime_arg ~doc ~docs ~docv:"PREFIX" ~default ?group ipv4 "ipv4"
 
+  let optional_network ?group ?(docs = Mirage_runtime.s_net) () =
+    let doc =
+      str
+        "The optional network of %a specified as an IP address and netmask, e.g. \
+         192.168.0.1/16 ."
+        pp_group group
+    in
+    runtime_arg ~doc ~docs ~docv:"PREFIX" ~default:None ?group Arg.(some ipv4) "ipv4"
+
   let gateway ?group ?(docs = Mirage_runtime.s_net) default =
     let doc = str "The gateway of %a." pp_group group in
     runtime_arg ~doc ~docs ~docv:"IP" ~default ?group

--- a/lib_runtime/mirage_runtime_network.ml
+++ b/lib_runtime/mirage_runtime_network.ml
@@ -44,11 +44,13 @@ module V4 = struct
   let optional_network ?group ?(docs = Mirage_runtime.s_net) () =
     let doc =
       str
-        "The optional network of %a specified as an IP address and netmask, e.g. \
-         192.168.0.1/16 ."
+        "The optional network of %a specified as an IP address and netmask, \
+         e.g. 192.168.0.1/16 ."
         pp_group group
     in
-    runtime_arg ~doc ~docs ~docv:"PREFIX" ~default:None ?group Arg.(some ipv4) "ipv4"
+    runtime_arg ~doc ~docs ~docv:"PREFIX" ~default:None ?group
+      Arg.(some ipv4)
+      "ipv4"
 
   let gateway ?group ?(docs = Mirage_runtime.s_net) default =
     let doc = str "The gateway of %a." pp_group group in

--- a/lib_runtime/mirage_runtime_network.mli
+++ b/lib_runtime/mirage_runtime_network.mli
@@ -26,6 +26,10 @@ module V4 : sig
   (** A network defined by an address and netmask, [docs] defaults to
       {!Mirage_runtime.s_net}. *)
 
+  val optional_network: ?group:string -> ?docs:string -> unit -> Prefix.t option Term.t
+  (** An optional network defined by an address and netmask, [docs] defaults to
+      {!Mirage_runtime.s_net}. *)
+
   val gateway : ?group:string -> ?docs:string -> t option -> t option Term.t
   (** A default gateway option, [docs] defaults to {!Mirage_runtime.s_net}. *)
 end

--- a/lib_runtime/mirage_runtime_network.mli
+++ b/lib_runtime/mirage_runtime_network.mli
@@ -26,7 +26,8 @@ module V4 : sig
   (** A network defined by an address and netmask, [docs] defaults to
       {!Mirage_runtime.s_net}. *)
 
-  val optional_network: ?group:string -> ?docs:string -> unit -> Prefix.t option Term.t
+  val optional_network :
+    ?group:string -> ?docs:string -> unit -> Prefix.t option Term.t
   (** An optional network defined by an address and netmask, [docs] defaults to
       {!Mirage_runtime.s_net}. *)
 

--- a/test/mirage/describe/run.t
+++ b/test/mirage/describe/run.t
@@ -3,14 +3,14 @@
 Describe before configure (using defaults)
   $ ./config.exe describe -t spt
   Name       describe
-  Keys       dhcp=false (default),
+  Keys       dhcp=true (default),
              net= (default),
              target=spt
 
 Describe before configure (no eval)
   $ ./config.exe describe --no-eval --dot -o-
   Name       describe
-  Keys       dhcp=false (default),
+  Keys       dhcp=true (default),
              net= (default),
              target=unix (default)
   Output     -digraph G {
@@ -44,46 +44,49 @@ Describe before configure (no eval)
                 27 [label="If\ntarget"];
                 28 [label="If\ntarget"];
                 29 [label="ethernet_make__29\nEthernet.Make\n", shape="box"];
-                30 [label="ipv6_make__30\nIpv6.Make\n", shape="box"];
-                31 [label="arp_make__31\nArp.Make\n", shape="box"];
-                32 [label="qubes_db__32\nQubes.DB\n", shape="box"];
-                33 [label="qubesdb_ipv4_make__33\nQubesdb_ipv4.Make\n", shape="box"];
-                34 [label="dhcp_ipv4_make__34\nDhcp_ipv4.Make\n", shape="box"];
-                35 [label="static_ipv4_make__35\nStatic_ipv4.Make\n", shape="box"];
-                36 [label="If\ndhcp, net,\ntarget"];
-                37 [label="tcpip_stack_direct_ipv4v6__37\nTcpip_stack_direct.IPV4V6\n", shape="box"];
-                38 [label="tcp_flow_make__38\nTcp.Flow.Make\n", shape="box"];
-                39 [label="udp_make__39\nUdp.Make\n", shape="box"];
-                40 [label="icmpv4_make__40\nIcmpv4.Make\n", shape="box"];
-                41 [label="tcpip_stack_direct_makev4v6__41\nTcpip_stack_direct.MakeV4V6\n", shape="box"];
-                42 [label="If\ndhcp, net,\ntarget"];
-                43 [label="app__43\nApp\n", shape="box"];
-                44 [label="mirage_runtime__44\nMirage_runtime\n", shape="box"];
-                45 [label="mirage_crypto_rng_mirage__45\nMirage_crypto_rng_mirage\n", shape="box"];
-                46 [label="mirage_mtime__46\nMirage_mtime\n", shape="box"];
-                47 [label="mirage_mtime__47\nMirage_mtime\n", shape="box"];
-                48 [label="mirage_mtime__48\nMirage_mtime\n", shape="box"];
-                49 [label="If\ntarget"];
-                50 [label="If\ntarget"];
-                51 [label="mirage_ptime__51\nMirage_ptime\n", shape="box"];
-                52 [label="mirage_ptime__52\nMirage_ptime\n", shape="box"];
-                53 [label="mirage_ptime__53\nMirage_ptime\n", shape="box"];
-                54 [label="If\ntarget"];
-                55 [label="If\ntarget"];
-                56 [label="mirage_sleep__56\nMirage_sleep\n", shape="box"];
-                57 [label="mirage_sleep__57\nMirage_sleep\n", shape="box"];
-                58 [label="mirage_sleep__58\nMirage_sleep\n", shape="box"];
-                59 [label="If\ntarget"];
-                60 [label="If\ntarget"];
-                61 [label="mirage_logs__61\nMirage_logs\n", shape="box"];
-                62 [label="mirage_runtime__62\nMirage_runtime\n", shape="box"];
-                63 [label="cmdliner_stdlib__63\nCmdliner_stdlib\n", shape="box"];
-                64 [label="mirage_bootvar__64\nMirage_bootvar\n", shape="box"];
-                65 [label="mirage_bootvar__65\nMirage_bootvar\n", shape="box"];
-                66 [label="mirage_bootvar__66\nMirage_bootvar\n", shape="box"];
-                67 [label="If\ntarget"];
-                68 [label="struct_end__68\nstruct end\n", shape="box"];
-                69 [label="mirage_runtime__69\nMirage_runtime\ntarget", shape="box"];
+                30 [label="arp_make__30\nArp.Make\n", shape="box"];
+                31 [label="dhcp_ipv4_make__31\nDhcp_ipv4.Make\n", shape="box"];
+                32 [label="dhcp_ipv4_proj_net__32\nDhcp_ipv4.Proj_net\n", shape="box"];
+                33 [label="If\ndhcp, net,\ntarget"];
+                34 [label="ipv6_make__34\nIpv6.Make\n", shape="box"];
+                35 [label="qubes_db__35\nQubes.DB\n", shape="box"];
+                36 [label="qubesdb_ipv4_make__36\nQubesdb_ipv4.Make\n", shape="box"];
+                37 [label="dhcp_ipv4_proj_ipv4__37\nDhcp_ipv4.Proj_ipv4\n", shape="box"];
+                38 [label="static_ipv4_make__38\nStatic_ipv4.Make\n", shape="box"];
+                39 [label="If\ndhcp, net,\ntarget"];
+                40 [label="tcpip_stack_direct_ipv4v6__40\nTcpip_stack_direct.IPV4V6\n", shape="box"];
+                41 [label="tcp_flow_make__41\nTcp.Flow.Make\n", shape="box"];
+                42 [label="udp_make__42\nUdp.Make\n", shape="box"];
+                43 [label="icmpv4_make__43\nIcmpv4.Make\n", shape="box"];
+                44 [label="tcpip_stack_direct_makev4v6__44\nTcpip_stack_direct.MakeV4V6\n", shape="box"];
+                45 [label="If\ndhcp, net,\ntarget"];
+                46 [label="app__46\nApp\n", shape="box"];
+                47 [label="mirage_runtime__47\nMirage_runtime\n", shape="box"];
+                48 [label="mirage_crypto_rng_mirage__48\nMirage_crypto_rng_mirage\n", shape="box"];
+                49 [label="mirage_mtime__49\nMirage_mtime\n", shape="box"];
+                50 [label="mirage_mtime__50\nMirage_mtime\n", shape="box"];
+                51 [label="mirage_mtime__51\nMirage_mtime\n", shape="box"];
+                52 [label="If\ntarget"];
+                53 [label="If\ntarget"];
+                54 [label="mirage_ptime__54\nMirage_ptime\n", shape="box"];
+                55 [label="mirage_ptime__55\nMirage_ptime\n", shape="box"];
+                56 [label="mirage_ptime__56\nMirage_ptime\n", shape="box"];
+                57 [label="If\ntarget"];
+                58 [label="If\ntarget"];
+                59 [label="mirage_sleep__59\nMirage_sleep\n", shape="box"];
+                60 [label="mirage_sleep__60\nMirage_sleep\n", shape="box"];
+                61 [label="mirage_sleep__61\nMirage_sleep\n", shape="box"];
+                62 [label="If\ntarget"];
+                63 [label="If\ntarget"];
+                64 [label="mirage_logs__64\nMirage_logs\n", shape="box"];
+                65 [label="mirage_runtime__65\nMirage_runtime\n", shape="box"];
+                66 [label="cmdliner_stdlib__66\nCmdliner_stdlib\n", shape="box"];
+                67 [label="mirage_bootvar__67\nMirage_bootvar\n", shape="box"];
+                68 [label="mirage_bootvar__68\nMirage_bootvar\n", shape="box"];
+                69 [label="mirage_bootvar__69\nMirage_bootvar\n", shape="box"];
+                70 [label="If\ntarget"];
+                71 [label="struct_end__71\nstruct end\n", shape="box"];
+                72 [label="mirage_runtime__72\nMirage_runtime\ntarget", shape="box"];
                 
                 3 -> 2 [style="dashed"];
                 3 -> 1 [style="dashed"];
@@ -120,78 +123,82 @@ Describe before configure (no eval)
                 28 -> 24 [style="dotted", headport="n"];
                 28 -> 27 [style="bold", style="dotted", headport="n"];
                 29 -> 28 [];
-                30 -> 28 [];
                 30 -> 29 [];
+                31 -> 28 [];
                 31 -> 29 [];
-                33 -> 32 [];
-                33 -> 29 [];
-                33 -> 31 [];
-                34 -> 28 [];
+                31 -> 30 [];
+                32 -> 31 [];
+                33 -> 32 [style="dotted", headport="n"];
+                33 -> 28 [style="bold", style="dotted", headport="n"];
+                34 -> 33 [];
                 34 -> 29 [];
-                34 -> 31 [];
-                35 -> 29 [];
-                35 -> 31 [];
-                36 -> 33 [style="dotted", headport="n"];
-                36 -> 34 [style="dotted", headport="n"];
-                36 -> 35 [style="bold", style="dotted", headport="n"];
-                37 -> 36 [];
-                37 -> 30 [];
-                38 -> 37 [];
-                39 -> 37 [];
-                40 -> 36 [];
-                41 -> 28 [];
-                41 -> 29 [];
-                41 -> 31 [];
-                41 -> 37 [];
+                36 -> 35 [];
+                36 -> 29 [];
+                36 -> 30 [];
+                37 -> 31 [];
+                38 -> 29 [];
+                38 -> 30 [];
+                39 -> 36 [style="dotted", headport="n"];
+                39 -> 37 [style="dotted", headport="n"];
+                39 -> 38 [style="bold", style="dotted", headport="n"];
+                40 -> 39 [];
+                40 -> 34 [];
                 41 -> 40 [];
-                41 -> 39 [];
-                41 -> 38 [];
-                42 -> 3 [style="dotted", headport="n"];
-                42 -> 41 [style="bold", style="dotted", headport="n"];
-                43 -> 42 [];
-                49 -> 47 [style="dotted", headport="n"];
-                49 -> 48 [style="dotted", headport="n"];
-                49 -> 47 [style="bold", style="dotted", headport="n"];
-                50 -> 46 [style="dotted", headport="n"];
-                50 -> 49 [style="dotted", headport="n"];
-                50 -> 46 [style="bold", style="dotted", headport="n"];
-                54 -> 52 [style="dotted", headport="n"];
-                54 -> 53 [style="dotted", headport="n"];
-                54 -> 52 [style="bold", style="dotted", headport="n"];
-                55 -> 51 [style="dotted", headport="n"];
-                55 -> 54 [style="dotted", headport="n"];
-                55 -> 51 [style="bold", style="dotted", headport="n"];
-                59 -> 57 [style="dotted", headport="n"];
-                59 -> 58 [style="dotted", headport="n"];
-                59 -> 57 [style="bold", style="dotted", headport="n"];
-                60 -> 56 [style="dotted", headport="n"];
-                60 -> 59 [style="dotted", headport="n"];
-                60 -> 56 [style="bold", style="dotted", headport="n"];
-                67 -> 64 [style="dotted", headport="n"];
-                67 -> 64 [style="dotted", headport="n"];
-                67 -> 65 [style="dotted", headport="n"];
-                67 -> 65 [style="dotted", headport="n"];
-                67 -> 65 [style="dotted", headport="n"];
-                67 -> 65 [style="dotted", headport="n"];
-                67 -> 65 [style="dotted", headport="n"];
-                67 -> 66 [style="bold", style="dotted", headport="n"];
-                68 -> 67 [style="dashed"];
-                69 -> 68 [style="dashed"];
-                69 -> 63 [style="dashed"];
-                69 -> 62 [style="dashed"];
-                69 -> 61 [style="dashed"];
-                69 -> 60 [style="dashed"];
-                69 -> 55 [style="dashed"];
-                69 -> 50 [style="dashed"];
-                69 -> 45 [style="dashed"];
-                69 -> 44 [style="dashed"];
-                69 -> 43 [style="dashed"];
+                42 -> 40 [];
+                43 -> 39 [];
+                44 -> 33 [];
+                44 -> 29 [];
+                44 -> 30 [];
+                44 -> 40 [];
+                44 -> 43 [];
+                44 -> 42 [];
+                44 -> 41 [];
+                45 -> 3 [style="dotted", headport="n"];
+                45 -> 44 [style="bold", style="dotted", headport="n"];
+                46 -> 45 [];
+                52 -> 50 [style="dotted", headport="n"];
+                52 -> 51 [style="dotted", headport="n"];
+                52 -> 50 [style="bold", style="dotted", headport="n"];
+                53 -> 49 [style="dotted", headport="n"];
+                53 -> 52 [style="dotted", headport="n"];
+                53 -> 49 [style="bold", style="dotted", headport="n"];
+                57 -> 55 [style="dotted", headport="n"];
+                57 -> 56 [style="dotted", headport="n"];
+                57 -> 55 [style="bold", style="dotted", headport="n"];
+                58 -> 54 [style="dotted", headport="n"];
+                58 -> 57 [style="dotted", headport="n"];
+                58 -> 54 [style="bold", style="dotted", headport="n"];
+                62 -> 60 [style="dotted", headport="n"];
+                62 -> 61 [style="dotted", headport="n"];
+                62 -> 60 [style="bold", style="dotted", headport="n"];
+                63 -> 59 [style="dotted", headport="n"];
+                63 -> 62 [style="dotted", headport="n"];
+                63 -> 59 [style="bold", style="dotted", headport="n"];
+                70 -> 67 [style="dotted", headport="n"];
+                70 -> 67 [style="dotted", headport="n"];
+                70 -> 68 [style="dotted", headport="n"];
+                70 -> 68 [style="dotted", headport="n"];
+                70 -> 68 [style="dotted", headport="n"];
+                70 -> 68 [style="dotted", headport="n"];
+                70 -> 68 [style="dotted", headport="n"];
+                70 -> 69 [style="bold", style="dotted", headport="n"];
+                71 -> 70 [style="dashed"];
+                72 -> 71 [style="dashed"];
+                72 -> 66 [style="dashed"];
+                72 -> 65 [style="dashed"];
+                72 -> 64 [style="dashed"];
+                72 -> 63 [style="dashed"];
+                72 -> 58 [style="dashed"];
+                72 -> 53 [style="dashed"];
+                72 -> 48 [style="dashed"];
+                72 -> 47 [style="dashed"];
+                72 -> 46 [style="dashed"];
                 }
 
 Describe after configure
   $ echo "-txen" > context
   $ ./config.exe describe --context-file=context
   Name       describe
-  Keys       dhcp=false (default),
+  Keys       dhcp=true (default),
              net= (default),
              target=xen

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -34,7 +34,7 @@ Configure the project for Unix:
   ;;
   
   let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
-  # 202 "lib/devices/runtime_arg.ml"
+  # 203 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;
   
@@ -208,7 +208,7 @@ Configure the project for Xen:
   ;;
   
   let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
-  # 202 "lib/devices/runtime_arg.ml"
+  # 203 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;
   

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -34,12 +34,12 @@ Configure the project for Unix:
   ;;
   
   let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
-  # 199 "lib/devices/runtime_arg.ml"
+  # 202 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 379 "lib/mirage.ml"
+  # 390 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -69,7 +69,7 @@ Configure the project for Unix:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 265 "lib/mirage.ml"
+  # 276 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
@@ -106,7 +106,7 @@ Configure the project for Unix:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 274 "lib/mirage.ml"
+  # 285 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -145,7 +145,7 @@ Configure the project for Unix:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 360 "lib/mirage.ml"
+  # 371 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"
@@ -208,12 +208,12 @@ Configure the project for Xen:
   ;;
   
   let mirage_runtime_logs__key = Mirage_runtime.register_arg @@
-  # 199 "lib/devices/runtime_arg.ml"
+  # 202 "lib/devices/runtime_arg.ml"
     Mirage_runtime.logs
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 379 "lib/mirage.ml"
+  # 390 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -243,7 +243,7 @@ Configure the project for Xen:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 265 "lib/mirage.ml"
+  # 276 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
@@ -280,7 +280,7 @@ Configure the project for Xen:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 274 "lib/mirage.ml"
+  # 285 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -319,7 +319,7 @@ Configure the project for Xen:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 360 "lib/mirage.ml"
+  # 371 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -39,7 +39,7 @@ Configure the project for Unix:
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 390 "lib/mirage.ml"
+  # 391 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -69,7 +69,7 @@ Configure the project for Unix:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 276 "lib/mirage.ml"
+  # 277 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
@@ -106,7 +106,7 @@ Configure the project for Unix:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 285 "lib/mirage.ml"
+  # 286 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -145,7 +145,7 @@ Configure the project for Unix:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 371 "lib/mirage.ml"
+  # 372 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"
@@ -213,7 +213,7 @@ Configure the project for Xen:
   ;;
   
   let cmdliner_stdlib_setup_backtracesome_true_randomize_hashtablessome_true___key = Mirage_runtime.register_arg @@
-  # 390 "lib/mirage.ml"
+  # 391 "lib/mirage.ml"
     Cmdliner_stdlib.setup ~backtrace:(Some true) ~randomize_hashtables:(Some true) ()
   ;;
   
@@ -243,7 +243,7 @@ Configure the project for Xen:
   
   let mirage_runtime__4 = lazy (
     let _mirage_runtime_delay = (mirage_runtime_delay__key ()) in
-  # 276 "lib/mirage.ml"
+  # 277 "lib/mirage.ml"
     Mirage_sleep.ns (Duration.of_sec _mirage_runtime_delay)
   );;
   # 52 "mirage/main.ml"
@@ -280,7 +280,7 @@ Configure the project for Xen:
   # 83 "mirage/main.ml"
   
   let mirage_runtime__10 = lazy (
-  # 285 "lib/mirage.ml"
+  # 286 "lib/mirage.ml"
     Mirage_runtime.set_name "random"; Lwt.return_unit
   );;
   # 89 "mirage/main.ml"
@@ -319,7 +319,7 @@ Configure the project for Xen:
     __mirage_crypto_rng_mirage__9 >>= fun _mirage_crypto_rng_mirage__9 ->
     __mirage_runtime__10 >>= fun _mirage_runtime__10 ->
     __app_make__12 >>= fun _app_make__12 ->
-  # 371 "lib/mirage.ml"
+  # 372 "lib/mirage.ml"
     return ()
   );;
   # 128 "mirage/main.ml"


### PR DESCRIPTION
This depends on https://github.com/mirage/charrua/pull/142.

This PR makes available the DHCP lease from `Mirage.ipv4_of_dhcp` to configure other devices. As an example `Mirage.generic_dns_client` is extended so it can get DNS servers from DHCP. Another candidate could be syslog that may use DHCP log server as its log destination.

The code currently compiles, but I am almost certain it's not 100% correct. I am opening a draft PR as I think it is of interest to get early feedback on the overall design. I think the interface is how I want it; what needs work is the code generation that I'm almost certain isn't correct.

The ideas have been tested out in this PR: https://github.com/robur-coop/traceroute/pull/7

The new `Mirage.dhcp_requests` type contains mutable state. This is somewhat straying away from the current style. I think however it has merit. The challenge is that between a device `x` and a `dhcp_ipv4` there is a sort of mutual dependency: `x` wants a lease from `dhcp_ipv4` while `dhcp_ipv4` is required to know what DHCP option `x` and any other dependents are interested in. I think with mutable state we have a somewhat nice way of propagating back from `x` to `dhcp_ipv4` what dhcp options we are interested in.