### PR TITLE
Remove `mirage-opam-overlays` from default repositories

### DIFF
--- a/lib/functoria/cli.ml
+++ b/lib/functoria/cli.ml
@@ -94,8 +94,7 @@ let extra_repos doc_section =
       ~doc:
         "Additional opam-repositories to use when using `opam monorepo lock' \
          to gather local sources. Default: \
-         https://github.com/dune-universe/opam-overlays.git & \
-         https://github.com/dune-universe/mirage-opam-overlays.git."
+         https://github.com/dune-universe/opam-overlays.git."
       [ "extra-repos" ]
   in
   Arg.(
@@ -103,8 +102,6 @@ let extra_repos doc_section =
     & opt (list key)
         [
           ("opam-overlays", "https://github.com/dune-universe/opam-overlays.git");
-          ( "mirage-overlays",
-            "https://github.com/dune-universe/mirage-opam-overlays.git" );
         ]
     & doc)
 

--- a/test/functoria/e2e/help.t
+++ b/test/functoria/e2e/help.t
@@ -37,12 +37,11 @@ Test that the help command works without config file:
              Display I/O actions instead of executing them.
   
          --extra-repos=NAME1:URL1,NAME2:URL2,...
-         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git,mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git
+         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git
          or MIRAGE_EXTRA_REPOS env)
              Additional opam-repositories to use when using `opam monorepo
              lock' to gather local sources. Default:
-             https://github.com/dune-universe/opam-overlays.git &
-             https://github.com/dune-universe/mirage-opam-overlays.git.
+             https://github.com/dune-universe/opam-overlays.git.
   
          -f FILE, --file=FILE, --config-file=FILE (absent=config.ml)
              The configuration file to use.

--- a/test/functoria/test_cli.ml
+++ b/test/functoria/test_cli.ml
@@ -39,8 +39,6 @@ let test_configure () =
               [
                 ( "opam-overlays",
                   "https://github.com/dune-universe/opam-overlays.git" );
-                ( "mirage-overlays",
-                  "https://github.com/dune-universe/mirage-opam-overlays.git" );
               ];
             args =
               {

--- a/test/mirage/help/configure-o.t
+++ b/test/mirage/help/configure-o.t
@@ -28,12 +28,11 @@ Help configure -o --man-format=plain
              Display I/O actions instead of executing them.
   
          --extra-repos=NAME1:URL1,NAME2:URL2,...
-         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git,mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git
+         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git
          or MIRAGE_EXTRA_REPOS env)
              Additional opam-repositories to use when using `opam monorepo
              lock' to gather local sources. Default:
-             https://github.com/dune-universe/opam-overlays.git &
-             https://github.com/dune-universe/mirage-opam-overlays.git.
+             https://github.com/dune-universe/opam-overlays.git.
   
          -f FILE, --file=FILE, --config-file=FILE (absent=config.ml)
              The configuration file to use.
@@ -122,12 +121,11 @@ Help configure -o --help=plain
              Display I/O actions instead of executing them.
   
          --extra-repos=NAME1:URL1,NAME2:URL2,...
-         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git,mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git
+         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git
          or MIRAGE_EXTRA_REPOS env)
              Additional opam-repositories to use when using `opam monorepo
              lock' to gather local sources. Default:
-             https://github.com/dune-universe/opam-overlays.git &
-             https://github.com/dune-universe/mirage-opam-overlays.git.
+             https://github.com/dune-universe/opam-overlays.git.
   
          -f FILE, --file=FILE, --config-file=FILE (absent=config.ml)
              The configuration file to use.

--- a/test/mirage/help/configure.t
+++ b/test/mirage/help/configure.t
@@ -28,12 +28,11 @@ Help configure --man-format=plain
              Display I/O actions instead of executing them.
   
          --extra-repos=NAME1:URL1,NAME2:URL2,...
-         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git,mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git
+         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git
          or MIRAGE_EXTRA_REPOS env)
              Additional opam-repositories to use when using `opam monorepo
              lock' to gather local sources. Default:
