### PR TITLE
Add a new arg for dhcp request

### DIFF
--- a/lib/devices/ip.ml
+++ b/lib/devices/ip.ml
@@ -71,7 +71,7 @@ let ipv4_dhcp_conf ~ip ~gateway ~no_init requests =
         code ~pos:__POS__
           "let requests =@[@ Option.map (List.map \
            Dhcp_wire.int_to_option_code_exn)@ %a@]@ in@ let options = [ \
-           Dhcp_wire.Hostname (Mirage_runtime.name ()) ] in@ %s.connect@[@ \
+           Dhcp_wire.Hostname (Mirage_runtime.hostname ()) ] in@ %s.connect@[@ \
            ~no_init:%s@ ?cidr:%s@ ?gateway:%s@ ?requests@ ~options@ %s@ %s@ \
            %s@]"
           Fmt.(parens (Dump.option (Dump.list int)))

--- a/lib/functoria/info.ml
+++ b/lib/functoria/info.ml
@@ -22,6 +22,7 @@ type t = {
   config_file : Fpath.t;
   name : string;
   project_name : string;
+  hostname : string;
   output : string option;
   keys : Key.Set.t;
   runtime_args : Runtime_arg.Set.t;
@@ -36,6 +37,7 @@ type t = {
 }
 
 let name t = t.name
+let hostname t = t.hostname
 let project_name t = t.project_name
 let config_file t = t.config_file
 
@@ -70,7 +72,7 @@ let context t = t.context
 
 let v ?(config_file = Fpath.v "config.ml") ~packages ~local_libs ~keys
     ~runtime_args ~context ?configure_cmd ?pre_build_cmd ?lock_location
-    ~build_cmd ~src ~project_name name =
+    ~build_cmd ~src ~project_name ?hostname name =
   let keys = Key.Set.of_list keys in
   let runtime_args = Runtime_arg.Set.of_list runtime_args in
   let opam ~extra_repo ~install ~opam_name =
@@ -78,6 +80,7 @@ let v ?(config_file = Fpath.v "config.ml") ~packages ~local_libs ~keys
       ?configure:configure_cmd ?pre_build:pre_build_cmd ?lock_location
       ~build:build_cmd ~src ~opam_name name
   in
+  let hostname = Option.value hostname ~default:name in
   let packages =
     List.fold_left
       (fun m p ->
@@ -93,6 +96,7 @@ let v ?(config_file = Fpath.v "config.ml") ~packages ~local_libs ~keys
   {
     config_file;
     name;
+    hostname;
     project_name;
     keys;
     runtime_args;

--- a/lib/functoria/info.mli
+++ b/lib/functoria/info.mli
@@ -27,6 +27,9 @@ val config_file : t -> Fpath.t
 val name : t -> string
 (** [name t] is the name of the application. *)
 
+val hostname : t -> string
+(** [hostname t] is the hostname of the application. *)
+
 val project_name : t -> string
 (** [project_name t] is the project name. *)
 
@@ -80,6 +83,7 @@ val v :
   build_cmd:(Fpath.t option -> string) ->
   src:[ `Auto | `None | `Some of string ] ->
   project_name:string ->
+  ?hostname:string ->
   string ->
   t
 (** [create context n r] contains information about the application being built.

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -280,6 +280,7 @@ let delay_startup =
   impl ~packages ~runtime_args ~connect "Mirage_runtime" delay
 
 let unikernel_name = Functoria.job
+let unikernel_hostname = Functoria.job
 
 let unikernel_name =
   let connect i _ _ =
@@ -287,6 +288,13 @@ let unikernel_name =
       (Info.name i)
   in
   impl ~connect "Mirage_runtime" unikernel_name
+
+let unikernel_hostname =
+  let connect i _ _ =
+    code ~pos:__POS__ "Mirage_runtime.set_hostname %S; Lwt.return_unit"
+      (Info.hostname i)
+  in
+  impl ~connect "Mirage_runtime" unikernel_hostname
 
 (** Functoria devices *)
 
@@ -421,6 +429,7 @@ let register ?(argv = default_argv) ?(reporter = default_reporter ())
     ++ Some mtime
     ++ Some random
     ++ Some unikernel_name
+    ++ Some unikernel_hostname
   in
   register ?init ?src name jobs
 

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -140,7 +140,7 @@ let hostname_k =
       ~doc:
         "Hostname of the unikernel. Accessible with `Mirage_runtime.hostname` \
          (), used for DHCP request."
-      ~absent:"defaults to `name`" [ "hostname" ]
+      ~absent:"defaults to `name`" [ "dhcp-hostname" ]
   in
   Arg.(value & opt (some' string) None doc)
 

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -134,8 +134,20 @@ let name_k =
   in
   Arg.(value & opt (some' string) None doc)
 
+let hostname_k =
+  let doc =
+    Arg.info ~docs:Cmdliner.Manpage.s_common_options
+      ~doc:
+        "Hostname of the unikernel. Accessible with `Mirage_runtime.hostname` \
+         (), used for DHCP request."
+      ~absent:"defaults to `name`" [ "hostname" ]
+  in
+  Arg.(value & opt (some' string) None doc)
+
 let _name : string option ref = ref None
+let _hostname : string option ref = ref None
 let set_name s = _name := Some s
+let set_hostname s = _hostname := Some s
 
 let name =
   let r = Functoria_runtime.register_arg name_k in
@@ -144,6 +156,14 @@ let name =
     | Some x, _ -> x
     | None, Some x -> x
     | None, None -> "no-name"
+
+let hostname =
+  let r = Functoria_runtime.register_arg hostname_k in
+  fun () ->
+    match (r (), !_hostname) with
+    | Some x, _ -> x
+    | None, Some x -> x
+    | None, None -> name ()
 
 (* Hooks *)
 

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -82,10 +82,18 @@ val delay : int Term.t
 val name_k : string option Term.t
 (** The name key. *)
 
+val hostname_k : string option Term.t
+(** The hostname key. *)
+
 val name : unit -> string
 (** The current name of the unikernel. This is expected to be the same during
     the lifetime of an unikernel (but there's no guarantee since it can be
     modified). *)
+
+val hostname : unit -> string
+(** The current hostname of the unikernel. This is expected to be the same
+    during the lifetime of an unikernel (but there's no guarantee since it can
+    be modified). *)
 
 (** {2 Registering scheduler hooks} *)
 
@@ -146,3 +154,7 @@ val runtime_args : unit -> unit Cmdliner.Term.t list
 
 val set_name : string -> unit
 (** Set the name of the unikernel, called at load time for the default name. *)
+
+val set_hostname : string -> unit
+(** Set the hostname of the unikernel, called at load time for the default
+    hostname. *)


### PR DESCRIPTION
While working on an orchestration system [Mollymawk](https://github.com/robur-coop/mollymawk) for MirageOs unikernels deployed on [Albatross](https://github.com/robur-coop/albatross), we ran into a unique issue with the unikernel `--name` arg.
The goal is to autoscale unikernels based on load.
The problem is, when a unikernel scales, and we repeat it's `--name` value to the clone, then this becomes problematic in the sense that we then have two unikernels reporting metrics under the same name. What we really want is for both unikernels (primary and clone) to request for a dhcp lease with the same hostname, but keep unique names for any other purpose. 
This PR adds a new `--dhcp-hostname` for requesting the dhcp lease, and the default value is whatever `--name` is.