### PR TITLE
doc: --no-dhcp *disables* dhcp

### DIFF
--- a/lib/devices/key.ml
+++ b/lib/devices/key.ml
@@ -147,7 +147,7 @@ let configure_flag ?(group = "") ~doc name =
   Key.create (prefix ^ name) key
 
 let no_dhcp ?group () =
-  let doc = Fmt.str "Enable dhcp for %a." pp_group group in
+  let doc = Fmt.str "Disable dhcp for %a." pp_group group in
   configure_flag ~doc ?group "no-dhcp"
 
 let utcp ?group () =


### PR DESCRIPTION
The docstring for `--no-dhcp` was kept from the `--dhcp=...` option in #1636 even though the semantics are inverted.