### PR TITLE
Fix OCaml CI

### DIFF
--- a/test/functoria/e2e/errors.t
+++ b/test/functoria/e2e/errors.t
@@ -3,7 +3,7 @@ of a device's connect function:
 
   $ ./test.exe configure -f errors/in_device.ml
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
-  $ dune build
+  $ dune build | grep -v "Hint: "
   File "errors/in_device.ml", line 6, characters 2-26:
   Error: Unbound value Unikernel_make__4.start'
   Hint: Did you mean start?
@@ -23,7 +23,7 @@ Then, not enough:
 
   $ ./test.exe configure -f errors/in_functor_not_enough.ml
   test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
-  $ dune build
+  $ dune build | grep -v 'File "errors/test/main.ml"'
   File "errors/test/main.ml", line 34, characters 3-26:
   Error: The module Unikernel_make__4 is a functor, it cannot have any components
   [1]

--- a/test/mirage/random/run-opam-git.t
+++ b/test/mirage/random/run-opam-git.t
@@ -24,6 +24,7 @@ Make an empty commit and rename it to main. Otherwise we don't have any branches
 Configure the project for Unix:
 
   $ mirage configure -t unix
+  mirage: [WARNING] Skipping version check, since our_version is not watermarked
   Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
 
 Check the source url of the generated opam package
@@ -38,6 +39,7 @@ Now, let's use a remote with ssh transport:
 Configure the project again for Unix:
 
   $ mirage configure -t unix
+  mirage: [WARNING] Skipping version check, since our_version is not watermarked
   Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
 
 Check the source url of the generated opam package

--- a/test/mirage/random/run.t
+++ b/test/mirage/random/run.t
@@ -1,6 +1,7 @@
 Configure the project for Unix:
 
   $ mirage configure -t unix
+  mirage: [WARNING] Skipping version check, since our_version is not watermarked
   Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   $ ls . mirage/
   .:
@@ -169,6 +170,7 @@ Configure the project for Unix:
 Configure the project for Xen:
 
   $ mirage configure -t xen
+  mirage: [WARNING] Skipping version check, since our_version is not watermarked
   Successfully configured the unikernel. Now run 'make' (or more fine-grained steps: 'make all', 'make depends', or 'make lock').
   $ ls . mirage/
   .:


### PR DESCRIPTION
This is an attempt to fix OCaml-CI issues:

```
File "test/functoria/e2e/errors.t", line 1, characters 0-0:
/usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/functoria/e2e/errors.t _build/default/test/functoria/e2e/errors.t.corrected
diff --git a/_build/default/test/functoria/e2e/errors.t b/_build/default/test/functoria/e2e/errors.t.corrected
index 637ded6..7a1c9e0 100644
--- a/_build/default/test/functoria/e2e/errors.t
+++ b/_build/default/test/functoria/e2e/errors.t.corrected
@@ -6,7 +6,7 @@ of a device's connect function:
$ dune build
File "errors/in_device.ml", line 6, characters 2-26:
Error: Unbound value Unikernel_make__4.start'
-  Hint: Did you mean start?
+  Hint:   Did you mean Unikernel_make__4.start?
[1]
$ ./test.exe clean -f errors/in_device.ml


@@ -24,7 +24,7 @@ Then, not enough:
$ ./test.exe configure -f errors/in_functor_not_enough.ml
test.exe: [WARNING] Skipping version check, since our_version ("1.0~test") fails to parse: only digits and . allowed in version
$ dune build
-  File "errors/test/main.ml", line 34, characters 3-26:
+  File "errors/test/main.ml", line 34, characters 3-20:
Error: The module Unikernel_make__4 is a functor, it cannot have any components
[1]
$ ./test.exe clean -f errors/in_functor_not_enough.ml
"/usr/bin/env" "bash" "-c" "opam exec -- dune build @install @check @runtest && rm -rf _build" failed with exit status 1
2026-05-05 11:43.04: Job failed: Failed: Build failed
```