### PR TITLE
[tcp] introduce tcp-max-open-connections runtime argument

### DIFF
--- a/lib/devices/runtime_arg.ml
+++ b/lib/devices/runtime_arg.ml
@@ -51,6 +51,10 @@ let interface ?group ?docs default =
   runtime_network_key ~pos:__POS__ "interface %a%a%S" pp_group group pp_docs
     docs default
 
+let tcp_max_open_connections ?group ?docs default =
+  runtime_network_key ~pos:__POS__ "tcp_max_open_connections %a%a%d" pp_group
+    group pp_docs docs default
+
 module V4 = struct
   open Ipaddr.V4
 

--- a/lib/devices/runtime_arg.mli
+++ b/lib/devices/runtime_arg.mli
@@ -33,6 +33,10 @@ val v : 'a arg -> Functoria.Runtime_arg.t
 val interface : ?group:string -> ?docs:string -> string -> string runtime_arg
 (** A network interface. *)
 
+val tcp_max_open_connections :
+  ?group:string -> ?docs:string -> int -> int runtime_arg
+(** A limit on the number of open connections for the TCP layer *)
+
 (** Ipv4 Arguments. *)
 module V4 : sig
   open Ipaddr.V4

--- a/lib/devices/stack.ml
+++ b/lib/devices/stack.ml
@@ -40,10 +40,10 @@ let direct_stackv4v6 ?group ?tcp network eth arp ipv4 ipv6 =
   $ ip
   $ Icmp.direct_icmpv4 ipv4
   $ Udp.direct_udp ip
-  $ match tcp with None -> Tcp.direct_tcp ip | Some tcp -> tcp
+  $ match tcp with None -> Tcp.direct_tcp ?group ip | Some tcp -> tcp
 
-let keyed_direct_stackv4v6 ?tcp ~ipv4_only ~ipv6_only network eth arp ipv4 ipv6
-    =
+let keyed_direct_stackv4v6 ?group ?tcp ~ipv4_only ~ipv6_only network eth arp
+    ipv4 ipv6 =
   let ip = Ip.keyed_ipv4v6 ~ipv4_only ~ipv6_only ipv4 ipv6 in
   stackv4v6_direct_conf ()
   $ network
@@ -52,7 +52,7 @@ let keyed_direct_stackv4v6 ?tcp ~ipv4_only ~ipv6_only network eth arp ipv4 ipv6
   $ ip
   $ Icmp.direct_icmpv4 ipv4
   $ Udp.direct_udp ip
-  $ match tcp with None -> Tcp.direct_tcp ip | Some tcp -> tcp
+  $ match tcp with None -> Tcp.direct_tcp ?group ip | Some tcp -> tcp
 
 let generic_ipv4v6_stack p ?group ?ipv4_network ?ipv4_gateway ?ipv6_network
     ?ipv6_gateway ?(arp = Arp.arp) ?tcp tap =
@@ -71,7 +71,7 @@ let generic_ipv4v6_stack p ?group ?ipv4_network ?ipv4_gateway ?ipv6_network
     Ip.keyed_create_ipv6 ?group ?network:ipv6_network ?gateway:ipv6_gateway
       ~no_init:ipv4_only tap e
   in
-  keyed_direct_stackv4v6 ~ipv4_only ~ipv6_only ?tcp tap e a i4 i6
+  keyed_direct_stackv4v6 ?group ~ipv4_only ~ipv6_only ?tcp tap e a i4 i6
 
 let socket_stackv4v6 ?(group = "") () =
   let v4key = Runtime_arg.V4.network ~group Ipaddr.V4.Prefix.global in

--- a/lib/devices/tcp.ml
+++ b/lib/devices/tcp.ml
@@ -8,15 +8,21 @@ let tcp = Functoria.Type.Type TCP
 let tcpv4v6 : tcpv4v6 typ = tcp
 
 (* this needs to be a function due to the value restriction. *)