-             https://github.com/dune-universe/opam-overlays.git &
-             https://github.com/dune-universe/mirage-opam-overlays.git.
+             https://github.com/dune-universe/opam-overlays.git.
   
          -f FILE, --file=FILE, --config-file=FILE (absent=config.ml)
              The configuration file to use.
@@ -122,12 +121,11 @@ Configure help --help=plain
              Display I/O actions instead of executing them.
   
          --extra-repos=NAME1:URL1,NAME2:URL2,...
-         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git,mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git
+         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git
          or MIRAGE_EXTRA_REPOS env)
              Additional opam-repositories to use when using `opam monorepo
              lock' to gather local sources. Default:
-             https://github.com/dune-universe/opam-overlays.git &
-             https://github.com/dune-universe/mirage-opam-overlays.git.
+             https://github.com/dune-universe/opam-overlays.git.
   
          -f FILE, --file=FILE, --config-file=FILE (absent=config.ml)
              The configuration file to use.

--- a/test/mirage/help/query.t
+++ b/test/mirage/help/query.t
@@ -16,12 +16,11 @@ Help query --man-format=plain
              Enable call to `opam depext' in the project Makefile.
   
          --extra-repos=NAME1:URL1,NAME2:URL2,...
-         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git,mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git
+         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git
          or MIRAGE_EXTRA_REPOS env)
              Additional opam-repositories to use when using `opam monorepo
              lock' to gather local sources. Default:
-             https://github.com/dune-universe/opam-overlays.git &
-             https://github.com/dune-universe/mirage-opam-overlays.git.
+             https://github.com/dune-universe/opam-overlays.git.
   
          --no-depext
              Disable call to `opam depext' in the project Makefile.
@@ -116,12 +115,11 @@ Help query --help=plain
              Enable call to `opam depext' in the project Makefile.
   
          --extra-repos=NAME1:URL1,NAME2:URL2,...
-         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git,mirage-overlays:https://github.com/dune-universe/mirage-opam-overlays.git
+         (absent=opam-overlays:https://github.com/dune-universe/opam-overlays.git
          or MIRAGE_EXTRA_REPOS env)
              Additional opam-repositories to use when using `opam monorepo
              lock' to gather local sources. Default:
