### PR TITLE
Avoid RSS memory leaks: call malloc_trim

### DIFF
--- a/lib_runtime/dune
+++ b/lib_runtime/dune
@@ -2,6 +2,9 @@
  (name mirage_runtime)
  (public_name mirage-runtime)
  (modules mirage_runtime)
+ (foreign_stubs
+  (language c)
+  (names stub_mirage_runtime))
  (libraries mirage-runtime.functoria lwt logs))
 
 (library

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -189,7 +189,7 @@ let help_version = Functoria_runtime.help_version
 external malloc_trim : int -> bool = "stub_malloc_trim_noalloc" [@@noalloc]
 
 let trim_on_major_cycle () =
-  let (_ : bool) = malloc_trim (1 lsl 22) in ()
+  let (_ : bool) = malloc_trim (1 lsl 22) in
+  ()
 
-let (_ : Gc.alarm) =
-  Gc.create_alarm trim_on_major_cycle
+let (malloc_trim_alarm : Gc.alarm) = Gc.create_alarm trim_on_major_cycle

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -185,3 +185,5 @@ let runtime_args = Functoria_runtime.runtime_args
 let register_arg = Functoria_runtime.register_arg
 let argument_error = Functoria_runtime.argument_error
 let help_version = Functoria_runtime.help_version
+
+external malloc_trim : int -> bool = "stub_malloc_trim_noalloc" [@@noalloc]

--- a/lib_runtime/mirage_runtime.ml
+++ b/lib_runtime/mirage_runtime.ml
@@ -187,3 +187,9 @@ let argument_error = Functoria_runtime.argument_error
 let help_version = Functoria_runtime.help_version
 
 external malloc_trim : int -> bool = "stub_malloc_trim_noalloc" [@@noalloc]
+
+let trim_on_major_cycle () =
+  let (_ : bool) = malloc_trim (1 lsl 22) in ()
+
+let (_ : Gc.alarm) =
+  Gc.create_alarm trim_on_major_cycle

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -146,3 +146,5 @@ val runtime_args : unit -> unit Cmdliner.Term.t list
 
 val set_name : string -> unit
 (** Set the name of the unikernel, called at load time for the default name. *)
+
+val malloc_trim: int -> bool

--- a/lib_runtime/mirage_runtime.mli
+++ b/lib_runtime/mirage_runtime.mli
@@ -147,4 +147,5 @@ val runtime_args : unit -> unit Cmdliner.Term.t list
 val set_name : string -> unit
 (** Set the name of the unikernel, called at load time for the default name. *)
 
-val malloc_trim: int -> bool
+val malloc_trim : int -> bool
+val malloc_trim_alarm : Gc.alarm

--- a/lib_runtime/stub_mirage_runtime.c
+++ b/lib_runtime/stub_mirage_runtime.c
@@ -1,0 +1,15 @@
+#define CAML_NAME_SPACE
+#include "caml/mlvalues.h"
+
+#ifdef __GLIBC__
+#include <malloc.h>
+#else
+
+static int malloc_trim(size_t pad) { return 0; }
+#endif
+
+CAMLprim value stub_malloc_trim_noalloc(value const val_pad) {
+  long const pad = Long_val(val_pad);
+  return Val_bool(pad >= 0 && malloc_trim(pad));
+}
+

--- a/test/mirage/memory/dune
+++ b/test/mirage/memory/dune
@@ -1,0 +1,7 @@
+(test
+ (name test_malloc_trim)
+ ; malloc_trim is glibc specific, so restrict to Linux
+ ; /proc/self/smaps_rollup is Linux specific too
+ (enabled_if
+  (= %{system} linux))
+ (libraries mirage-runtime))

--- a/test/mirage/memory/test_malloc_trim.ml
+++ b/test/mirage/memory/test_malloc_trim.ml
@@ -1,0 +1,94 @@
+let find_rss str =
+  try Scanf.sscanf str "Rss: %d kB" Option.some
+  with Scanf.Scan_failure _ -> None
+
+let find_rss_slow ch =
+  let (_skip_first_line : string) = input_line ch in
+  Seq.of_dispenser (fun () -> In_channel.input_line ch) |> Seq.find_map find_rss
+
+(** [get_rss_slow ()] returns the Resident Set Size of the current process.
+
+    See [proc_pid_statm(5)]: the RSS values reported in [/proc/self/stat],
+    [/proc/self/statm], and [/proc/self/status] are inaccurate. Accurate values
+    are in [/proc/self/smaps] and [/proc/self/smaps_rollup] although these are
+    slower to query.
+
+    This function is used in unit tests, so accuracy is preferred.
+
+    There is no POSIX function to retrieve current RSS usage, [getrusage(2)] can
+    only return MaxRSS. *)
+let get_rss_slow () =
+  Gc.compact ();
+  let r =
+    In_channel.with_open_text "/proc/self/smaps_rollup" find_rss_slow
+    |> Option.get
+  in
+  Gc.compact ();
+  r
+
+let n = 1 lsl 14
+let m = 509 (* 509 + 3 words overhead for large arrays -> 512*8 = 4096 *)
+
+let test () =
+  try
+    let rss0 = get_rss_slow () in
+    let a = Array.make 4 [||] in
+
+    a.(0) <- Array.make_matrix n m 0;
+    a.(1) <- Array.make_matrix 1 m 0;
+    a.(2) <- Array.make_matrix n m 0;
+    a.(3) <- Array.make_matrix 1 m 0;
+
+    (* RSS should've increase here *)
+    let rss1 = get_rss_slow () in
+
+    (* Now free the middle values.
+         Do not free the last value, that'd get immediately returned by glibc.
+       *)
+    a.(0) <- [||];
+    a.(2) <- [||];
+
+    (* This frees the values from the OCaml side,
+         but glibc might retain them *)
+    Gc.compact ();
+
+    let rss2 = get_rss_slow () in
+
+    (* keep it alive across the [Gc.compact] *)
+    let _alive = Sys.opaque_identity a in
+    Gc.compact ();
+
+    let rss3 = get_rss_slow () in
+    Printf.printf "RSS0: %d kB\n" rss0;
+    Printf.printf "RSS1: %d kB\n" rss1;
+    Printf.printf "RSS2: %d kB\n" rss2;
+    Printf.printf "RSS3: %d kB\n" rss3;
+    assert (rss0 < rss1);
+
+    (* not accounting for OCaml value overhead the 2 arrays
+         are at least this many bytes
+       *)
+    let expected_kb = 2 * n * m * Sys.word_size / 8 / 1024 in
+    Printf.printf "Expected decrease: %d kB\n" expected_kb;
+    let actual_kb = rss1 - rss2 in
+    Printf.printf "Actual decrease RSS1-RSS2: %d kB\n" actual_kb;
+    if actual_kb < expected_kb then
+      failwith "OCaml released memory, but libc didn't"
+  with Sys_error e ->
+    (* maybe the kernel doesn't have support compiled in *)
+    Printf.eprintf "SKIP: %s\n" e
+
+let () =
+  (* ensure module is linked and initializers run *)
+  Mirage_runtime.set_name "test_malloc_trim";
+  test ();
+  test ();
+  Printf.printf "Disabling malloc_trim workaround\n";
+  Gc.delete_alarm Mirage_runtime.malloc_trim_alarm;
+  try
+    test ();
+    (* the behaviour of glibc can change over time, so don't fail if it works
+       without malloc_trim
+     *)
+    Printf.printf "Succeeded even without malloc_trim"
+  with Failure e -> Printf.eprintf "Ignoring expected failure: %s\n" e


### PR DESCRIPTION
    Before:
    ```
    $ ulimit -v 440000;OCAMLRUNPARAM=d=1 dist/memory)
    [...]
    2026-07-07T08:28:26+01:00: [INFO] [application] Done
    2026-07-07T08:28:26+01:00: [INFO] [application] Allocating a total of 36372480 words
    2026-07-07T08:28:26+01:00: [INFO] [application] Allocating 141802 * 254 = 36017708 words
    2026-07-07T08:28:26+01:00: [INFO] [application] Done
    2026-07-07T08:28:26+01:00: [INFO] [application] Allocating a total of 36372480 words
    Fatal error: caml_skiplist_insert: out of memory
    
    $ /bin/time dist/memory
    5.34user 0.20system 0:05.55elapsed 99%CPU (0avgtext+0avgdata 583236maxresident)k
    0inputs+0outputs (0major+145230minor)pagefaults 0swaps
    ```
    
    After:
    ```
    time dist/memory
    4.92user 0.94system 0:05.87elapsed 99%CPU (0avgtext+0avgdata 295536maxresident)k
    0inputs+0outputs (0major+446311minor)pagefaults 0swaps
    ```

Draft PR, because I also need to open a PR with the testcase.