-let tcp_direct_func () =
+let tcp_direct_func ?group () =
+  let max_open_connections =
+    Runtime_arg.(v (tcp_max_open_connections ?group 1_000))
+  in
+  let runtime_args = [ max_open_connections ] in
   let packages = [ Ip.right_tcpip_library [ "tcp" ] ] in
   let connect _ modname = function
-    | [ ip ] -> code ~pos:__POS__ "%s.connect %s" modname ip
+    | [ ip; max_open_connections ] ->
+        code ~pos:__POS__ "%s.connect ~max_listens:%s %s" modname
+          max_open_connections ip
     | _ -> Misc.connect_err "tcp" 1
   in
-  impl ~packages ~connect "Tcp.Flow.Make" (Ip.ip @-> tcp)
+  impl ~packages ~runtime_args ~connect "Tcp.Flow.Make" (Ip.ip @-> tcp)
 
-let direct_tcp ip = tcp_direct_func () $ ip
+let direct_tcp ?group ip = tcp_direct_func ?group () $ ip
 
 let tcpv4v6_socket_conf ~ipv4_only ~ipv6_only ipv4_key ipv6_key =
   let v = Runtime_arg.v in

--- a/lib/devices/tcp.mli
+++ b/lib/devices/tcp.mli
@@ -7,7 +7,7 @@ val tcp : 'a tcp typ
 type tcpv4v6 = Ip.v4v6 tcp
 
 val tcpv4v6 : tcpv4v6 typ
-val direct_tcp : 'a Ip.ip impl -> 'a tcp impl
+val direct_tcp : ?group:string -> 'a Ip.ip impl -> 'a tcp impl
 
 val tcpv4v6_socket_conf :
   ipv4_only:bool runtime_arg ->

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -549,7 +549,7 @@ val tcp : 'a tcp typ
 (** Implementation of the [Tcpip.Tcp.S] signature. *)
 
 val tcpv4v6 : tcpv4v6 typ
-val direct_tcp : 'a ip impl -> 'a tcp impl
+val direct_tcp : ?group:string -> 'a ip impl -> 'a tcp impl
 
 (** {2 Network stack configuration} *)
 

--- a/lib_runtime/mirage_runtime_network.ml
+++ b/lib_runtime/mirage_runtime_network.ml
@@ -76,6 +76,15 @@ let ipv6_only ?group ?(docs = Mirage_runtime.s_net) () =
   let doc = str "Only use IPv6 for %a." pp_group group in
   runtime_arg ~doc ~docs ?group ~default:false Arg.bool "ipv6-only"
 
+let tcp_max_open_connections ?group ?(docs = Mirage_runtime.s_net) default =
+  let doc =
+    str
+      "Maximum number of open TCP connections for %a. Incoming connections \
+       after that limit are dropped."
+      pp_group group
+  in
+  runtime_arg ~doc ~docs ?group ~default Arg.int "tcp-max-open-connections"
+
 let resolver ?group ?(docs = Mirage_runtime.s_net) ?default () =
   let doc = str "DNS resolver (default to anycast.censurfridns.dk)" in
   runtime_arg ~doc ~docv:"IP" ~docs ?group ~default

--- a/lib_runtime/mirage_runtime_network.mli
+++ b/lib_runtime/mirage_runtime_network.mli
@@ -56,6 +56,10 @@ val ipv6_only : ?group:string -> ?docs:string -> unit -> bool Term.t
 (** An option for dual stack to only use IPv6, [docs] defaults to
     {!Mirage_runtime.s_net}. *)
 
+val tcp_max_open_connections :
+  ?group:string -> ?docs:string -> int -> int Term.t
+(** The maximum number of open TCP connections. *)
+
 val resolver :
   ?group:string ->
   ?docs:string ->


### PR DESCRIPTION
Companion PR to https://github.com/mirage/mirage-tcpip/pull/535. This introduces the `--tcp-max-open-connections` to customize the maximum amount of listening TCP connections, which defaults to 1000.

**TODO** before considering this PR for merging, if and when https://github.com/mirage/mirage-tcpip/pull/535 is merged and released, raise upper bound for `mirage-tcpip`

See also https://github.com/mirage/mirage-tcpip/issues/534