### PR TITLE
Mirage_runtime_network: use "-" instead of "_" in boot arguments

### DIFF
--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -182,7 +182,6 @@ let with_argv =
       ]
 
 let runtime_args = Functoria_runtime.runtime_args
-let register = Functoria_runtime.register_arg
 let register_arg = Functoria_runtime.register_arg
 let argument_error = Functoria_runtime.argument_error
 let help_version = Functoria_runtime.help_version

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -144,11 +144,5 @@ val register_arg : 'a Cmdliner.Term.t -> (unit -> 'a)
 val with_argv : unit Cmdliner.Term.t list -> string -> string array -> unit
 val runtime_args : unit -> unit Cmdliner.Term.t list
 
-val register : 'a Cmdliner.Term.t -> (unit -> 'a)
-(* the return value is (unit -> 'a), let's keep the parens although they're
-   superfluous. *)
-[@@ocamlformat "disable"]
-[@@ocaml.deprecated "Use Mirage_runtime.register_arg instead."]
-
 val set_name : string -> unit
 (** Set the name of the unikernel, called at load time for the default name. *)

--- a/lib_runtime/mirage_runtime_network.ml
+++ b/lib_runtime/mirage_runtime_network.ml
@@ -97,55 +97,55 @@ let dns_servers ?group ?(docs = Mirage_runtime.s_dns) default =
   let doc = str "DNS servers (default to anycast.censurfridns.dk)" in
   runtime_arg ~doc ~docv:"DNS-SERVER" ~docs ?group ~default
     Arg.(some (list string))
-    "dns_servers"
+    "dns-servers"
 
 let dns_timeout ?group ?(docs = Mirage_runtime.s_dns) default =
   let doc = str "DNS timeout (in nanoseconds)" in
   runtime_arg ~doc ~docv:"DNS-TIMEOUT" ~docs ?group ~default
     Arg.(some int64)
-    "dns_timeout"
+    "dns-timeout"
 
 let dns_cache_size ?group ?(docs = Mirage_runtime.s_dns) default =
   let doc = str "DNS cache size" in
   runtime_arg ~doc ~docv:"DNS-CACHE-SIZE" ~docs ?group ~default
     Arg.(some int)
-    "dns_cache_size"
+    "dns-cache-size"
 
 let he_aaaa_timeout ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "AAAA timeout (in nanoseconds)" in
   runtime_arg ~doc ~docv:"AAAA-TIMEOUT" ~docs ?group ~default
     Arg.(some int64)
-    "he_aaaa_timeout"
+    "he-aaaa-timeout"
 
 let he_connect_delay ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "Delay (in nanoseconds) for connection establishment" in
   runtime_arg ~doc ~docv:"CONNECT-DELAY" ~docs ?group ~default
     Arg.(some int64)
-    "he_connect_delay"
+    "he-connect-delay"
 
 let he_connect_timeout ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "Connection establishment timeout (in nanoseconds)" in
   runtime_arg ~doc ~docv:"CONNECT-TIMEOUT" ~docs ?group ~default
     Arg.(some int64)
-    "he_connect_timeout"
+    "he-connect-timeout"
 
 let he_resolve_timeout ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "DNS resolution timeout (in nanoseconds)" in
   runtime_arg ~doc ~docv:"RESOLVE-TIMEOUT" ~docs ?group ~default
     Arg.(some int64)
-    "he_resolve_timeout"
+    "he-resolve-timeout"
 
 let he_resolve_retries ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "Amount of DNS resolution attempts" in
   runtime_arg ~doc ~docv:"RESOLVE-RETRIES" ~docs ?group ~default
     Arg.(some int)
-    "he_resolve_retries"
+    "he-resolve-retries"
 
 let he_timer_interval ?group ?(docs = Mirage_runtime.s_he) default =
   let doc = str "Interal (in nanoseconds) for execution of the timer" in
   runtime_arg ~doc ~docv:"TIMER-INTERVAL" ~docs ?group ~default
     Arg.(some int64)
-    "he_timer_interval"
+    "he-timer-interval"
 
 let ssh_key ?group ?(docs = Mirage_runtime.s_ssh) default =
   let doc = str "Private SSH key (rsa:<seed> or ed25519:<b64-key>)." in


### PR DESCRIPTION
dns-servers (was dns_servers),
dns-timeout (was dns_timeout),
dns-cache-size (was dns_cache_size),
he-aaaa-timeout (was he_aaaa_timeout),
he-connect-delay (was he_connect_delay),
he-connect-timeout (was he_connect_timeout),
he-resolve-timeout (was he_resolve_timeout),
he-resolve-retries (was he_resolve_retries),
he-timer-interval (was he_timer_interval)

//cc @reynir 

Since this is breaking, I also removed the deprecated Mirage_runtime.register binding.