-             https://github.com/dune-universe/opam-overlays.git &
-             https://github.com/dune-universe/mirage-opam-overlays.git.
+             https://github.com/dune-universe/opam-overlays.git.
   
          --no-depext
              Disable call to `opam depext' in the project Makefile.

--- a/test/mirage/query/run-dash_in_name.t
+++ b/test/mirage/query/run-dash_in_name.t
@@ -47,15 +47,13 @@ Query makefile
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@printf "\033[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \033[0m\n"
+  	@printf "\033[2musing overlay repository mirage: [opam-overlays] \033[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@printf "\033[2mremoving overlay repository [opam-overlays, mirage-overlays]\033[0m\n"
+  	@printf "\033[2mremoving overlay repository [opam-overlays]\033[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   

--- a/test/mirage/query/run-hvt.t
+++ b/test/mirage/query/run-hvt.t
@@ -45,9 +45,7 @@ Query opam file
   x-mirage-pre-build: [make "lock" "depext-lockfile" "pull"]
   
   x-mirage-extra-repo: [
-  ["opam-overlays" "https://github.com/dune-universe/opam-overlays.git"]
-  
-  ["mirage-overlays" "https://github.com/dune-universe/mirage-opam-overlays.git"]]
+  ["opam-overlays" "https://github.com/dune-universe/opam-overlays.git"]]
   
   x-opam-monorepo-opam-provided: ["mirage" "ocaml-solo5" "opam-monorepo" "solo5"]
   
@@ -91,15 +89,13 @@ Query Makefile
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@printf "\033[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \033[0m\n"
+  	@printf "\033[2musing overlay repository mirage: [opam-overlays] \033[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@printf "\033[2mremoving overlay repository [opam-overlays, mirage-overlays]\033[0m\n"
+  	@printf "\033[2mremoving overlay repository [opam-overlays]\033[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   
@@ -157,15 +153,13 @@ Query Makefile without depexts
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm
   
   repo-add:
-  	@printf "\033[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \033[0m\n"
+  	@printf "\033[2musing overlay repository mirage: [opam-overlays] \033[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@printf "\033[2mremoving overlay repository [opam-overlays, mirage-overlays]\033[0m\n"
+  	@printf "\033[2mremoving overlay repository [opam-overlays]\033[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
@@ -216,15 +210,13 @@ Query Makefile with depext
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@printf "\033[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \033[0m\n"
+  	@printf "\033[2musing overlay repository mirage: [opam-overlays] \033[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@printf "\033[2mremoving overlay repository [opam-overlays, mirage-overlays]\033[0m\n"
+  	@printf "\033[2mremoving overlay repository [opam-overlays]\033[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   

--- a/test/mirage/query/run-noop.t
+++ b/test/mirage/query/run-noop.t
@@ -47,15 +47,13 @@ Query makefile
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@printf "\033[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \033[0m\n"
+  	@printf "\033[2musing overlay repository mirage: [opam-overlays] \033[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@printf "\033[2mremoving overlay repository [opam-overlays, mirage-overlays]\033[0m\n"
+  	@printf "\033[2mremoving overlay repository [opam-overlays]\033[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   

--- a/test/mirage/query/run.t
+++ b/test/mirage/query/run.t
@@ -47,9 +47,7 @@ Query opam file
   x-mirage-pre-build: [make "lock" "depext-lockfile" "pull"]
   
   x-mirage-extra-repo: [
-  ["opam-overlays" "https://github.com/dune-universe/opam-overlays.git"]
-  
-  ["mirage-overlays" "https://github.com/dune-universe/mirage-opam-overlays.git"]]
+  ["opam-overlays" "https://github.com/dune-universe/opam-overlays.git"]]
   
   x-opam-monorepo-opam-provided: ["mirage" "opam-monorepo"]
   
@@ -91,15 +89,13 @@ Query Makefile
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@printf "\033[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \033[0m\n"
+  	@printf "\033[2musing overlay repository mirage: [opam-overlays] \033[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@printf "\033[2mremoving overlay repository [opam-overlays, mirage-overlays]\033[0m\n"
+  	@printf "\033[2mremoving overlay repository [opam-overlays]\033[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   
@@ -158,15 +154,13 @@ Query Makefile without depexts
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm
   
   repo-add:
-  	@printf "\033[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \033[0m\n"
+  	@printf "\033[2musing overlay repository mirage: [opam-overlays] \033[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@printf "\033[2mremoving overlay repository [opam-overlays, mirage-overlays]\033[0m\n"
+  	@printf "\033[2mremoving overlay repository [opam-overlays]\033[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam.locked: $(MIRAGE_DIR)/$(UNIKERNEL_NAME).opam
@@ -218,15 +212,13 @@ Query Makefile with depext
   .PHONY: all lock install-switch pull clean depend depends build repo-add repo-rm depext-lockfile
   
   repo-add:
-  	@printf "\033[2musing overlay repository mirage: [opam-overlays, mirage-overlays] \033[0m\n"
+  	@printf "\033[2musing overlay repository mirage: [opam-overlays] \033[0m\n"
   	$(OPAM) repo add opam-overlays https://github.com/dune-universe/opam-overlays.git || $(OPAM) repo set-url opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo add mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git || $(OPAM) repo set-url mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   repo-rm:
-  	@printf "\033[2mremoving overlay repository [opam-overlays, mirage-overlays]\033[0m\n"
+  	@printf "\033[2mremoving overlay repository [opam-overlays]\033[0m\n"
   	$(OPAM) repo remove opam-overlays https://github.com/dune-universe/opam-overlays.git
-  	$(OPAM) repo remove mirage-overlays https://github.com/dune-universe/mirage-opam-overlays.git
   
   
   


### PR DESCRIPTION
This patch proposes to remove the `mirage-opam-overlays`.

The repo has been merged with `opam-overlays`. See:

- https://github.com/dune-universe/opam-overlays/pull/252
- https://github.com/dune-universe/mirage-opam-overlays/pull/9
