### PR TITLE
ipv4_dhcp_conf: add as a DHCP option the hostname

### DIFF
--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -70,8 +70,10 @@ let ipv4_dhcp_conf ~ip ~gateway ~no_init requests =
         let requests = Dhcp_requests.consume requests in
         code ~pos:__POS__
           "let requests =@[@ Option.map (List.map \
-           Dhcp_wire.int_to_option_code_exn)@ %a@]@ in@ %s.connect@[@ \
-           ?requests@ ~no_init:%s@ ?cidr:%s@ ?gateway:%s@ %s@ %s@ %s@]"
+           Dhcp_wire.int_to_option_code_exn)@ %a@]@ in@ let options = [ \
+           Dhcp_wire.Hostname (Mirage_runtime.name ()) ] in@ %s.connect@[@ \
+           ~no_init:%s@ ?cidr:%s@ ?gateway:%s@ ?requests@ ~options@ %s@ %s@ \
+           %s@]"
           Fmt.(parens (Dump.option (Dump.list int)))
           requests modname no_init ip gateway network ethernet arp
     | _ -> Misc.connect_err "ipv4 dhcp" 6


### PR DESCRIPTION
We use the previously added (in #1611) `--name` boot argument